### PR TITLE
docs: add core-api port binding gotcha to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ Further HTTP contract: `docs/core-api-interface.md`.
    cd api && dotnet run --project Statevia.Core.Api
    ```
 
-   Or with env: `DATABASE_URL="postgres://statevia:statevia@localhost:5432/statevia" PORT=8080 dotnet run --project Statevia.Core.Api`
+   Or with env: `DATABASE_URL="postgres://statevia:statevia@localhost:5432/statevia" ASPNETCORE_URLS="http://0.0.0.0:8080" dotnet run --project Statevia.Core.Api --no-launch-profile`
+   **Gotcha**: `launchSettings.json` hardcodes ports 62427/62428. Use `--no-launch-profile` + `ASPNETCORE_URLS` to bind to port 8080.
    Migrations: `cd api && dotnet ef database update --project Statevia.Core.Api`.
 3. **ui** — run dev server:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Development environment setup and documentation improvement for Cloud Agent environments.

### Changes

- Updated `AGENTS.md` to document a non-obvious gotcha: `launchSettings.json` hardcodes ports 62427/62428, so `--no-launch-profile` + `ASPNETCORE_URLS` must be used to bind core-api to port 8080 in Cloud VM environments.

### Environment Setup Verification

All three components (engine, core-api, ui) were built, tested, and run successfully:

| Service | Status | Notes |
|---------|--------|-------|
| **PostgreSQL 16** | Running (Docker) | `docker run ... postgres:16` on port 5432 |
| **core-api (C# ASP.NET Core)** | Running | Port 8080 with `--no-launch-profile` |
| **ui (Next.js)** | Running | Port 3000 with `CORE_API_INTERNAL_BASE=http://localhost:8080` |

### Tests

- **engine tests**: 149 passed (148 + 1 CLI test)
- **core-api tests**: 252 passed
- **ui vitest**: 259 passed, 2 pre-existing failures (`ActionLinkGroup` tests, unrelated to this change)
- **tsc --noEmit**: clean

### Hello World Demo

Created a workflow definition and started a workflow via the API, confirmed execution graph completion.

[statevia_ui_dashboard_demo.mp4](https://cursor.com/agents/bc-a7f98e29-3399-4245-a8a1-171287dc72a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstatevia_ui_dashboard_demo.mp4)

[Statevia Dashboard](https://cursor.com/agents/bc-a7f98e29-3399-4245-a8a1-171287dc72a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_loaded.webp)
[Workflows page](https://cursor.com/agents/bc-a7f98e29-3399-4245-a8a1-171287dc72a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflows_page.webp)
[Definitions page](https://cursor.com/agents/bc-a7f98e29-3399-4245-a8a1-171287dc72a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdefinitions_page.webp)

API test log:
[hello_world_api_test.log](https://cursor.com/agents/bc-a7f98e29-3399-4245-a8a1-171287dc72a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_api_test.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7f98e29-3399-4245-a8a1-171287dc72a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7f98e29-3399-4245-a8a1-171287dc72a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

