### PR TITLE
Hosted Fork を物理子 execution に展開し、UI 向け合成読みモデルを追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,9 @@ Sonar / Analyzer: [`docs/development-guidelines.md`](docs/development-guidelines
 
 ## 実装メモ（エージェント向け）
 
-- **Read-model**: `GET /v1/executions` / graph は DB projection 正本（[`data-integration.md`](docs/specifications/data-integration.md)）
+- **Read-model**: `GET /v1/executions` / graph は DB projection 正本（[`data-integration.md`](docs/specifications/data-integration.md)）。Hosted 物理 Fork の親 graph / events は **GET 時合成**（UI は分割非認知。[`fork-join.md`](docs/specifications/execution/fork-join.md)）
 - **IO-14**: 既定で `input` / `output` を一覧 GET に含めない。ログは `LogRedaction`（[`io-log-masking.md`](docs/specifications/platform/io-log-masking.md)）
-- **Engine 境界**: `ExecutionEngine` は `IStateExecutor` のみ。Catalog / Policy / ModuleHost は Service API 側
+- **Engine 境界**: `ExecutionEngine` は `IStateExecutor` のみ。Catalog / Policy / ModuleHost は Service API 側。Hosted Fork の親子協調は Application（`execution_branches`・予約 Resume）
 - **Serena MCP**: プロジェクトごとに `serena-engine` … `serena-ui` の 9 サーバー（`serena-runtime` 含む）。切替は UI トグル（同時 On は原則 1）。未起動時は停止して起動を促す。[`serena-mcp-project-toggle`](.spec/archive/specs/serena-mcp-project-toggle/requirements.md) / [`.cursor/skills/serena-mcp-project-switch/SKILL.md`](.cursor/skills/serena-mcp-project-switch/SKILL.md)
 
 ## .NET SDK

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@
 ### 可観測性・運用性（C#）
 
 - 障害解析に必要な構造化ログと相関 ID（TraceId など）を維持し、主要処理の追跡可能性を確保する。
+- **`ILogger.Log*`（`LogWarning` / `LogError` 等）を直接呼ばない。** `[LoggerMessage]` によるソース生成 partial（例: `*LogMessages.cs`）経由で記録する。キー命名は `docs/reference/logging-property-keys.md`。
 - 監視で利用するメトリクスとログ粒度を意識し、運用時に判断できない実装を避ける。
 
 ### 信頼性・回復性（C#）

--- a/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionBranchRow.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionBranchRow.cs
@@ -26,8 +26,9 @@ public static class ExecutionBranchStatuses
 /// </summary>
 /// <remarks>
 /// <para>
-/// 一意: <c>(parent_execution_id, fork_state, branch_state)</c> および <c>execution_id</c>。
-/// <c>fork_state</c> / <c>join_state</c> / <c>branch_state</c> は定義の状態名空間（実行短名 UUID ではない）。
+/// 一意: <c>(parent_execution_id, fork_node_id, branch_state)</c> および <c>execution_id</c>。
+/// <c>fork_node_id</c> は親実行グラフ上の Fork 到達インスタンス（実行ノード ID）。
+/// <c>join_state</c> / <c>branch_state</c> は定義の状態名空間。
 /// </para>
 /// </remarks>
 public sealed class ExecutionBranchRow
@@ -38,8 +39,8 @@ public sealed class ExecutionBranchRow
     /// <summary>分岐を走らせる子 execution。</summary>
     public Guid ExecutionId { get; set; }
 
-    /// <summary>ForkTable キー（fork 遷移元の状態名）。</summary>
-    public required string ForkState { get; set; }
+    /// <summary>親実行グラフ上の Fork ノード ID（到達インスタンス）。</summary>
+    public required string ForkNodeId { get; set; }
 
     /// <summary>Join 状態名。</summary>
     public required string JoinState { get; set; }

--- a/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionBranchRow.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionBranchRow.cs
@@ -54,6 +54,12 @@ public sealed class ExecutionBranchRow
     /// <summary>終端時に親へ渡す output の JSON（任意）。</summary>
     public string? OutputJson { get; set; }
 
+    /// <summary>子終端時点の <c>states</c> JSON（Join 後の親 Context マージ用。任意）。</summary>
+    public string? StatesJson { get; set; }
+
+    /// <summary>子終端時点の <c>vars</c> JSON（Join 後の親 Context マージ用。任意）。</summary>
+    public string? VarsJson { get; set; }
+
     /// <summary>行作成時刻（UTC）。</summary>
     public DateTime CreatedAt { get; set; }
 
@@ -61,11 +67,15 @@ public sealed class ExecutionBranchRow
     public DateTime UpdatedAt { get; set; }
 }
 
-/// <summary><c>execution_branches</c> の status / output 更新用 DTO。</summary>
+/// <summary><c>execution_branches</c> の status / output / Context 更新用 DTO。</summary>
 /// <param name="Status">新しい status（<see cref="ExecutionBranchStatuses"/>）。</param>
 /// <param name="UpdatedAt">更新時刻（UTC）。</param>
 /// <param name="OutputJson">終端 output JSON。null のとき列は変更しない。</param>
+/// <param name="StatesJson">終端 <c>states</c> JSON。null のとき列は変更しない。</param>
+/// <param name="VarsJson">終端 <c>vars</c> JSON。null のとき列は変更しない。</param>
 public sealed record ExecutionBranchStatusUpdate(
     string Status,
     DateTime UpdatedAt,
-    string? OutputJson);
+    string? OutputJson,
+    string? StatesJson = null,
+    string? VarsJson = null);

--- a/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionBranchRow.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionBranchRow.cs
@@ -1,0 +1,70 @@
+namespace Statevia.Core.Application.Contracts.Persistence;
+
+/// <summary>
+/// <c>execution_branches.status</c> の許容値（Join 集約用の投影）。
+/// </summary>
+/// <remarks>
+/// <para><c>executions.status</c> の終端語彙（Running / Completed / Failed / Cancelled）に揃える。</para>
+/// </remarks>
+public static class ExecutionBranchStatuses
+{
+    /// <summary>子が未終端。</summary>
+    public const string Running = "Running";
+
+    /// <summary>子が正常終端。</summary>
+    public const string Completed = "Completed";
+
+    /// <summary>子が失敗終端。</summary>
+    public const string Failed = "Failed";
+
+    /// <summary>子がキャンセル終端。</summary>
+    public const string Cancelled = "Cancelled";
+}
+
+/// <summary>
+/// <c>execution_branches</c> 行。親 execution と Fork 分岐子 execution の関係正本。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 一意: <c>(parent_execution_id, fork_state, branch_state)</c> および <c>execution_id</c>。
+/// <c>fork_state</c> / <c>join_state</c> / <c>branch_state</c> は定義の状態名空間（実行短名 UUID ではない）。
+/// </para>
+/// </remarks>
+public sealed class ExecutionBranchRow
+{
+    /// <summary>Fork に到達した親（ネスト時は親役）execution。</summary>
+    public Guid ParentExecutionId { get; set; }
+
+    /// <summary>分岐を走らせる子 execution。</summary>
+    public Guid ExecutionId { get; set; }
+
+    /// <summary>ForkTable キー（fork 遷移元の状態名）。</summary>
+    public required string ForkState { get; set; }
+
+    /// <summary>Join 状態名。</summary>
+    public required string JoinState { get; set; }
+
+    /// <summary>分岐先頭状態名。</summary>
+    public required string BranchState { get; set; }
+
+    /// <summary>Join 集約用の完了事実要約（<see cref="ExecutionBranchStatuses"/>）。</summary>
+    public required string Status { get; set; }
+
+    /// <summary>終端時に親へ渡す output の JSON（任意）。</summary>
+    public string? OutputJson { get; set; }
+
+    /// <summary>行作成時刻（UTC）。</summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>行更新時刻（UTC）。</summary>
+    public DateTime UpdatedAt { get; set; }
+}
+
+/// <summary><c>execution_branches</c> の status / output 更新用 DTO。</summary>
+/// <param name="Status">新しい status（<see cref="ExecutionBranchStatuses"/>）。</param>
+/// <param name="UpdatedAt">更新時刻（UTC）。</param>
+/// <param name="OutputJson">終端 output JSON。null のとき列は変更しない。</param>
+public sealed record ExecutionBranchStatusUpdate(
+    string Status,
+    DateTime UpdatedAt,
+    string? OutputJson);

--- a/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionWaitRow.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionWaitRow.cs
@@ -24,11 +24,18 @@ public enum ExecutionWaitKind
 /// DelayWait の <c>allowed_events</c> と Delay 期限の Resume <c>eventName</c> は
 /// <see cref="DelayCompleted"/> のみを用いる（先頭要素の恣意的選択はしない）。
 /// </para>
+/// <para>
+/// 物理子終端の親向け Resume は <see cref="ChildCompleted"/> を用いる。
+/// Engine の Wait Resume には振らず、Host が Join 再評価する（D3）。
+/// </para>
 /// </remarks>
 public static class ExecutionWaitEventNames
 {
     /// <summary>DelayWait 期限到達時に Resume へ渡す固定イベント名。</summary>
     public const string DelayCompleted = "statevia.event.delay.completed";
+
+    /// <summary>物理子が終端したとき親へ渡す固定イベント名（Join 再評価トリガ）。</summary>
+    public const string ChildCompleted = "statevia.event.child.completed";
 }
 
 /// <summary>execution_waits テーブル。durable wait のみ永続化する（1 Wait ノード = 1 行）。</summary>

--- a/core/application/Statevia.Core.Application.Contracts/Persistence/IExecutionBranchRepository.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/IExecutionBranchRepository.cs
@@ -1,0 +1,79 @@
+namespace Statevia.Core.Application.Contracts.Persistence;
+
+/// <summary><c>execution_branches</c> 永続化。</summary>
+public interface IExecutionBranchRepository
+{
+    /// <summary>
+    /// 分岐行を冪等挿入する。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// キー <c>(parent_execution_id, fork_state, branch_state)</c> が未存在なら挿入する。
+    /// 既存かつ <see cref="ExecutionBranchRow.ExecutionId"/> が一致すれば何もしない。
+    /// 既存かつ <c>execution_id</c> が異なれば <see cref="InvalidOperationException"/>。
+    /// </para>
+    /// </remarks>
+    /// <param name="uow">同一トランザクションの Unit of Work。</param>
+    /// <param name="branches">挿入する分岐行。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    Task InsertBranchesIdempotentAsync(
+        ICoreUnitOfWork uow,
+        IReadOnlyList<ExecutionBranchRow> branches,
+        CancellationToken ct);
+
+    /// <summary>
+    /// 親 execution 配下の分岐行を作成時刻順で返す。
+    /// </summary>
+    /// <param name="uow">同一トランザクションの Unit of Work。</param>
+    /// <param name="parentExecutionId">親 execution。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>分岐行一覧。</returns>
+    Task<IReadOnlyList<ExecutionBranchRow>> ListByParentExecutionIdAsync(
+        ICoreUnitOfWork uow,
+        Guid parentExecutionId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// 親・Fork 単位の分岐行を返す。
+    /// </summary>
+    /// <param name="uow">同一トランザクションの Unit of Work。</param>
+    /// <param name="parentExecutionId">親 execution。</param>
+    /// <param name="forkState">Fork 状態名キー。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>当該 Fork の分岐行一覧。</returns>
+    Task<IReadOnlyList<ExecutionBranchRow>> ListByParentAndForkAsync(
+        ICoreUnitOfWork uow,
+        Guid parentExecutionId,
+        string forkState,
+        CancellationToken ct);
+
+    /// <summary>
+    /// 子 execution_id で分岐行を取得する。
+    /// </summary>
+    /// <param name="uow">同一トランザクションの Unit of Work。</param>
+    /// <param name="childExecutionId">子 execution。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>分岐行。無ければ null。</returns>
+    Task<ExecutionBranchRow?> GetByChildExecutionIdAsync(
+        ICoreUnitOfWork uow,
+        Guid childExecutionId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// 分岐の status / output を更新する。
+    /// </summary>
+    /// <param name="uow">同一トランザクションの Unit of Work。</param>
+    /// <param name="parentExecutionId">親 execution。</param>
+    /// <param name="forkState">Fork 状態名キー。</param>
+    /// <param name="branchState">分岐先頭状態名。</param>
+    /// <param name="update">status / updatedAt / output の更新内容。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>更新できたとき true。行が無いとき false。</returns>
+    Task<bool> TryUpdateStatusAsync(
+        ICoreUnitOfWork uow,
+        Guid parentExecutionId,
+        string forkState,
+        string branchState,
+        ExecutionBranchStatusUpdate update,
+        CancellationToken ct);
+}

--- a/core/application/Statevia.Core.Application.Contracts/Persistence/IExecutionBranchRepository.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/IExecutionBranchRepository.cs
@@ -8,7 +8,7 @@ public interface IExecutionBranchRepository
     /// </summary>
     /// <remarks>
     /// <para>
-    /// キー <c>(parent_execution_id, fork_state, branch_state)</c> が未存在なら挿入する。
+    /// キー <c>(parent_execution_id, fork_node_id, branch_state)</c> が未存在なら挿入する。
     /// 既存かつ <see cref="ExecutionBranchRow.ExecutionId"/> が一致すれば何もしない。
     /// 既存かつ <c>execution_id</c> が異なれば <see cref="InvalidOperationException"/>。
     /// </para>
@@ -34,17 +34,17 @@ public interface IExecutionBranchRepository
         CancellationToken ct);
 
     /// <summary>
-    /// 親・Fork 単位の分岐行を返す。
+    /// 親・Fork 到達インスタンス単位の分岐行を返す。
     /// </summary>
     /// <param name="uow">同一トランザクションの Unit of Work。</param>
     /// <param name="parentExecutionId">親 execution。</param>
-    /// <param name="forkState">Fork 状態名キー。</param>
+    /// <param name="forkNodeId">親実行グラフ上の Fork ノード ID。</param>
     /// <param name="ct">キャンセル トークン。</param>
-    /// <returns>当該 Fork の分岐行一覧。</returns>
-    Task<IReadOnlyList<ExecutionBranchRow>> ListByParentAndForkAsync(
+    /// <returns>当該 Fork 到達の分岐行一覧。</returns>
+    Task<IReadOnlyList<ExecutionBranchRow>> ListByParentAndForkNodeAsync(
         ICoreUnitOfWork uow,
         Guid parentExecutionId,
-        string forkState,
+        string forkNodeId,
         CancellationToken ct);
 
     /// <summary>
@@ -64,7 +64,7 @@ public interface IExecutionBranchRepository
     /// </summary>
     /// <param name="uow">同一トランザクションの Unit of Work。</param>
     /// <param name="parentExecutionId">親 execution。</param>
-    /// <param name="forkState">Fork 状態名キー。</param>
+    /// <param name="forkNodeId">親実行グラフ上の Fork ノード ID。</param>
     /// <param name="branchState">分岐先頭状態名。</param>
     /// <param name="update">status / updatedAt / output の更新内容。</param>
     /// <param name="ct">キャンセル トークン。</param>
@@ -72,7 +72,7 @@ public interface IExecutionBranchRepository
     Task<bool> TryUpdateStatusAsync(
         ICoreUnitOfWork uow,
         Guid parentExecutionId,
-        string forkState,
+        string forkNodeId,
         string branchState,
         ExecutionBranchStatusUpdate update,
         CancellationToken ct);

--- a/core/application/Statevia.Core.Application.Contracts/Persistence/IExecutionWorkQueue.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/IExecutionWorkQueue.cs
@@ -5,16 +5,29 @@ namespace Statevia.Core.Application.Contracts.Persistence;
 /// </summary>
 public interface IExecutionWorkQueue
 {
-    /// <summary>ワーク項目をキューへ追加する。</summary>
+    /// <summary>ワーク項目をキューへ追加する（専用 DbContext で即コミット）。</summary>
     /// <param name="item">追加する項目。</param>
     /// <param name="ct">キャンセル トークン。</param>
+    /// <remarks>呼び出し側 UoW と原子性を取る場合は <see cref="EnqueueAsync(ICoreUnitOfWork, ExecutionWorkItemRow, CancellationToken)"/> を使う。</remarks>
     Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct);
 
-    /// <summary>複数のワーク項目を同一コミットでキューへ追加する。</summary>
+    /// <summary>呼び出し側 UoW にワーク項目を追加する（SaveChanges / コミットは呼び出し側）。</summary>
+    /// <param name="uow">同一トランザクションの Unit of Work。</param>
+    /// <param name="item">追加する項目。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct);
+
+    /// <summary>複数のワーク項目を同一コミットでキューへ追加する（専用 DbContext）。</summary>
     /// <param name="items">追加する項目。空なら何もしない。</param>
     /// <param name="ct">キャンセル トークン。</param>
     /// <remarks>チャンク分割は負荷計測後に検討する。現状は呼び出し側の全件を一括投入する。</remarks>
     Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct);
+
+    /// <summary>呼び出し側 UoW に複数ワーク項目を追加する（SaveChanges / コミットは呼び出し側）。</summary>
+    /// <param name="uow">同一トランザクションの Unit of Work。</param>
+    /// <param name="items">追加する項目。空なら何もしない。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    Task EnqueueManyAsync(ICoreUnitOfWork uow, IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct);
 
     /// <summary>
     /// 処理可能で未 lease または期限切れの項目を排他取得する。

--- a/core/application/Statevia.Core.Application.Contracts/Services/ExecutionDtos.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/ExecutionDtos.cs
@@ -30,6 +30,13 @@ public class StartExecutionRequest
 
     /// <summary>実行開始時の入力（任意）。</summary>
     public JsonElement? Input { get; set; }
+
+    /// <summary>
+    /// 開始状態名（省略時は定義の InitialState）。
+    /// Hosted の Fork 子 execution が分岐先頭から開始するときに使う。
+    /// </summary>
+    [JsonPropertyName("initialState")]
+    public string? InitialState { get; set; }
 }
 
 /// <summary>POST …/events のリクエスト本文。</summary>

--- a/core/application/Statevia.Core.Application.Contracts/Services/ExecutionDtos.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/ExecutionDtos.cs
@@ -168,7 +168,10 @@ public sealed class ExecutionEventsResponseDto
 /// <summary>タイムライン／SSE 用のイベント（UI の <c>ExecutionStreamEvent</c> + seq）。</summary>
 public sealed class TimelineEventDto
 {
-    /// <summary>event_store 上のシーケンス番号。</summary>
+    /// <summary>
+    /// タイムライン上のシーケンス番号。
+    /// 親 events GET（合成時）では合成通番。個別 execution の永続 seq とは限らない。
+    /// </summary>
     public long Seq { get; init; }
 
     /// <summary>イベント種別。</summary>

--- a/core/application/Statevia.Core.Application.Contracts/Services/ForkChildExpansionOptions.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/ForkChildExpansionOptions.cs
@@ -1,0 +1,20 @@
+namespace Statevia.Core.Application.Contracts.Services;
+
+/// <summary>
+/// Hosted Runtime が Fork を物理子 execution に展開するときの試行上限（D9）。
+/// </summary>
+/// <remarks>
+/// <para>設定セクション例: <c>Statevia:Runtime:ForkChildExpansion</c>。</para>
+/// <para>一時失敗では親をすぐ Failed にせず再試行し、上限超過後に親 Failed（残子 Cancel）とする。</para>
+/// </remarks>
+public sealed class ForkChildExpansionOptions
+{
+    /// <summary>構成バインド用セクション名。</summary>
+    public const string SectionName = "Statevia:Runtime:ForkChildExpansion";
+
+    /// <summary>展開操作の最大試行回数（初回含む）。既定 5。</summary>
+    public int MaxAttempts { get; set; } = 5;
+
+    /// <summary>試行間の基準遅延（ミリ秒）。既定 100。</summary>
+    public int BaseDelayMs { get; set; } = 100;
+}

--- a/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
@@ -54,11 +54,24 @@ public enum ForkJoinEvaluationKind
     Failed
 }
 
+/// <summary>
+/// Join 充足時に親 Context へ投影する子 1 件分の Context 断片。
+/// </summary>
+/// <remarks>リスト順が適用順。同一キーは後勝ち（D5）。</remarks>
+/// <param name="States">子の完了済み State エントリ（stateName → `{ output: … }`）。</param>
+/// <param name="Vars">子終端時点の vars オブジェクト。</param>
+public sealed record ForkJoinChildContextMerge(
+    IReadOnlyDictionary<string, object?> States,
+    object? Vars);
+
 /// <summary>親 Join 再評価の結果。</summary>
 /// <param name="Kind">評価結果。</param>
 /// <param name="JoinState">対象 Join 状態名。</param>
 /// <param name="CandidateInputs">
 /// <see cref="ForkJoinEvaluationKind.Satisfied"/> のとき、分岐先頭 → 子終端 output の辞書。
+/// </param>
+/// <param name="ContextMerges">
+/// <see cref="ForkJoinEvaluationKind.Satisfied"/> のとき、UpdatedAt 昇順の Context 断片（後勝ち）。
 /// </param>
 /// <param name="FailureStatus">
 /// <see cref="ForkJoinEvaluationKind.Failed"/> のとき、親へ伝播する終端 status
@@ -68,6 +81,7 @@ public sealed record ForkJoinEvaluation(
     ForkJoinEvaluationKind Kind,
     string JoinState,
     IReadOnlyDictionary<string, object?>? CandidateInputs = null,
+    IReadOnlyList<ForkJoinChildContextMerge>? ContextMerges = null,
     string? FailureStatus = null);
 
 /// <summary>
@@ -75,7 +89,7 @@ public sealed record ForkJoinEvaluation(
 /// </summary>
 /// <remarks>
 /// <para>子行作成・security snapshot 継承・Start enqueue・展開リトライ（D9）を担う。</para>
-/// <para>子終端信号と Join 再評価（D2-B / D3）も担う。親 Context の states/vars マージは別タスク。</para>
+/// <para>子終端信号・Join 再評価（D2-B / D3）と、充足時の親 Context（states / vars）マージ材料（D5）を担う。</para>
 /// <para>input 写像は Engine 側で行い、本コーディネータは写像済み input を受け取る。</para>
 /// </remarks>
 public interface IForkChildExecutionCoordinator
@@ -94,12 +108,16 @@ public interface IForkChildExecutionCoordinator
     /// <param name="childExecutionId">終端した子 execution。</param>
     /// <param name="status">子の投影 status（Completed / Failed / Cancelled）。</param>
     /// <param name="outputJson">子終端 output の JSON（任意）。</param>
+    /// <param name="statesJson">子終端 <c>states</c> の JSON（任意）。</param>
+    /// <param name="varsJson">子終端 <c>vars</c> の JSON（任意）。</param>
     /// <param name="ct">キャンセル トークン。</param>
     /// <returns>分岐行があり信号を処理したとき true。非子のとき false。</returns>
     Task<bool> NotifyChildTerminalAsync(
         Guid childExecutionId,
         string status,
         string? outputJson,
+        string? statesJson,
+        string? varsJson,
         CancellationToken ct);
 
     /// <summary>

--- a/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
@@ -41,11 +41,41 @@ public sealed record ForkExpansionResult(
     IReadOnlyList<Guid> ChildExecutionIds,
     string JoinState);
 
+/// <summary>親 Join 再評価の結果種別。</summary>
+public enum ForkJoinEvaluationKind
+{
+    /// <summary>未終端子があり、Join を進めない。</summary>
+    Waiting,
+
+    /// <summary>全必須子が Completed。候補 input で Join 充足可能。</summary>
+    Satisfied,
+
+    /// <summary>必須子のいずれかが Failed / Cancelled。親へ失敗伝播する。</summary>
+    Failed
+}
+
+/// <summary>親 Join 再評価の結果。</summary>
+/// <param name="Kind">評価結果。</param>
+/// <param name="JoinState">対象 Join 状態名。</param>
+/// <param name="CandidateInputs">
+/// <see cref="ForkJoinEvaluationKind.Satisfied"/> のとき、分岐先頭 → 子終端 output の辞書。
+/// </param>
+/// <param name="FailureStatus">
+/// <see cref="ForkJoinEvaluationKind.Failed"/> のとき、親へ伝播する終端 status
+///（<c>Failed</c> または <c>Cancelled</c>）。
+/// </param>
+public sealed record ForkJoinEvaluation(
+    ForkJoinEvaluationKind Kind,
+    string JoinState,
+    IReadOnlyDictionary<string, object?>? CandidateInputs = null,
+    string? FailureStatus = null);
+
 /// <summary>
 /// Hosted Runtime 向けに Fork を親＋子 execution へ展開する。
 /// </summary>
 /// <remarks>
 /// <para>子行作成・security snapshot 継承・Start enqueue・展開リトライ（D9）を担う。</para>
+/// <para>子終端信号と Join 再評価（D2-B / D3）も担う。親 Context の states/vars マージは別タスク。</para>
 /// <para>input 写像は Engine 側で行い、本コーディネータは写像済み input を受け取る。</para>
 /// </remarks>
 public interface IForkChildExecutionCoordinator
@@ -57,6 +87,32 @@ public interface IForkChildExecutionCoordinator
     /// <param name="ct">キャンセル トークン。</param>
     /// <returns>展開結果。</returns>
     Task<ForkExpansionResult> ExpandForkAsync(ForkExpansionRequest request, CancellationToken ct);
+
+    /// <summary>
+    /// 子 execution 終端を <c>execution_branches</c> へ反映し、親へ予約 Resume を enqueue する。
+    /// </summary>
+    /// <param name="childExecutionId">終端した子 execution。</param>
+    /// <param name="status">子の投影 status（Completed / Failed / Cancelled）。</param>
+    /// <param name="outputJson">子終端 output の JSON（任意）。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>分岐行があり信号を処理したとき true。非子のとき false。</returns>
+    Task<bool> NotifyChildTerminalAsync(
+        Guid childExecutionId,
+        string status,
+        string? outputJson,
+        CancellationToken ct);
+
+    /// <summary>
+    /// 親の指定 Fork 到達について <c>execution_branches</c> から Join を再評価する。
+    /// </summary>
+    /// <param name="parentExecutionId">親 execution。</param>
+    /// <param name="forkNodeId">親実行グラフ上の Fork ノード ID。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>評価結果（Waiting / Satisfied / Failed）。</returns>
+    Task<ForkJoinEvaluation> EvaluateJoinAsync(
+        Guid parentExecutionId,
+        string forkNodeId,
+        CancellationToken ct);
 }
 
 /// <summary>Fork 展開で Join を一意に解決できないとき。</summary>

--- a/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
@@ -102,6 +102,7 @@ public sealed record ForkWaitDeliveryTarget(
 /// <para>子行作成・security snapshot 継承・Start enqueue・展開リトライ（D9）を担う。</para>
 /// <para>子終端信号・Join 再評価（D2-B / D3）と、充足時の親 Context（states / vars）マージ材料（D5）を担う。</para>
 /// <para>親 Cancel の未終端子カスケードと、分岐 Wait の配送先解決（要件4）も担う。</para>
+/// <para>親 graph 読み取り時の論理 Fork/Join 合成（D6）も担う。</para>
 /// <para>input 写像は Engine 側で行い、本コーディネータは写像済み input を受け取る。</para>
 /// </remarks>
 public interface IForkChildExecutionCoordinator
@@ -169,6 +170,18 @@ public interface IForkChildExecutionCoordinator
         Guid requestedExecutionId,
         string? nodeId,
         string eventName,
+        CancellationToken ct);
+
+    /// <summary>
+    /// 親の読み取り用 graph JSON を、直下（再帰）の物理子グラフと合成する（D6・GET 時）。
+    /// </summary>
+    /// <param name="executionId">対象 execution（親または中間親）。</param>
+    /// <param name="baseGraphJson">当該 execution の永続 graph JSON。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>合成後 JSON。子が無ければ <paramref name="baseGraphJson"/>。</returns>
+    Task<string> ComposeReadModelGraphJsonAsync(
+        Guid executionId,
+        string baseGraphJson,
         CancellationToken ct);
 }
 

--- a/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
@@ -102,7 +102,7 @@ public sealed record ForkWaitDeliveryTarget(
 /// <para>子行作成・security snapshot 継承・Start enqueue・展開リトライ（D9）を担う。</para>
 /// <para>子終端信号・Join 再評価（D2-B / D3）と、充足時の親 Context（states / vars）マージ材料（D5）を担う。</para>
 /// <para>親 Cancel の未終端子カスケードと、分岐 Wait の配送先解決（要件4）も担う。</para>
-/// <para>親 graph 読み取り時の論理 Fork/Join 合成（D6）も担う。</para>
+/// <para>親 graph 読み取り時の論理 Fork/Join 合成（D6）と、イベント合成用の子孫列挙（D6.1）も担う。</para>
 /// <para>input 写像は Engine 側で行い、本コーディネータは写像済み input を受け取る。</para>
 /// </remarks>
 public interface IForkChildExecutionCoordinator
@@ -182,6 +182,16 @@ public interface IForkChildExecutionCoordinator
     Task<string> ComposeReadModelGraphJsonAsync(
         Guid executionId,
         string baseGraphJson,
+        CancellationToken ct);
+
+    /// <summary>
+    /// 直下（再帰）の物理子 execution ID を列挙する（D6.1・イベント合成用）。
+    /// </summary>
+    /// <param name="parentExecutionId">ルート（または中間親）execution。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>子孫 ID（親自身は含まない）。順序は安定していればよい。</returns>
+    Task<IReadOnlyList<Guid>> ListDescendantExecutionIdsAsync(
+        Guid parentExecutionId,
         CancellationToken ct);
 }
 

--- a/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
@@ -1,0 +1,71 @@
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Contracts.Services;
+
+/// <summary>Fork 展開における 1 分岐分の写像済み入力。</summary>
+/// <param name="BranchState">分岐先頭状態名。</param>
+/// <param name="MappedInput">親 Context で評価済みの子 Start input（未定義時は Fork 元 output）。</param>
+public sealed record ForkBranchExpansion(
+    string BranchState,
+    object? MappedInput);
+
+/// <summary>Fork 物理子展開の要求。</summary>
+/// <param name="ParentExecutionId">親 execution。</param>
+/// <param name="TenantId">テナント。</param>
+/// <param name="DefinitionId">定義 ID。</param>
+/// <param name="DefinitionVersionId">定義版 ID。</param>
+/// <param name="DefinitionVersion">定義版番号（Start 要求用）。</param>
+/// <param name="DefinitionDisplayId">Start の definitionId に渡す表示／UUID 文字列。</param>
+/// <param name="SecuritySnapshotJson">親から継承する security snapshot JSON。</param>
+/// <param name="CompiledDefinition">親と同じコンパイル済み定義（Join 解決用）。</param>
+/// <param name="ForkNodeId">親実行グラフ上の Fork ノード ID（到達インスタンス）。</param>
+/// <param name="Branches">分岐先頭と写像済み input。</param>
+public sealed record ForkExpansionRequest(
+    Guid ParentExecutionId,
+    Guid TenantId,
+    Guid DefinitionId,
+    Guid DefinitionVersionId,
+    int DefinitionVersion,
+    string DefinitionDisplayId,
+    string SecuritySnapshotJson,
+    CompiledWorkflowDefinition CompiledDefinition,
+    string ForkNodeId,
+    IReadOnlyList<ForkBranchExpansion> Branches);
+
+/// <summary>Fork 物理子展開の結果。</summary>
+/// <param name="Succeeded">展開が完了したとき true。上限超過で親 Failed にしたとき false。</param>
+/// <param name="ChildExecutionIds">作成または再利用した子 execution ID（分岐順）。</param>
+/// <param name="JoinState">解決した Join 状態名。</param>
+public sealed record ForkExpansionResult(
+    bool Succeeded,
+    IReadOnlyList<Guid> ChildExecutionIds,
+    string JoinState);
+
+/// <summary>
+/// Hosted Runtime 向けに Fork を親＋子 execution へ展開する。
+/// </summary>
+/// <remarks>
+/// <para>子行作成・security snapshot 継承・Start enqueue・展開リトライ（D9）を担う。</para>
+/// <para>input 写像は Engine 側で行い、本コーディネータは写像済み input を受け取る。</para>
+/// </remarks>
+public interface IForkChildExecutionCoordinator
+{
+    /// <summary>
+    /// Fork 到達時に子 execution を作成し Start work item を enqueue する。
+    /// </summary>
+    /// <param name="request">展開要求。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>展開結果。</returns>
+    Task<ForkExpansionResult> ExpandForkAsync(ForkExpansionRequest request, CancellationToken ct);
+}
+
+/// <summary>Fork 展開で Join を一意に解決できないとき。</summary>
+public sealed class ForkJoinResolutionException : InvalidOperationException
+{
+    /// <summary>例外を生成する。</summary>
+    /// <param name="message">説明。</param>
+    public ForkJoinResolutionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
@@ -85,11 +85,23 @@ public sealed record ForkJoinEvaluation(
     string? FailureStatus = null);
 
 /// <summary>
+/// 親 ID で届いた Wait イベントを子 execution へ振り向ける配送先。
+/// </summary>
+/// <param name="ExecutionId">実際に Resume する execution（子）。</param>
+/// <param name="NodeId">子上の Wait ノード ID。</param>
+/// <param name="EventName">再開イベント名。</param>
+public sealed record ForkWaitDeliveryTarget(
+    Guid ExecutionId,
+    string NodeId,
+    string EventName);
+
+/// <summary>
 /// Hosted Runtime 向けに Fork を親＋子 execution へ展開する。
 /// </summary>
 /// <remarks>
 /// <para>子行作成・security snapshot 継承・Start enqueue・展開リトライ（D9）を担う。</para>
 /// <para>子終端信号・Join 再評価（D2-B / D3）と、充足時の親 Context（states / vars）マージ材料（D5）を担う。</para>
+/// <para>親 Cancel の未終端子カスケードと、分岐 Wait の配送先解決（要件4）も担う。</para>
 /// <para>input 写像は Engine 側で行い、本コーディネータは写像済み input を受け取る。</para>
 /// </remarks>
 public interface IForkChildExecutionCoordinator
@@ -130,6 +142,33 @@ public interface IForkChildExecutionCoordinator
     Task<ForkJoinEvaluation> EvaluateJoinAsync(
         Guid parentExecutionId,
         string forkNodeId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// 親 Cancel 時に、未終端（Running）の子へ Cancel work item を enqueue する。
+    /// </summary>
+    /// <remarks>ネスト時は各層の Cancel 処理で再帰的に孫へ伝播する。</remarks>
+    /// <param name="parentExecutionId">親（または中間親）execution。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    Task CascadeCancelToRunningChildrenAsync(Guid parentExecutionId, CancellationToken ct);
+
+    /// <summary>
+    /// 親 ID へ届いた Wait Resume / PublishEvent を、子の <c>execution_waits</c> へ解決する。
+    /// </summary>
+    /// <remarks>
+    /// <para>要求 execution 自身に一致 Wait があるときは null（呼び出し側が従来どおり処理）。</para>
+    /// <para>子にだけ一致が 1 件あるとき配送先を返す。複数一致は例外（422）。</para>
+    /// </remarks>
+    /// <param name="requestedExecutionId">クライアントが指定した execution。</param>
+    /// <param name="nodeId">Resume の nodeId。PublishEvent 互換は null。</param>
+    /// <param name="eventName">再開イベント名。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>子への振替先。振替不要または一致なしのとき null。</returns>
+    /// <exception cref="InvalidOperationException">複数子に一致 Wait があり曖昧なとき。</exception>
+    Task<ForkWaitDeliveryTarget?> TryResolveChildWaitDeliveryAsync(
+        Guid requestedExecutionId,
+        string? nodeId,
+        string eventName,
         CancellationToken ct);
 }
 

--- a/core/application/Statevia.Core.Application.Contracts/Services/IForkExpansionHostHandler.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/IForkExpansionHostHandler.cs
@@ -1,0 +1,16 @@
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Contracts.Services;
+
+/// <summary>
+/// Engine の <see cref="ForkExpansionEvent"/> を受け、物理子展開と親 Unload を行う Hosted 側ハンドラ。
+/// </summary>
+public interface IForkExpansionHostHandler
+{
+    /// <summary>
+    /// Fork 展開イベントを処理する。呼び出し元はテナント文脈を設定済みであること。
+    /// </summary>
+    /// <param name="evt">Engine からの展開通知。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    Task HandleAsync(ForkExpansionEvent evt, CancellationToken ct);
+}

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -26,6 +26,8 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<ExecutionOwnershipTracker>();
         services.AddScoped<IExecutionService, ExecutionService>();
         services.AddScoped<IEventIngressService, EventIngressService>();
+        services.AddScoped<IForkChildExecutionCoordinator, ForkChildExecutionCoordinator>();
+        services.AddScoped<IForkExpansionHostHandler, ForkExpansionHostHandler>();
 
         return services;
     }

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -347,7 +347,10 @@ internal sealed class ExecutionService : IExecutionService
                 async (uow, innerCt) =>
                 {
                     var createdAt = DateTime.UtcNow;
-                    var status = MapStatus(_engine.GetSnapshot(engineId));
+                    var startSnapshot = _engine.GetSnapshot(engineId)
+                        ?? throw new InvalidOperationException(
+                            $"Cannot project execution '{resolvedExecutionId}': engine snapshot is missing after Start.");
+                    var status = MapStatus(startSnapshot);
                     var graphJson = _engine.ExportExecutionGraph(engineId);
 
                     ExecutionResponse response;
@@ -664,7 +667,15 @@ internal sealed class ExecutionService : IExecutionService
         var row = await _executor.ExecuteReadOnlyAsync(
             (uow, innerCt) => _executions.GetSnapshotByExecutionIdAsync(uow, uuid.Value, innerCt),
             ct).ConfigureAwait(false);
-        return row is null ? throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound) : row.GraphJson;
+        if (row is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        if (_forkChildCoordinator is null)
+            return row.GraphJson;
+
+        return await _forkChildCoordinator
+            .ComposeReadModelGraphJsonAsync(uuid.Value, row.GraphJson, ct)
+            .ConfigureAwait(false);
     }
 
     public Task EnsureExecutionExistsAsync(Guid executionId, CancellationToken ct) =>
@@ -1038,7 +1049,10 @@ internal sealed class ExecutionService : IExecutionService
 
             if (snapshot.IsCompleted || snapshot.IsCancelled || snapshot.IsFailed)
             {
-                // 終端後も Load が残る経路があるため、Worker の Load 境界で解放する。
+                // 終端後に Unload すると投影キューが engine 不在でスキップし、
+                // Start 直後の不完全 graph のまま Completed だけ残る。最終投影を先に確定する。
+                await _projectionUpdateQueue.DrainAsync(executionId, ct).ConfigureAwait(false);
+                await UpdateProjectionFromEngineAsync(executionId, ct).ConfigureAwait(false);
                 _engine.Unload(engineId);
                 return;
             }
@@ -2003,7 +2017,16 @@ internal sealed class ExecutionService : IExecutionService
                 var graphId = await _displayIds
                     .GetDisplayIdAsync(DisplayIdResourceTypes.Definition, execution.DefinitionId.ToString("D"), innerCt)
                     .ConfigureAwait(false) ?? execution.DefinitionId.ToString("D");
-                return ExecutionViewMapper.BuildExecutionView(execution, snapshot.GraphJson, displayId, graphId);
+
+                var graphJson = snapshot.GraphJson;
+                if (_forkChildCoordinator is not null)
+                {
+                    graphJson = await _forkChildCoordinator
+                        .ComposeReadModelGraphJsonAsync(uuid, snapshot.GraphJson, innerCt)
+                        .ConfigureAwait(false);
+                }
+
+                return ExecutionViewMapper.BuildExecutionView(execution, graphJson, displayId, graphId);
             },
             ct).ConfigureAwait(false);
     }
@@ -2183,9 +2206,9 @@ internal sealed class ExecutionService : IExecutionService
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
     }
 
-    private static string MapStatus(ExecutionSnapshot? snapshot)
+    private static string MapStatus(ExecutionSnapshot snapshot)
     {
-        if (snapshot is null) return ExecutionProjectionStatuses.Unknown;
+        ArgumentNullException.ThrowIfNull(snapshot);
         if (snapshot.IsCompleted) return ExecutionProjectionStatuses.Completed;
         if (snapshot.IsCancelled) return ExecutionProjectionStatuses.Cancelled;
         if (snapshot.IsFailed) return ExecutionProjectionStatuses.Failed;
@@ -2352,10 +2375,17 @@ internal sealed class ExecutionService : IExecutionService
         }
 
         // Unload 前に投影へ反映する（Unload 後は GetSnapshot が null になり投影キューが空振りする）。
+        // snapshot 欠落時は Unknown/`{}` を書かず checkpoint のみ残す（マルチ Worker 競合で UI を壊さない）。
         var snapshot = _engine.GetSnapshot(engineExecutionId);
-        var status = MapStatus(snapshot);
-        var cancelRequested = snapshot?.IsCancelled;
-        var graphJson = _engine.ExportExecutionGraph(engineExecutionId);
+        string? status = null;
+        bool? cancelRequested = null;
+        string? graphJson = null;
+        if (snapshot is not null)
+        {
+            status = MapStatus(snapshot);
+            cancelRequested = snapshot.IsCancelled;
+            graphJson = _engine.ExportExecutionGraph(engineExecutionId);
+        }
 
         var json = JsonSerializer.Serialize(checkpoint, CamelCaseJsonSerializerOptions);
         var updatedAt = DateTime.UtcNow;
@@ -2364,7 +2394,7 @@ internal sealed class ExecutionService : IExecutionService
             {
                 var execution = await _executions.GetByExecutionIdAsync(uow, executionId, innerCt)
                     .ConfigureAwait(false);
-                if (execution is not null && graphJson is not null)
+                if (execution is not null && status is not null && graphJson is not null)
                 {
                     await _executions
                         .UpdateExecutionAndSnapshotAsync(
@@ -2586,13 +2616,28 @@ internal sealed class ExecutionService : IExecutionService
             ct).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Engine 上の実行から投影用 status / graph を取得する。
+    /// </summary>
+    /// <remarks>
+    /// snapshot 欠落時に <c>Unknown</c> と <c>{}</c> を永続すると一覧 UI が落ちるため、欠落は例外とする。
+    /// 呼び出し側は事前に Load / Ensure 済みであること。キュー投影は
+    /// <see cref="BuildProjectionFromEngineForQueue"/> を使い欠落をスキップする。
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">Engine に snapshot が無いとき。</exception>
     private (string Status, bool? CancelRequested, string GraphJson) BuildProjectionFromEngine(Guid executionId)
     {
         var engineId = executionId.ToString();
         var snapshot = _engine.GetSnapshot(engineId);
+        if (snapshot is null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot project execution '{executionId}': engine snapshot is missing.");
+        }
+
         var graphJson = _engine.ExportExecutionGraph(engineId);
         var status = MapStatus(snapshot);
-        return (status, snapshot?.IsCancelled, graphJson);
+        return (status, snapshot.IsCancelled, graphJson);
     }
 
     private (string? status, bool? cancelRequested, string? graphJson) BuildProjectionFromEngineForQueue(Guid executionId)

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -729,6 +729,14 @@ internal sealed class ExecutionService : IExecutionService
             return;
         }
 
+        // WORKER / 同期 Cancel: 未終端子へ Cancel をカスケード（ネストは各層で再帰）。
+        if (_forkChildCoordinator is not null)
+        {
+            await _forkChildCoordinator
+                .CascadeCancelToRunningChildrenAsync(uuid.Value, ct)
+                .ConfigureAwait(false);
+        }
+
         await _projectionUpdateQueue.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
 
         var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
@@ -1123,6 +1131,17 @@ internal sealed class ExecutionService : IExecutionService
         if (execution is null)
             throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
 
+        // 親 ID への PublishEvent も子 Wait へ振り替える（要件4）。
+        if (await TryRedirectPublishEventToChildWaitAsync(
+                uuid.Value,
+                eventName,
+                idempotencyKey,
+                requestContext,
+                ct).ConfigureAwait(false))
+        {
+            return;
+        }
+
         await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
         await _projectionUpdateQueue.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
@@ -1432,6 +1451,18 @@ internal sealed class ExecutionService : IExecutionService
         if (execution is null)
             throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
 
+        // 親 ID へ届いた分岐 Wait は子 execution へ振り替える（要件4）。
+        if (await TryRedirectResumeToChildWaitAsync(
+                uuid.Value,
+                nodeId,
+                eventName,
+                idempotencyKey,
+                requestContext,
+                ct).ConfigureAwait(false))
+        {
+            return;
+        }
+
         await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
         await _projectionUpdateQueue.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
@@ -1535,6 +1566,69 @@ internal sealed class ExecutionService : IExecutionService
 
         // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
         await _projectionUpdateQueue.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 親 ID の Resume を子 Wait へ振り替える。振り替えたとき true。
+    /// </summary>
+    private async Task<bool> TryRedirectResumeToChildWaitAsync(
+        Guid requestedExecutionId,
+        string nodeId,
+        string eventName,
+        string? idempotencyKey,
+        CommandRequestContext requestContext,
+        CancellationToken ct)
+    {
+        if (_forkChildCoordinator is null)
+            return false;
+
+        if (string.Equals(eventName, ExecutionWaitEventNames.ChildCompleted, StringComparison.Ordinal))
+            return false;
+
+        var delivery = await _forkChildCoordinator
+            .TryResolveChildWaitDeliveryAsync(requestedExecutionId, nodeId, eventName, ct)
+            .ConfigureAwait(false);
+        if (delivery is null)
+            return false;
+
+        await ResumeNodeAsync(
+                delivery.ExecutionId.ToString("D"),
+                delivery.NodeId,
+                delivery.EventName,
+                idempotencyKey,
+                requestContext,
+                ct)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// 親 ID の PublishEvent を子 Wait へ振り替える。振り替えたとき true。
+    /// </summary>
+    private async Task<bool> TryRedirectPublishEventToChildWaitAsync(
+        Guid requestedExecutionId,
+        string eventName,
+        string? idempotencyKey,
+        CommandRequestContext requestContext,
+        CancellationToken ct)
+    {
+        if (_forkChildCoordinator is null)
+            return false;
+
+        var delivery = await _forkChildCoordinator
+            .TryResolveChildWaitDeliveryAsync(requestedExecutionId, nodeId: null, eventName, ct)
+            .ConfigureAwait(false);
+        if (delivery is null)
+            return false;
+
+        await PublishEventAsync(
+                delivery.ExecutionId.ToString("D"),
+                delivery.EventName,
+                idempotencyKey,
+                requestContext,
+                ct)
+            .ConfigureAwait(false);
+        return true;
     }
 
     /// <summary>

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -302,23 +302,23 @@ internal sealed class ExecutionService : IExecutionService
                         innerCt).ConfigureAwait(false);
                 }
 
-                return accepted;
-            },
-            ct).ConfigureAwait(false);
+                await _workQueue!.EnqueueAsync(
+                    uow,
+                    new ExecutionWorkItemRow
+                    {
+                        WorkItemId = _idGenerator.NewGuid(),
+                        ExecutionId = executionId,
+                        Kind = ExecutionWorkItemKinds.Start,
+                        Payload = JsonSerializer.Serialize(
+                            new ExecutionStartWorkItemPayload(executionId, request),
+                            ExecutionWorkItemPayloadJson.Options),
+                        AvailableAt = createdAt,
+                        Attempts = 0,
+                        CreatedAt = createdAt
+                    },
+                    innerCt).ConfigureAwait(false);
 
-        var now = DateTime.UtcNow;
-        await _workQueue!.EnqueueAsync(
-            new ExecutionWorkItemRow
-            {
-                WorkItemId = _idGenerator.NewGuid(),
-                ExecutionId = executionId,
-                Kind = ExecutionWorkItemKinds.Start,
-                Payload = JsonSerializer.Serialize(
-                    new ExecutionStartWorkItemPayload(executionId, request),
-                    ExecutionWorkItemPayloadJson.Options),
-                AvailableAt = now,
-                Attempts = 0,
-                CreatedAt = now
+                return accepted;
             },
             ct).ConfigureAwait(false);
 
@@ -333,7 +333,7 @@ internal sealed class ExecutionService : IExecutionService
         var compiled = RestoreCompiledDefinitionFromVersion(args.VersionRow);
         var resolvedExecutionId = args.ExecutionId ?? _idGenerator.NewGuid();
         var engineId = resolvedExecutionId.ToString();
-        _engine.Start(compiled, engineId, args.Request.Input);
+        _engine.Start(compiled, engineId, args.Request.Input, args.Request.InitialState);
 
         var graphId = await _displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Definition, args.DefinitionId.ToString("D"), ct).ConfigureAwait(false)
             ?? args.DefinitionId.ToString("D");
@@ -819,11 +819,11 @@ internal sealed class ExecutionService : IExecutionService
         CommandDedupKey? dedupKey,
         CancellationToken ct)
     {
-        if (dedupKey is { } saveKey)
-        {
-            var now = DateTime.UtcNow;
-            await _executor.ExecuteReadCommittedAsync(
-                async (uow, innerCt) =>
+        var now = DateTime.UtcNow;
+        await _executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                if (dedupKey is { } saveKey)
                 {
                     await _dedup.SaveAsync(
                         uow,
@@ -839,21 +839,21 @@ internal sealed class ExecutionService : IExecutionService
                             ExpiresAt = now.AddHours(24)
                         },
                         innerCt).ConfigureAwait(false);
-                },
-                ct).ConfigureAwait(false);
-        }
+                }
 
-        var enqueueAt = DateTime.UtcNow;
-        await _workQueue!.EnqueueAsync(
-            new ExecutionWorkItemRow
-            {
-                WorkItemId = _idGenerator.NewGuid(),
-                ExecutionId = executionId,
-                Kind = ExecutionWorkItemKinds.Cancel,
-                Payload = "{}",
-                AvailableAt = enqueueAt,
-                Attempts = 0,
-                CreatedAt = enqueueAt
+                await _workQueue!.EnqueueAsync(
+                    uow,
+                    new ExecutionWorkItemRow
+                    {
+                        WorkItemId = _idGenerator.NewGuid(),
+                        ExecutionId = executionId,
+                        Kind = ExecutionWorkItemKinds.Cancel,
+                        Payload = "{}",
+                        AvailableAt = now,
+                        Attempts = 0,
+                        CreatedAt = now
+                    },
+                    innerCt).ConfigureAwait(false);
             },
             ct).ConfigureAwait(false);
     }

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -87,6 +87,7 @@ internal sealed class ExecutionService : IExecutionService
     private readonly IOptions<EventDeliveryRetryOptions> _eventDeliveryRetryOptions;
     private readonly ICorrelationIdAccessor _correlationIdAccessor;
     private readonly IExecutionProjectionUpdateQueue _projectionUpdateQueue;
+    private readonly IForkChildExecutionCoordinator? _forkChildCoordinator;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
@@ -119,7 +120,8 @@ internal sealed class ExecutionService : IExecutionService
         IExecutionCheckpointStore checkpointStore,
         IExecutionProjectionUpdateQueue? projectionUpdateQueue = null,
         IExecutionWorkQueue? workQueue = null,
-        ExecutionOwnershipTracker? ownershipTracker = null)
+        ExecutionOwnershipTracker? ownershipTracker = null,
+        IForkChildExecutionCoordinator? forkChildCoordinator = null)
     {
         _engine = engine;
         _displayIds = displayIds;
@@ -148,6 +150,7 @@ internal sealed class ExecutionService : IExecutionService
         _eventDeliveryRetryOptions = eventDeliveryRetryOptions;
         _correlationIdAccessor = correlationIdAccessor;
         _projectionUpdateQueue = projectionUpdateQueue ?? NoopExecutionProjectionUpdateQueue.Instance;
+        _forkChildCoordinator = forkChildCoordinator;
     }
 
     public async Task<ExecutionResponse> StartAsync(
@@ -1438,6 +1441,13 @@ internal sealed class ExecutionService : IExecutionService
         if (await TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
             return;
 
+        // 物理子終端の予約イベントは Wait Resume ではなく Join 再評価へ振る（D3）。
+        if (string.Equals(eventName, ExecutionWaitEventNames.ChildCompleted, StringComparison.Ordinal))
+        {
+            await HandleChildCompletedResumeAsync(uuid.Value, execution, nodeId, ct).ConfigureAwait(false);
+            return;
+        }
+
         await EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
 
         // Resume 正本: nodeId + eventName。wait 行は nodeId で先行削除する。
@@ -1525,6 +1535,164 @@ internal sealed class ExecutionService : IExecutionService
 
         // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
         await _projectionUpdateQueue.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 物理子終端の予約 Resume を受け、親の Join を再評価する（D2-B / D3）。
+    /// </summary>
+    /// <param name="parentExecutionId">親 execution。</param>
+    /// <param name="execution">親の投影行。</param>
+    /// <param name="forkNodeId">Resume payload の nodeId（Fork 到達インスタンス）。</param>
+    /// <param name="ct">キャンセル。</param>
+    private async Task HandleChildCompletedResumeAsync(
+        Guid parentExecutionId,
+        ExecutionRow execution,
+        string forkNodeId,
+        CancellationToken ct)
+    {
+        if (_forkChildCoordinator is null)
+            return;
+
+        if (IsTerminalExecutionProjectionStatus(execution.Status))
+            return;
+
+        var evaluation = await _forkChildCoordinator
+            .EvaluateJoinAsync(parentExecutionId, forkNodeId, ct)
+            .ConfigureAwait(false);
+
+        switch (evaluation.Kind)
+        {
+            case ForkJoinEvaluationKind.Waiting:
+                return;
+
+            case ForkJoinEvaluationKind.Failed:
+                await FailParentFromJoinAsync(
+                        parentExecutionId,
+                        forkNodeId,
+                        evaluation.FailureStatus ?? ExecutionProjectionStatuses.Failed,
+                        ct)
+                    .ConfigureAwait(false);
+                return;
+
+            case ForkJoinEvaluationKind.Satisfied:
+                await CompleteParentPhysicalJoinAsync(
+                        parentExecutionId,
+                        execution,
+                        forkNodeId,
+                        evaluation,
+                        ct)
+                    .ConfigureAwait(false);
+                return;
+
+            default:
+                throw new InvalidOperationException($"Unknown fork join evaluation kind '{evaluation.Kind}'.");
+        }
+    }
+
+    /// <summary>Join 失敗／キャンセルを親投影へ伝播する（残子 Cancel はタスク 6）。</summary>
+    private async Task FailParentFromJoinAsync(
+        Guid parentExecutionId,
+        string forkNodeId,
+        string failureStatus,
+        CancellationToken ct)
+    {
+        _logger.ForkJoinFailedPropagated(parentExecutionId, forkNodeId, failureStatus);
+
+        var snapshot = await _executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => _executions.GetSnapshotByExecutionIdAsync(uow, parentExecutionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        var graphJson = snapshot?.GraphJson ?? """{"nodes":[],"edges":[]}""";
+        var cancelRequested = string.Equals(
+            failureStatus,
+            ExecutionProjectionStatuses.Cancelled,
+            StringComparison.Ordinal);
+
+        await _executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    await _executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            parentExecutionId,
+                            failureStatus,
+                            cancelRequested,
+                            graphJson,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    await DiscardOrRefreshRuntimeCheckpointAsync(
+                            uow,
+                            parentExecutionId.ToString(),
+                            parentExecutionId,
+                            innerCt)
+                        .ConfigureAwait(false);
+                },
+                ct)
+            .ConfigureAwait(false);
+
+        _engine.Unload(parentExecutionId.ToString());
+    }
+
+    /// <summary>Join 充足時に親 Engine で物理 Join を完了し投影を更新する。</summary>
+    private async Task CompleteParentPhysicalJoinAsync(
+        Guid parentExecutionId,
+        ExecutionRow execution,
+        string forkNodeId,
+        ForkJoinEvaluation evaluation,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(evaluation.CandidateInputs);
+        _logger.ForkJoinSatisfied(parentExecutionId, forkNodeId, evaluation.JoinState);
+
+        await EnsureEngineRuntimeLoadedForMutationAsync(parentExecutionId, execution, ct).ConfigureAwait(false);
+
+        var engineId = parentExecutionId.ToString();
+        _engine.CompletePhysicalJoin(engineId, evaluation.JoinState, evaluation.CandidateInputs);
+        await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
+
+        var (status, cancelRequested, graphJson) = BuildProjectionFromEngine(parentExecutionId);
+        await _executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    await _executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            parentExecutionId,
+                            status,
+                            cancelRequested,
+                            graphJson,
+                            innerCt)
+                        .ConfigureAwait(false);
+                    await SyncOperationalProjectionAsync(
+                            uow,
+                            parentExecutionId,
+                            execution.TenantId,
+                            status,
+                            graphJson,
+                            nodeIdToClear: null,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    if (ShouldDiscardRuntimeCheckpoint(status, graphJson))
+                    {
+                        await DiscardOrRefreshRuntimeCheckpointAsync(
+                                uow,
+                                engineId,
+                                parentExecutionId,
+                                innerCt)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await UpsertRuntimeCheckpointAsync(uow, engineId, parentExecutionId, innerCt)
+                            .ConfigureAwait(false);
+                    }
+                },
+                ct)
+            .ConfigureAwait(false);
+
+        await _projectionUpdateQueue.EnqueueAsync(parentExecutionId, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -2217,11 +2385,33 @@ internal sealed class ExecutionService : IExecutionService
             },
             ct).ConfigureAwait(false);
 
+        string? childTerminalOutputJson = null;
+        if (ExecutionProjectionStatuses.IsTerminal(status))
+            childTerminalOutputJson = TryGetWorkflowOutputJson(engineExecutionId);
+
         if (shouldUnloadAfterProjection)
         {
             _engine.Unload(engineExecutionId);
             _logger.CheckpointUnloadedAfterProjectionSync(executionId);
         }
+
+        if (ExecutionProjectionStatuses.IsTerminal(status) && _forkChildCoordinator is not null)
+        {
+            await _forkChildCoordinator
+                .NotifyChildTerminalAsync(executionId, status, childTerminalOutputJson, ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>ロード中 Engine から終端 workflow output を JSON 文字列として取り出す。</summary>
+    private string? TryGetWorkflowOutputJson(string engineExecutionId)
+    {
+        var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
+        var output = checkpoint?.Context.WorkflowOutput;
+        if (output is null || output.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+            return null;
+
+        return output.Value.GetRawText();
     }
 
     /// <summary>

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -1648,7 +1648,19 @@ internal sealed class ExecutionService : IExecutionService
         await EnsureEngineRuntimeLoadedForMutationAsync(parentExecutionId, execution, ct).ConfigureAwait(false);
 
         var engineId = parentExecutionId.ToString();
-        _engine.CompletePhysicalJoin(engineId, evaluation.JoinState, evaluation.CandidateInputs);
+        IReadOnlyList<PhysicalJoinContextFragment>? fragments = null;
+        if (evaluation.ContextMerges is { Count: > 0 })
+        {
+            fragments = evaluation.ContextMerges
+                .Select(m => new PhysicalJoinContextFragment(m.States, m.Vars))
+                .ToList();
+        }
+
+        _engine.CompletePhysicalJoin(
+            engineId,
+            evaluation.JoinState,
+            evaluation.CandidateInputs,
+            fragments);
         await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
 
         var (status, cancelRequested, graphJson) = BuildProjectionFromEngine(parentExecutionId);
@@ -2386,8 +2398,13 @@ internal sealed class ExecutionService : IExecutionService
             ct).ConfigureAwait(false);
 
         string? childTerminalOutputJson = null;
+        string? childTerminalStatesJson = null;
+        string? childTerminalVarsJson = null;
         if (ExecutionProjectionStatuses.IsTerminal(status))
-            childTerminalOutputJson = TryGetWorkflowOutputJson(engineExecutionId);
+        {
+            (childTerminalOutputJson, childTerminalStatesJson, childTerminalVarsJson) =
+                TryGetChildTerminalContextJson(engineExecutionId);
+        }
 
         if (shouldUnloadAfterProjection)
         {
@@ -2398,20 +2415,53 @@ internal sealed class ExecutionService : IExecutionService
         if (ExecutionProjectionStatuses.IsTerminal(status) && _forkChildCoordinator is not null)
         {
             await _forkChildCoordinator
-                .NotifyChildTerminalAsync(executionId, status, childTerminalOutputJson, ct)
+                .NotifyChildTerminalAsync(
+                    executionId,
+                    status,
+                    childTerminalOutputJson,
+                    childTerminalStatesJson,
+                    childTerminalVarsJson,
+                    ct)
                 .ConfigureAwait(false);
         }
     }
 
-    /// <summary>ロード中 Engine から終端 workflow output を JSON 文字列として取り出す。</summary>
-    private string? TryGetWorkflowOutputJson(string engineExecutionId)
+    /// <summary>ロード中 Engine から終端 Context（output / states / vars）を JSON 文字列として取り出す。</summary>
+    private (string? OutputJson, string? StatesJson, string? VarsJson) TryGetChildTerminalContextJson(
+        string engineExecutionId)
     {
         var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
-        var output = checkpoint?.Context.WorkflowOutput;
-        if (output is null || output.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
-            return null;
+        if (checkpoint is null)
+            return (null, null, null);
 
-        return output.Value.GetRawText();
+        var output = checkpoint.Context.WorkflowOutput;
+        string? outputJson = null;
+        if (output is not null
+            && output.Value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+        {
+            outputJson = output.Value.GetRawText();
+        }
+
+        string? statesJson = null;
+        if (checkpoint.Context.States is { Count: > 0 })
+        {
+            statesJson = JsonSerializer.Serialize(
+                checkpoint.Context.States.ToDictionary(
+                    kv => kv.Key,
+                    kv => kv.Value,
+                    StringComparer.OrdinalIgnoreCase),
+                CamelCaseJsonSerializerOptions);
+        }
+
+        string? varsJson = null;
+        var vars = checkpoint.Context.Vars;
+        if (vars is not null
+            && vars.Value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+        {
+            varsJson = vars.Value.GetRawText();
+        }
+
+        return (outputJson, statesJson, varsJson);
     }
 
     /// <summary>

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -1378,54 +1378,69 @@ internal sealed class ExecutionService : IExecutionService
             throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
 
         var displayId = await _displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false) ?? execution.ExecutionId.ToString("D");
+        // D6 / D6.1: GraphUpdated patch は合成グラフ由来。
         var graphJson = await GetGraphJsonAsync(idOrUuid, ct).ConfigureAwait(false);
         var patchNodes = ExecutionViewMapper.MapGraphPatchNodes(graphJson);
 
-        var (items, hasMore) = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _eventStore.ListAfterSeqAsync(uow, uuid.Value, afterSeq, limit, innerCt),
-            ct).ConfigureAwait(false);
-
-        var typeStarted = EventStoreEventType.WorkflowStarted.ToPersistedString();
-        var typeCancelled = EventStoreEventType.WorkflowCancelled.ToPersistedString();
-        var typePublished = EventStoreEventType.EventPublished.ToPersistedString();
-
-        var events = new List<TimelineEventDto>(items.Count);
-        foreach (var row in items)
-        {
-            var at = row.OccurredAt.ToString("O");
-            var timelineEvent = row.Type switch
-            {
-                _ when row.Type == typeStarted => new TimelineEventDto
-                {
-                    Seq = row.Seq,
-                    Type = "ExecutionStatusChanged",
-                    ExecutionId = displayId,
-                    To = ExecutionProjectionStatuses.Running,
-                    At = at
-                },
-                _ when row.Type == typeCancelled => new TimelineEventDto
-                {
-                    Seq = row.Seq,
-                    Type = "ExecutionStatusChanged",
-                    ExecutionId = displayId,
-                    To = ExecutionProjectionStatuses.Cancelled,
-                    At = at
-                },
-                _ when row.Type == typePublished => new TimelineEventDto
-                {
-                    Seq = row.Seq,
-                    Type = "GraphUpdated",
-                    ExecutionId = displayId,
-                    Patch = new GraphUpdatedPatchDto { Nodes = patchNodes },
-                    At = at
-                },
-                _ => null
-            };
-            if (timelineEvent is not null)
-                events.Add(timelineEvent);
-        }
+        var sourceRows = await LoadEventStoreRowsForTimelineAsync(uuid.Value, ct).ConfigureAwait(false);
+        var (events, hasMore) = PhysicalForkEventTimelineComposer.ComposePage(
+            sourceRows,
+            displayId,
+            patchNodes,
+            afterSeq,
+            limit);
 
         return new ExecutionEventsResponseDto { Events = events, HasMore = hasMore };
+    }
+
+    /// <summary>
+    /// 親＋再帰子孫の event_store 行を読み取り合成用に集める（D6.1）。
+    /// </summary>
+    private async Task<IReadOnlyList<PhysicalForkEventTimelineComposer.SourceRow>> LoadEventStoreRowsForTimelineAsync(
+        Guid rootExecutionId,
+        CancellationToken ct)
+    {
+        var executionIds = new List<Guid> { rootExecutionId };
+        if (_forkChildCoordinator is not null)
+        {
+            var descendants = await _forkChildCoordinator
+                .ListDescendantExecutionIdsAsync(rootExecutionId, ct)
+                .ConfigureAwait(false);
+            executionIds.AddRange(descendants);
+        }
+
+        var rows = new List<PhysicalForkEventTimelineComposer.SourceRow>();
+        foreach (var executionId in executionIds)
+        {
+            var isRoot = executionId == rootExecutionId;
+            long afterSeq = 0;
+            while (true)
+            {
+                var pageAfter = afterSeq;
+                var (items, hasMore) = await _executor.ExecuteReadOnlyAsync(
+                        (uow, innerCt) => _eventStore.ListAfterSeqAsync(
+                            uow,
+                            executionId,
+                            pageAfter,
+                            limit: 500,
+                            innerCt),
+                        ct)
+                    .ConfigureAwait(false);
+
+                foreach (var item in items)
+                    rows.Add(new PhysicalForkEventTimelineComposer.SourceRow(item, isRoot));
+
+                if (!hasMore || items.Count == 0)
+                    break;
+
+                afterSeq = items[^1].Seq;
+                // 暴走防止（異常に長い event_store）。
+                if (rows.Count >= 50_000)
+                    break;
+            }
+        }
+
+        return rows;
     }
 
     public async Task ResumeNodeAsync(

--- a/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
@@ -12,10 +12,12 @@ namespace Statevia.Core.Application.Services;
 /// <remarks>
 /// <para>子作成・execution_branches・Start enqueue を同一 ReadCommitted で行い、一時失敗は Options に従い再試行する（D9）。</para>
 /// <para>上限超過時は作成済みの未終端子へ Cancel を enqueue し、親を Failed にする。</para>
+/// <para>親 Cancel カスケードと分岐 Wait の子配送解決（要件4）も担う。</para>
 /// </remarks>
 /// <param name="executor">トランザクション実行。</param>
 /// <param name="executions">executions 永続化。</param>
 /// <param name="branches">execution_branches 永続化。</param>
+/// <param name="waits">execution_waits 永続化（配送先解決）。</param>
 /// <param name="workQueue">work item キュー。</param>
 /// <param name="idGenerator">ID 生成。</param>
 /// <param name="displayIdWrites">display ID 割当。</param>
@@ -30,6 +32,7 @@ public sealed class ForkChildExecutionCoordinator(
     ICoreTransactionExecutor executor,
     IExecutionRepository executions,
     IExecutionBranchRepository branches,
+    IExecutionWaitRepository waits,
     IExecutionWorkQueue workQueue,
     IIdGenerator idGenerator,
     IDisplayIdWriteService displayIdWrites,
@@ -233,6 +236,66 @@ public sealed class ForkChildExecutionCoordinator(
             joinState,
             CandidateInputs: candidateInputs,
             ContextMerges: contextMerges);
+    }
+
+    /// <inheritdoc />
+    public async Task CascadeCancelToRunningChildrenAsync(Guid parentExecutionId, CancellationToken ct)
+    {
+        await executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    var rows = await branches.ListByParentExecutionIdAsync(uow, parentExecutionId, innerCt)
+                        .ConfigureAwait(false);
+                    await EnqueueCancelForRunningBranchesAsync(uow, rows, DateTime.UtcNow, innerCt)
+                        .ConfigureAwait(false);
+                },
+                ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<ForkWaitDeliveryTarget?> TryResolveChildWaitDeliveryAsync(
+        Guid requestedExecutionId,
+        string? nodeId,
+        string eventName,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventName);
+        var normalizedEvent = eventName.Trim();
+
+        return await executor.ExecuteReadOnlyAsync(
+                async (uow, innerCt) =>
+                {
+                    var localWaits = await waits.ListByExecutionIdAsync(uow, requestedExecutionId, innerCt)
+                        .ConfigureAwait(false);
+                    if (FindMatchingWaits(localWaits, requestedExecutionId, nodeId, normalizedEvent).Count > 0)
+                        return null;
+
+                    var childRows = await branches.ListByParentExecutionIdAsync(uow, requestedExecutionId, innerCt)
+                        .ConfigureAwait(false);
+                    if (childRows.Count == 0)
+                        return null;
+
+                    var matches = new List<ForkWaitDeliveryTarget>();
+                    foreach (var childExecutionId in childRows.Select(child => child.ExecutionId))
+                    {
+                        var childWaits = await waits.ListByExecutionIdAsync(uow, childExecutionId, innerCt)
+                            .ConfigureAwait(false);
+                        matches.AddRange(
+                            FindMatchingWaits(childWaits, childExecutionId, nodeId, normalizedEvent));
+                    }
+
+                    return matches.Count switch
+                    {
+                        0 => null,
+                        1 => matches[0],
+                        _ => throw new InvalidOperationException(
+                            $"Ambiguous Wait delivery for execution {requestedExecutionId:D} event '{normalizedEvent}': "
+                            + $"{matches.Count} child waits match.")
+                    };
+                },
+                ct)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -441,26 +504,60 @@ public sealed class ForkChildExecutionCoordinator(
                             innerCt)
                         .ConfigureAwait(false);
 
-                    var cancelItems = rows
-                        .Where(r => string.Equals(r.Status, ExecutionBranchStatuses.Running, StringComparison.Ordinal))
-                        .Select(row => new ExecutionWorkItemRow
-                        {
-                            WorkItemId = idGenerator.NewGuid(),
-                            ExecutionId = row.ExecutionId,
-                            Kind = ExecutionWorkItemKinds.Cancel,
-                            Payload = "{}",
-                            AvailableAt = now,
-                            Attempts = 0,
-                            CreatedAt = now
-                        })
-                        .ToList();
-
-                    await workQueue.EnqueueManyAsync(uow, cancelItems, innerCt).ConfigureAwait(false);
+                    await EnqueueCancelForRunningBranchesAsync(uow, rows, now, innerCt).ConfigureAwait(false);
                 },
                 ct)
             .ConfigureAwait(false);
 
         _ = joinState;
+    }
+
+    private async Task EnqueueCancelForRunningBranchesAsync(
+        ICoreUnitOfWork uow,
+        IReadOnlyList<ExecutionBranchRow> rows,
+        DateTime now,
+        CancellationToken ct)
+    {
+        var cancelItems = rows
+            .Where(r => string.Equals(r.Status, ExecutionBranchStatuses.Running, StringComparison.Ordinal))
+            .Select(row => new ExecutionWorkItemRow
+            {
+                WorkItemId = idGenerator.NewGuid(),
+                ExecutionId = row.ExecutionId,
+                Kind = ExecutionWorkItemKinds.Cancel,
+                Payload = "{}",
+                AvailableAt = now,
+                Attempts = 0,
+                CreatedAt = now
+            })
+            .ToList();
+
+        if (cancelItems.Count == 0)
+            return;
+
+        await workQueue.EnqueueManyAsync(uow, cancelItems, ct).ConfigureAwait(false);
+    }
+
+    private static List<ForkWaitDeliveryTarget> FindMatchingWaits(
+        IReadOnlyList<ExecutionWaitRow> waitRows,
+        Guid executionId,
+        string? nodeId,
+        string eventName)
+    {
+        return waitRows
+            .Where(wait =>
+            {
+                if (!string.IsNullOrWhiteSpace(nodeId)
+                    && !string.Equals(wait.NodeId, nodeId, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                return wait.AllowedEvents.Any(allowed =>
+                    string.Equals(allowed, eventName, StringComparison.Ordinal));
+            })
+            .Select(wait => new ForkWaitDeliveryTarget(executionId, wait.NodeId, eventName))
+            .ToList();
     }
 
     private static JsonElement? ToJsonElement(object? value)

--- a/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
@@ -13,7 +13,7 @@ namespace Statevia.Core.Application.Services;
 /// <para>子作成・execution_branches・Start enqueue を同一 ReadCommitted で行い、一時失敗は Options に従い再試行する（D9）。</para>
 /// <para>上限超過時は作成済みの未終端子へ Cancel を enqueue し、親を Failed にする。</para>
 /// <para>親 Cancel カスケードと分岐 Wait の子配送解決（要件4）も担う。</para>
-/// <para>親 graph 読み取り時の論理 Fork/Join 合成（D6）も担う。</para>
+/// <para>親 graph 読み取り時の論理 Fork/Join 合成（D6）と、イベント合成用の子孫列挙（D6.1）も担う。</para>
 /// </remarks>
 /// <param name="executor">トランザクション実行。</param>
 /// <param name="executions">executions 永続化。</param>
@@ -341,6 +341,36 @@ public sealed class ForkChildExecutionCoordinator(
         }
 
         return PhysicalForkGraphComposer.Compose(baseGraphJson, composedBranches);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Guid>> ListDescendantExecutionIdsAsync(
+        Guid parentExecutionId,
+        CancellationToken ct)
+    {
+        var result = new List<Guid>();
+        var queue = new Queue<Guid>();
+        queue.Enqueue(parentExecutionId);
+        var seen = new HashSet<Guid> { parentExecutionId };
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            var childRows = await executor.ExecuteReadOnlyAsync(
+                    (uow, innerCt) => branches.ListByParentExecutionIdAsync(uow, current, innerCt),
+                    ct)
+                .ConfigureAwait(false);
+
+            foreach (var childId in childRows
+                         .Select(r => r.ExecutionId)
+                         .Where(id => seen.Add(id)))
+            {
+                result.Add(childId);
+                queue.Enqueue(childId);
+            }
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
@@ -98,6 +98,8 @@ public sealed class ForkChildExecutionCoordinator(
         Guid childExecutionId,
         string status,
         string? outputJson,
+        string? statesJson,
+        string? varsJson,
         CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(status);
@@ -120,7 +122,12 @@ public sealed class ForkChildExecutionCoordinator(
                                 branch.ParentExecutionId,
                                 branch.ForkNodeId,
                                 branch.BranchState,
-                                new ExecutionBranchStatusUpdate(status, now, outputJson),
+                                new ExecutionBranchStatusUpdate(
+                                    status,
+                                    now,
+                                    outputJson,
+                                    statesJson,
+                                    varsJson),
                                 innerCt)
                             .ConfigureAwait(false);
                         if (!updated)
@@ -212,15 +219,20 @@ public sealed class ForkChildExecutionCoordinator(
         }
 
         var candidateInputs = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        foreach (var row in rows)
+        var contextMerges = new List<ForkJoinChildContextMerge>();
+        foreach (var row in rows.OrderBy(r => r.UpdatedAt).ThenBy(r => r.BranchState, StringComparer.Ordinal))
         {
             candidateInputs[row.BranchState] = ParseOutputJson(row.OutputJson);
+            contextMerges.Add(new ForkJoinChildContextMerge(
+                ParseStatesJson(row.StatesJson),
+                ParseOutputJson(row.VarsJson)));
         }
 
         return new ForkJoinEvaluation(
             ForkJoinEvaluationKind.Satisfied,
             joinState,
-            CandidateInputs: candidateInputs);
+            CandidateInputs: candidateInputs,
+            ContextMerges: contextMerges);
     }
 
     /// <summary>
@@ -470,5 +482,21 @@ public sealed class ForkChildExecutionCoordinator(
 
         using var document = JsonDocument.Parse(outputJson);
         return document.RootElement.Clone();
+    }
+
+    private static Dictionary<string, object?> ParseStatesJson(string? statesJson)
+    {
+        if (string.IsNullOrWhiteSpace(statesJson))
+            return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+        using var document = JsonDocument.Parse(statesJson);
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+            return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+        return document.RootElement.EnumerateObject()
+            .ToDictionary(
+                prop => prop.Name,
+                prop => (object?)prop.Value.Clone(),
+                StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
@@ -93,6 +93,136 @@ public sealed class ForkChildExecutionCoordinator(
         return new ForkExpansionResult(Succeeded: false, Array.Empty<Guid>(), joinState);
     }
 
+    /// <inheritdoc />
+    public async Task<bool> NotifyChildTerminalAsync(
+        Guid childExecutionId,
+        string status,
+        string? outputJson,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(status);
+        if (!ExecutionProjectionStatuses.IsTerminal(status))
+            throw new ArgumentException($"Status '{status}' is not terminal.", nameof(status));
+
+        var now = DateTime.UtcNow;
+        return await executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    var branch = await branches.GetByChildExecutionIdAsync(uow, childExecutionId, innerCt)
+                        .ConfigureAwait(false);
+                    if (branch is null)
+                        return false;
+
+                    if (string.Equals(branch.Status, ExecutionBranchStatuses.Running, StringComparison.Ordinal))
+                    {
+                        var updated = await branches.TryUpdateStatusAsync(
+                                uow,
+                                branch.ParentExecutionId,
+                                branch.ForkNodeId,
+                                branch.BranchState,
+                                new ExecutionBranchStatusUpdate(status, now, outputJson),
+                                innerCt)
+                            .ConfigureAwait(false);
+                        if (!updated)
+                            return false;
+                    }
+                    else if (!ExecutionProjectionStatuses.IsTerminal(branch.Status))
+                    {
+                        return false;
+                    }
+
+                    var resumePayload = JsonSerializer.Serialize(
+                        new ExecutionResumeWorkItemPayload(
+                            ExecutionResumeWorkItemModes.Event,
+                            branch.ForkNodeId,
+                            ExecutionWaitEventNames.ChildCompleted),
+                        ExecutionWorkItemPayloadJson.Options);
+
+                    await workQueue.EnqueueAsync(
+                            uow,
+                            new ExecutionWorkItemRow
+                            {
+                                WorkItemId = idGenerator.NewGuid(),
+                                ExecutionId = branch.ParentExecutionId,
+                                Kind = ExecutionWorkItemKinds.Resume,
+                                Payload = resumePayload,
+                                AvailableAt = now,
+                                Attempts = 0,
+                                CreatedAt = now
+                            },
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    logger.ForkChildTerminalSignaled(
+                        childExecutionId,
+                        branch.ParentExecutionId,
+                        branch.ForkNodeId,
+                        status);
+                    return true;
+                },
+                ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<ForkJoinEvaluation> EvaluateJoinAsync(
+        Guid parentExecutionId,
+        string forkNodeId,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(forkNodeId);
+
+        var rows = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => branches.ListByParentAndForkNodeAsync(
+                    uow,
+                    parentExecutionId,
+                    forkNodeId,
+                    innerCt),
+                ct)
+            .ConfigureAwait(false);
+
+        if (rows.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No execution_branches for parent {parentExecutionId:D} forkNodeId '{forkNodeId}'.");
+        }
+
+        var joinState = rows[0].JoinState;
+
+        var failed = rows.FirstOrDefault(r =>
+            string.Equals(r.Status, ExecutionBranchStatuses.Failed, StringComparison.Ordinal)
+            || string.Equals(r.Status, ExecutionBranchStatuses.Cancelled, StringComparison.Ordinal));
+        if (failed is not null)
+        {
+            // 論理 Join と同様、一文失敗は未終端の兄弟を待たずに親へ伝播する。
+            return new ForkJoinEvaluation(
+                ForkJoinEvaluationKind.Failed,
+                joinState,
+                FailureStatus: failed.Status);
+        }
+
+        if (rows.Any(r => string.Equals(r.Status, ExecutionBranchStatuses.Running, StringComparison.Ordinal)))
+        {
+            return new ForkJoinEvaluation(ForkJoinEvaluationKind.Waiting, joinState);
+        }
+
+        if (!rows.All(r => string.Equals(r.Status, ExecutionBranchStatuses.Completed, StringComparison.Ordinal)))
+        {
+            return new ForkJoinEvaluation(ForkJoinEvaluationKind.Waiting, joinState);
+        }
+
+        var candidateInputs = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in rows)
+        {
+            candidateInputs[row.BranchState] = ParseOutputJson(row.OutputJson);
+        }
+
+        return new ForkJoinEvaluation(
+            ForkJoinEvaluationKind.Satisfied,
+            joinState,
+            CandidateInputs: candidateInputs);
+    }
+
     /// <summary>
     /// Join.all と Fork 分岐先頭集合が一致する Join を一意に解決する。
     /// </summary>
@@ -331,5 +461,14 @@ public sealed class ForkChildExecutionCoordinator(
         var json = JsonSerializer.Serialize(value, CamelCaseJson);
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
+    }
+
+    private static JsonElement? ParseOutputJson(string? outputJson)
+    {
+        if (string.IsNullOrWhiteSpace(outputJson))
+            return null;
+
+        using var document = JsonDocument.Parse(outputJson);
+        return document.RootElement.Clone();
     }
 }

--- a/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
@@ -1,0 +1,335 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// Hosted Runtime の Fork を親＋子 execution に展開する。
+/// </summary>
+/// <remarks>
+/// <para>子作成・execution_branches・Start enqueue を同一 ReadCommitted で行い、一時失敗は Options に従い再試行する（D9）。</para>
+/// <para>上限超過時は作成済みの未終端子へ Cancel を enqueue し、親を Failed にする。</para>
+/// </remarks>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="executions">executions 永続化。</param>
+/// <param name="branches">execution_branches 永続化。</param>
+/// <param name="workQueue">work item キュー。</param>
+/// <param name="idGenerator">ID 生成。</param>
+/// <param name="displayIdWrites">display ID 割当。</param>
+/// <param name="eventStore">イベントストア。</param>
+/// <param name="options">展開リトライ設定。</param>
+/// <param name="logger">ログ。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
+public sealed class ForkChildExecutionCoordinator(
+    ICoreTransactionExecutor executor,
+    IExecutionRepository executions,
+    IExecutionBranchRepository branches,
+    IExecutionWorkQueue workQueue,
+    IIdGenerator idGenerator,
+    IDisplayIdWriteService displayIdWrites,
+    IEventStoreRepository eventStore,
+    IOptions<ForkChildExpansionOptions> options,
+    ILogger<ForkChildExecutionCoordinator> logger) : IForkChildExecutionCoordinator
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly ForkChildExpansionOptions _options = options.Value;
+
+    /// <inheritdoc />
+    public async Task<ForkExpansionResult> ExpandForkAsync(ForkExpansionRequest request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Branches);
+        if (request.Branches.Count == 0)
+            throw new ArgumentException("Fork branches must not be empty.", nameof(request));
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ForkNodeId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.DefinitionDisplayId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.SecuritySnapshotJson);
+        ArgumentNullException.ThrowIfNull(request.CompiledDefinition);
+        if (_options.MaxAttempts < 1)
+            throw new InvalidOperationException("ForkChildExpansionOptions.MaxAttempts must be >= 1.");
+
+        var joinState = ResolveJoinState(request.CompiledDefinition, request.Branches);
+
+        Exception? lastError = null;
+        for (var attempt = 1; attempt <= _options.MaxAttempts; attempt++)
+        {
+            try
+            {
+                var childIds = await TryExpandOnceAsync(request, joinState, ct).ConfigureAwait(false);
+                return new ForkExpansionResult(Succeeded: true, childIds, joinState);
+            }
+#pragma warning disable CA1031 // 展開一時失敗は D9 どおり再試行し、上限後に親 Failed へ倒す
+            catch (Exception ex) when (ex is not ForkJoinResolutionException and not OperationCanceledException)
+#pragma warning restore CA1031
+            {
+                lastError = ex;
+                logger.ForkExpansionAttemptFailed(
+                    ex,
+                    attempt,
+                    _options.MaxAttempts,
+                    request.ParentExecutionId,
+                    request.ForkNodeId);
+
+                if (attempt >= _options.MaxAttempts)
+                    break;
+
+                var delayMs = Math.Max(0, _options.BaseDelayMs) * attempt;
+                if (delayMs > 0)
+                    await Task.Delay(delayMs, ct).ConfigureAwait(false);
+            }
+        }
+
+        await FailParentAfterExhaustionAsync(request, joinState, lastError, ct).ConfigureAwait(false);
+        return new ForkExpansionResult(Succeeded: false, Array.Empty<Guid>(), joinState);
+    }
+
+    /// <summary>
+    /// Join.all と Fork 分岐先頭集合が一致する Join を一意に解決する。
+    /// </summary>
+    internal static string ResolveJoinState(
+        CompiledWorkflowDefinition definition,
+        IReadOnlyList<ForkBranchExpansion> branches)
+    {
+        var branchSet = new HashSet<string>(
+            branches.Select(b => b.BranchState),
+            StringComparer.OrdinalIgnoreCase);
+        if (branchSet.Count != branches.Count)
+            throw new ForkJoinResolutionException("Fork branch states must be unique.");
+
+        var matches = definition.JoinTable
+            .Where(pair =>
+            {
+                var joinDeps = new HashSet<string>(pair.Value, StringComparer.OrdinalIgnoreCase);
+                return joinDeps.SetEquals(branchSet);
+            })
+            .Select(pair => pair.Key)
+            .ToList();
+
+        return matches.Count switch
+        {
+            1 => matches[0],
+            0 => throw new ForkJoinResolutionException(
+                $"No Join matches fork branches [{string.Join(", ", branchSet)}]."),
+            _ => throw new ForkJoinResolutionException(
+                $"Ambiguous Join for fork branches [{string.Join(", ", branchSet)}]: {string.Join(", ", matches)}.")
+        };
+    }
+
+    private async Task<IReadOnlyList<Guid>> TryExpandOnceAsync(
+        ForkExpansionRequest request,
+        string joinState,
+        CancellationToken ct)
+    {
+        var existing = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => branches.ListByParentAndForkNodeAsync(
+                    uow,
+                    request.ParentExecutionId,
+                    request.ForkNodeId,
+                    innerCt),
+                ct)
+            .ConfigureAwait(false);
+
+        if (existing.Count == request.Branches.Count
+            && existing.All(b => string.Equals(b.JoinState, joinState, StringComparison.OrdinalIgnoreCase)))
+        {
+            // 展開済み（クラッシュ再入）: 二重 Start を避けるため enqueue しない。
+            return existing
+                .OrderBy(b => IndexOfBranch(request.Branches, b.BranchState))
+                .Select(b => b.ExecutionId)
+                .ToList();
+        }
+
+        var prepared = await executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    var now = DateTime.UtcNow;
+                    var createdBranches = new List<ExecutionBranchRow>(request.Branches.Count);
+                    var startItems = new List<ExecutionWorkItemRow>(request.Branches.Count);
+                    const string emptyGraphJson = """{"nodes":[],"edges":[]}""";
+
+                    foreach (var branch in request.Branches)
+                    {
+                        var childId = idGenerator.NewGuid();
+                        await displayIdWrites
+                            .AllocateAsync(uow, DisplayIdResourceTypes.Execution, childId, innerCt)
+                            .ConfigureAwait(false);
+
+                        var childRow = new ExecutionRow
+                        {
+                            ExecutionId = childId,
+                            TenantId = request.TenantId,
+                            DefinitionId = request.DefinitionId,
+                            DefinitionVersionId = request.DefinitionVersionId,
+                            Status = ExecutionProjectionStatuses.Running,
+                            StartedAt = now,
+                            UpdatedAt = now,
+                            CancelRequested = false,
+                            RestartLost = false,
+                            SecuritySnapshotJson = request.SecuritySnapshotJson
+                        };
+                        var snapshotRow = new ExecutionGraphSnapshotRow
+                        {
+                            ExecutionId = childId,
+                            GraphJson = emptyGraphJson,
+                            UpdatedAt = now
+                        };
+                        await executions.AddExecutionAndSnapshotAsync(uow, childRow, snapshotRow, innerCt)
+                            .ConfigureAwait(false);
+
+                        var startedPayload = JsonSerializer.Serialize(
+                            new
+                            {
+                                parentExecutionId = request.ParentExecutionId.ToString("D"),
+                                forkNodeId = request.ForkNodeId,
+                                branchState = branch.BranchState,
+                                joinState,
+                                definitionId = request.DefinitionId.ToString("D"),
+                                definitionVersionId = request.DefinitionVersionId.ToString("D"),
+                                definitionVersion = request.DefinitionVersion,
+                                tenantId = request.TenantId
+                            },
+                            CamelCaseJson);
+                        await eventStore
+                            .AppendAsync(uow, childId, EventStoreEventType.WorkflowStarted, startedPayload, innerCt)
+                            .ConfigureAwait(false);
+
+                        createdBranches.Add(new ExecutionBranchRow
+                        {
+                            ParentExecutionId = request.ParentExecutionId,
+                            ExecutionId = childId,
+                            ForkNodeId = request.ForkNodeId,
+                            JoinState = joinState,
+                            BranchState = branch.BranchState,
+                            Status = ExecutionBranchStatuses.Running,
+                            CreatedAt = now,
+                            UpdatedAt = now
+                        });
+
+                        var startRequest = new StartExecutionRequest
+                        {
+                            DefinitionId = request.DefinitionDisplayId,
+                            DefinitionVersionId = request.DefinitionVersionId,
+                            DefinitionVersion = request.DefinitionVersion,
+                            Input = ToJsonElement(branch.MappedInput),
+                            InitialState = branch.BranchState
+                        };
+                        startItems.Add(new ExecutionWorkItemRow
+                        {
+                            WorkItemId = idGenerator.NewGuid(),
+                            ExecutionId = childId,
+                            Kind = ExecutionWorkItemKinds.Start,
+                            Payload = JsonSerializer.Serialize(
+                                new ExecutionStartWorkItemPayload(childId, startRequest),
+                                ExecutionWorkItemPayloadJson.Options),
+                            AvailableAt = now,
+                            Attempts = 0,
+                            CreatedAt = now
+                        });
+                    }
+
+                    await branches.InsertBranchesIdempotentAsync(uow, createdBranches, innerCt)
+                        .ConfigureAwait(false);
+                    await workQueue.EnqueueManyAsync(uow, startItems, innerCt).ConfigureAwait(false);
+
+                    return createdBranches.Select(b => b.ExecutionId).ToList();
+                },
+                ct)
+            .ConfigureAwait(false);
+
+        return prepared;
+    }
+
+    private static int IndexOfBranch(IReadOnlyList<ForkBranchExpansion> branches, string branchState)
+    {
+        for (var i = 0; i < branches.Count; i++)
+        {
+            if (string.Equals(branches[i].BranchState, branchState, StringComparison.OrdinalIgnoreCase))
+                return i;
+        }
+
+        return int.MaxValue;
+    }
+
+    private async Task FailParentAfterExhaustionAsync(
+        ForkExpansionRequest request,
+        string joinState,
+        Exception? lastError,
+        CancellationToken ct)
+    {
+        logger.ForkExpansionExhausted(
+            lastError ?? new InvalidOperationException("Fork expansion exhausted with no captured exception."),
+            request.ParentExecutionId,
+            request.ForkNodeId);
+
+        var now = DateTime.UtcNow;
+        await executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    var rows = await branches.ListByParentAndForkNodeAsync(
+                            uow,
+                            request.ParentExecutionId,
+                            request.ForkNodeId,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    var snapshot = await executions.GetSnapshotByExecutionIdAsync(
+                            uow,
+                            request.ParentExecutionId,
+                            innerCt)
+                        .ConfigureAwait(false);
+                    var graphJson = snapshot?.GraphJson ?? """{"nodes":[],"edges":[]}""";
+
+                    await executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            request.ParentExecutionId,
+                            ExecutionProjectionStatuses.Failed,
+                            cancelRequested: true,
+                            graphJson,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    var cancelItems = rows
+                        .Where(r => string.Equals(r.Status, ExecutionBranchStatuses.Running, StringComparison.Ordinal))
+                        .Select(row => new ExecutionWorkItemRow
+                        {
+                            WorkItemId = idGenerator.NewGuid(),
+                            ExecutionId = row.ExecutionId,
+                            Kind = ExecutionWorkItemKinds.Cancel,
+                            Payload = "{}",
+                            AvailableAt = now,
+                            Attempts = 0,
+                            CreatedAt = now
+                        })
+                        .ToList();
+
+                    await workQueue.EnqueueManyAsync(uow, cancelItems, innerCt).ConfigureAwait(false);
+                },
+                ct)
+            .ConfigureAwait(false);
+
+        _ = joinState;
+    }
+
+    private static JsonElement? ToJsonElement(object? value)
+    {
+        if (value is null)
+            return null;
+        if (value is JsonElement element)
+            return element.Clone();
+
+        var json = JsonSerializer.Serialize(value, CamelCaseJson);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+}

--- a/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
@@ -13,6 +13,7 @@ namespace Statevia.Core.Application.Services;
 /// <para>子作成・execution_branches・Start enqueue を同一 ReadCommitted で行い、一時失敗は Options に従い再試行する（D9）。</para>
 /// <para>上限超過時は作成済みの未終端子へ Cancel を enqueue し、親を Failed にする。</para>
 /// <para>親 Cancel カスケードと分岐 Wait の子配送解決（要件4）も担う。</para>
+/// <para>親 graph 読み取り時の論理 Fork/Join 合成（D6）も担う。</para>
 /// </remarks>
 /// <param name="executor">トランザクション実行。</param>
 /// <param name="executions">executions 永続化。</param>
@@ -296,6 +297,50 @@ public sealed class ForkChildExecutionCoordinator(
                 },
                 ct)
             .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ComposeReadModelGraphJsonAsync(
+        Guid executionId,
+        string baseGraphJson,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseGraphJson);
+
+        var childRows = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => branches.ListByParentExecutionIdAsync(uow, executionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+
+        if (childRows.Count == 0)
+            return baseGraphJson;
+
+        var composedBranches = new List<PhysicalForkGraphComposer.BranchGraph>(childRows.Count);
+        foreach (var child in childRows)
+        {
+            var childSnapshot = await executor.ExecuteReadOnlyAsync(
+                    (uow, innerCt) => executions.GetSnapshotByExecutionIdAsync(uow, child.ExecutionId, innerCt),
+                    ct)
+                .ConfigureAwait(false);
+            var childBase = childSnapshot?.GraphJson ?? """{"nodes":[],"edges":[]}""";
+            // ネスト Fork: 子自身も親役なら再帰合成してから親へ載せる。
+            var childComposed = await ComposeReadModelGraphJsonAsync(child.ExecutionId, childBase, ct)
+                .ConfigureAwait(false);
+            // Join 辺は状態名ではなく、この Fork 訪問に対応する Join 到達 nodeId に固定する。
+            var joinNodeId = PhysicalForkGraphComposer.ResolveJoinNodeId(
+                    baseGraphJson,
+                    child.ForkNodeId,
+                    child.JoinState)
+                ?? string.Empty;
+            composedBranches.Add(
+                new PhysicalForkGraphComposer.BranchGraph(
+                    child.ForkNodeId,
+                    joinNodeId,
+                    child.BranchState,
+                    childComposed));
+        }
+
+        return PhysicalForkGraphComposer.Compose(baseGraphJson, composedBranches);
     }
 
     /// <summary>

--- a/core/application/Statevia.Core.Application/Services/ForkExpansionHostHandler.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkExpansionHostHandler.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// Engine Fork 展開イベントを <see cref="IForkChildExecutionCoordinator"/> に接続する。
+/// </summary>
+/// <remarks>
+/// <para>成功時は親を checkpoint 保存のうえ Unload し、Join 待ち中はメモリに常駐させない（D2-B）。</para>
+/// </remarks>
+public sealed class ForkExpansionHostHandler(
+    ICoreTransactionExecutor executor,
+    IExecutionRepository executions,
+    IDefinitionRepository definitions,
+    IDefinitionCompilerService compiler,
+    IForkChildExecutionCoordinator coordinator,
+    IExecutionService executionService,
+    ILogger<ForkExpansionHostHandler> logger) : IForkExpansionHostHandler
+{
+    /// <inheritdoc />
+    public async Task HandleAsync(ForkExpansionEvent evt, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        if (!Guid.TryParse(evt.ExecutionId, out var parentExecutionId))
+        {
+            logger.ForkExpansionSkippedInvalidExecutionId(evt.ExecutionId);
+            return;
+        }
+
+        var parent = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => executions.GetByExecutionIdAsync(uow, parentExecutionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        if (parent is null)
+        {
+            logger.ForkExpansionSkippedParentNotFound(parentExecutionId);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(parent.SecuritySnapshotJson))
+            throw new InvalidOperationException(
+                $"Parent execution {parentExecutionId:D} has no security snapshot to inherit.");
+
+        var versionRow = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => definitions.GetVersionForExecutionByIdAsync(
+                    uow,
+                    parent.TenantId,
+                    parent.DefinitionVersionId,
+                    innerCt),
+                ct)
+            .ConfigureAwait(false);
+        if (versionRow is null)
+            throw new InvalidOperationException(
+                $"Definition version {parent.DefinitionVersionId:D} not found for parent {parentExecutionId:D}.");
+
+        var compiled = compiler.RestoreFromStoredVersion(versionRow.SourceYaml, versionRow.CompiledJson);
+        var branches = evt.Branches
+            .Select(b => new ForkBranchExpansion(b.BranchState, b.MappedInput))
+            .ToList();
+
+        var request = new ForkExpansionRequest(
+            ParentExecutionId: parentExecutionId,
+            TenantId: parent.TenantId,
+            DefinitionId: parent.DefinitionId,
+            DefinitionVersionId: parent.DefinitionVersionId,
+            DefinitionVersion: versionRow.Version,
+            DefinitionDisplayId: parent.DefinitionId.ToString("D"),
+            SecuritySnapshotJson: parent.SecuritySnapshotJson,
+            CompiledDefinition: compiled,
+            ForkNodeId: evt.SourceNodeId,
+            Branches: branches);
+
+        var result = await coordinator.ExpandForkAsync(request, ct).ConfigureAwait(false);
+        if (!result.Succeeded)
+            logger.ForkExpansionFailedParentMarkedFailed(parentExecutionId, evt.SourceNodeId);
+
+        // 成功時も Join 待ちで Engine に常駐させない（D2-B）。失敗時は Coordinator が親 Failed 済み。
+        await executionService
+            .PersistCheckpointAndUnloadByEngineIdAsync(evt.ExecutionId, evt.SourceNodeId, ct)
+            .ConfigureAwait(false);
+    }
+}

--- a/core/application/Statevia.Core.Application/Services/ForkExpansionLogMessages.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkExpansionLogMessages.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// Fork 物理子展開（Coordinator / HostHandler）用のログ（<see cref="LoggerMessageAttribute"/>）。
+/// </summary>
+internal static partial class ForkExpansionLogMessages
+{
+    [LoggerMessage(
+        EventId = 3101,
+        Level = LogLevel.Warning,
+        Message = "Fork expansion attempt failed. Attempt={attempt} MaxAttempts={maxAttempts} ParentExecutionId={parentExecutionId} ForkNodeId={forkNodeId}")]
+    public static partial void ForkExpansionAttemptFailed(
+        this ILogger logger,
+        Exception exception,
+        int attempt,
+        int maxAttempts,
+        Guid parentExecutionId,
+        string forkNodeId);
+
+    [LoggerMessage(
+        EventId = 3102,
+        Level = LogLevel.Error,
+        Message = "Fork expansion exhausted; failing parent and cancelling children. ParentExecutionId={parentExecutionId} ForkNodeId={forkNodeId}")]
+    public static partial void ForkExpansionExhausted(
+        this ILogger logger,
+        Exception exception,
+        Guid parentExecutionId,
+        string forkNodeId);
+
+    [LoggerMessage(
+        EventId = 3103,
+        Level = LogLevel.Warning,
+        Message = "Fork expansion skipped: invalid execution id. ExecutionId={executionId}")]
+    public static partial void ForkExpansionSkippedInvalidExecutionId(this ILogger logger, string executionId);
+
+    [LoggerMessage(
+        EventId = 3104,
+        Level = LogLevel.Warning,
+        Message = "Fork expansion skipped: parent execution not found. ParentExecutionId={parentExecutionId}")]
+    public static partial void ForkExpansionSkippedParentNotFound(this ILogger logger, Guid parentExecutionId);
+
+    [LoggerMessage(
+        EventId = 3105,
+        Level = LogLevel.Warning,
+        Message = "Fork expansion failed; parent marked Failed. ParentExecutionId={parentExecutionId} ForkNodeId={forkNodeId}")]
+    public static partial void ForkExpansionFailedParentMarkedFailed(
+        this ILogger logger,
+        Guid parentExecutionId,
+        string forkNodeId);
+}

--- a/core/application/Statevia.Core.Application/Services/ForkExpansionLogMessages.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkExpansionLogMessages.cs
@@ -49,4 +49,35 @@ internal static partial class ForkExpansionLogMessages
         this ILogger logger,
         Guid parentExecutionId,
         string forkNodeId);
+
+    [LoggerMessage(
+        EventId = 3106,
+        Level = LogLevel.Information,
+        Message = "Fork child terminal signaled to parent. ChildExecutionId={childExecutionId} ParentExecutionId={parentExecutionId} ForkNodeId={forkNodeId} Status={status}")]
+    public static partial void ForkChildTerminalSignaled(
+        this ILogger logger,
+        Guid childExecutionId,
+        Guid parentExecutionId,
+        string forkNodeId,
+        string status);
+
+    [LoggerMessage(
+        EventId = 3107,
+        Level = LogLevel.Information,
+        Message = "Fork join satisfied; completing physical join. ParentExecutionId={parentExecutionId} ForkNodeId={forkNodeId} JoinState={joinState}")]
+    public static partial void ForkJoinSatisfied(
+        this ILogger logger,
+        Guid parentExecutionId,
+        string forkNodeId,
+        string joinState);
+
+    [LoggerMessage(
+        EventId = 3108,
+        Level = LogLevel.Warning,
+        Message = "Fork join failed; propagating to parent. ParentExecutionId={parentExecutionId} ForkNodeId={forkNodeId} FailureStatus={failureStatus}")]
+    public static partial void ForkJoinFailedPropagated(
+        this ILogger logger,
+        Guid parentExecutionId,
+        string forkNodeId,
+        string failureStatus);
 }

--- a/core/application/Statevia.Core.Application/Services/PhysicalForkEventTimelineComposer.cs
+++ b/core/application/Statevia.Core.Application/Services/PhysicalForkEventTimelineComposer.cs
@@ -1,0 +1,129 @@
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Services;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 親と物理子の <c>event_store</c> 行を、論理 1 実行のタイムラインへ合成する（D6.1・GET 時）。
+/// </summary>
+/// <remarks>
+/// <para>永続は変更しない。応答 <c>seq</c> は合成通番。</para>
+/// <para>子孫の WorkflowStarted / WorkflowCancelled は落とす。</para>
+/// </remarks>
+internal static class PhysicalForkEventTimelineComposer
+{
+    private static readonly string TypeStarted = EventStoreEventType.WorkflowStarted.ToPersistedString();
+    private static readonly string TypeCancelled = EventStoreEventType.WorkflowCancelled.ToPersistedString();
+    private static readonly string TypePublished = EventStoreEventType.EventPublished.ToPersistedString();
+
+    /// <summary>合成入力の 1 行。</summary>
+    /// <param name="Row">永続イベント行。</param>
+    /// <param name="IsRoot">ルート（親）execution 由来なら true。</param>
+    internal readonly record struct SourceRow(EventStoreRow Row, bool IsRoot);
+
+    /// <summary>
+    /// ソース行を並べ替え・フィルタし、合成 seq でページングする。
+    /// </summary>
+    /// <param name="sourceRows">親＋子孫の永続行。</param>
+    /// <param name="rootDisplayId">タイムラインに載せる実行表示 ID。</param>
+    /// <param name="patchNodes">GraphUpdated 用の合成グラフ patch ノード。</param>
+    /// <param name="afterSeq">合成 seq の排他下限（0 で先頭から）。</param>
+    /// <param name="limit">返却上限。</param>
+    /// <returns>ページ分のイベントと hasMore。</returns>
+    public static (IReadOnlyList<TimelineEventDto> Events, bool HasMore) ComposePage(
+        IReadOnlyList<SourceRow> sourceRows,
+        string rootDisplayId,
+        IReadOnlyList<GraphPatchNodeDto> patchNodes,
+        long afterSeq,
+        int limit)
+    {
+        ArgumentNullException.ThrowIfNull(sourceRows);
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootDisplayId);
+        ArgumentNullException.ThrowIfNull(patchNodes);
+        ArgumentOutOfRangeException.ThrowIfNegative(afterSeq);
+        ArgumentOutOfRangeException.ThrowIfLessThan(limit, 1);
+
+        var composed = sourceRows
+            .Select(MapTimelineEvent)
+            .Where(e => e is not null)
+            .Select(e => e!)
+            .OrderBy(e => e.OccurredAt)
+            .ThenByDescending(e => e.IsRoot) // 同刻は親優先
+            .ThenBy(e => e.ExecutionId)
+            .ThenBy(e => e.PersistedSeq)
+            .Select((e, index) => new TimelineEventDto
+            {
+                Seq = index + 1L,
+                Type = e.Type,
+                ExecutionId = rootDisplayId,
+                To = e.To,
+                From = null,
+                Patch = e.Type == "GraphUpdated"
+                    ? new GraphUpdatedPatchDto { Nodes = patchNodes }
+                    : null,
+                At = e.OccurredAt.ToString("O")
+            })
+            .Where(e => e.Seq > afterSeq)
+            .Take(limit + 1)
+            .ToList();
+
+        var hasMore = composed.Count > limit;
+        if (hasMore)
+            composed.RemoveAt(composed.Count - 1);
+
+        return (composed, hasMore);
+    }
+
+    private static MappedEvent? MapTimelineEvent(SourceRow source)
+    {
+        var row = source.Row;
+        if (!source.IsRoot
+            && (row.Type == TypeStarted || row.Type == TypeCancelled))
+        {
+            return null;
+        }
+
+        if (row.Type == TypeStarted)
+        {
+            return new MappedEvent(
+                source.IsRoot,
+                row.ExecutionId,
+                row.Seq,
+                row.OccurredAt,
+                "ExecutionStatusChanged",
+                ExecutionProjectionStatuses.Running);
+        }
+
+        if (row.Type == TypeCancelled)
+        {
+            return new MappedEvent(
+                source.IsRoot,
+                row.ExecutionId,
+                row.Seq,
+                row.OccurredAt,
+                "ExecutionStatusChanged",
+                ExecutionProjectionStatuses.Cancelled);
+        }
+
+        if (row.Type == TypePublished)
+        {
+            return new MappedEvent(
+                source.IsRoot,
+                row.ExecutionId,
+                row.Seq,
+                row.OccurredAt,
+                "GraphUpdated",
+                null);
+        }
+
+        return null;
+    }
+
+    private sealed record MappedEvent(
+        bool IsRoot,
+        Guid ExecutionId,
+        long PersistedSeq,
+        DateTime OccurredAt,
+        string Type,
+        string? To);
+}

--- a/core/application/Statevia.Core.Application/Services/PhysicalForkGraphComposer.cs
+++ b/core/application/Statevia.Core.Application/Services/PhysicalForkGraphComposer.cs
@@ -1,0 +1,447 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Statevia.Core.Engine.ExecutionGraphs;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 親実行グラフと物理子グラフを、論理 Fork/Join に見えるよう合成する（D6・GET 時）。
+/// </summary>
+/// <remarks>
+/// <para>永続スナップショットは変更しない。読み取り専用の合成 JSON を返す。</para>
+/// <para>子ノードの <c>workerId</c> / <c>attempt</c> はそのまま引き継ぐ。</para>
+/// <para>
+/// Join 辺は状態名ではなく <c>joinNodeId</c>（親上の Join 到達インスタンス）に固定する。
+/// 循環で同名 Join が複数あるとき、Fork 訪問との対応は
+/// <see cref="ResolveJoinNodeId"/> が親グラフ上で解決する。
+/// </para>
+/// <para>
+/// 定義上の枝以外の見た目の合流を避けるため、親 Fork からの Fork 辺は
+/// <c>branchState</c> ノードへだけ張り、親 Join への Join 辺も枝先頭状態の終端に限る。
+/// ネスト内側 Join など枝先頭以外から親 Join への接続は <see cref="EdgeType.Next"/> とする。
+/// </para>
+/// </remarks>
+internal static class PhysicalForkGraphComposer
+{
+    private const string NodeIdProperty = "nodeId";
+    private const string StateNameProperty = "stateName";
+    private const string NodeTypeProperty = "nodeType";
+    private const string JoinNodeType = "Join";
+
+    private static readonly JsonSerializerOptions CompactJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>1 分岐分の子グラフ（再帰合成済み可）。</summary>
+    /// <param name="ForkNodeId">親上の Fork 到達ノード ID。</param>
+    /// <param name="JoinNodeId">親上の Join 到達ノード ID。未解決時は空（Join 辺を張らない）。</param>
+    /// <param name="BranchState">定義上の分岐先頭状態名（<c>execution_branches.branch_state</c>）。</param>
+    /// <param name="ChildGraphJson">子（または孫まで合成済み）の graph JSON。</param>
+    internal sealed record BranchGraph(
+        string ForkNodeId,
+        string JoinNodeId,
+        string BranchState,
+        string ChildGraphJson);
+
+    /// <summary>
+    /// 親グラフへ子グラフをマージし、Fork / Join 辺を補完する。
+    /// </summary>
+    /// <param name="parentGraphJson">親の永続 graph JSON。</param>
+    /// <param name="branches">親直下の分岐グラフ。</param>
+    /// <returns>合成後 JSON。分岐が空なら親をそのまま返す。</returns>
+    public static string Compose(string parentGraphJson, IReadOnlyList<BranchGraph> branches)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentGraphJson);
+        ArgumentNullException.ThrowIfNull(branches);
+        if (branches.Count == 0)
+            return parentGraphJson;
+
+        if (!TryParseGraph(parentGraphJson, out var parentNodes, out var parentEdges))
+            return parentGraphJson;
+
+        var nodeById = IndexNodesById(parentNodes);
+        var edges = parentEdges.ToList();
+        var edgeKeys = edges
+            .Select(EdgeKey)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var branch in branches)
+            MergeBranch(nodeById, edges, edgeKeys, branch);
+
+        var root = new JsonObject
+        {
+            ["nodes"] = new JsonArray(nodeById.Values.Select(n => n.DeepClone()).ToArray()),
+            ["edges"] = new JsonArray(edges.Select(e => (JsonNode?)e.DeepClone()).ToArray())
+        };
+        return root.ToJsonString(CompactJson);
+    }
+
+    /// <summary>
+    /// 親グラフ上で、指定 Fork 到達に対応する Join ノード ID を解決する。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 循環で同名 <paramref name="joinState"/> が複数あるとき、
+    /// Fork の <c>completedAt</c>（なければ <c>startedAt</c>）以降で最も早い Join を選ぶ。
+    /// 時刻が欠ける場合は、同名 Fork 訪問の出現順と Join 訪問の出現順をインデックス対応する。
+    /// </para>
+    /// </remarks>
+    /// <param name="parentGraphJson">親の永続 graph JSON。</param>
+    /// <param name="forkNodeId">親上の Fork 到達ノード ID。</param>
+    /// <param name="joinState">定義上の Join 状態名。</param>
+    /// <returns>対応する Join の <c>nodeId</c>。未解決なら <see langword="null"/>。</returns>
+    public static string? ResolveJoinNodeId(
+        string parentGraphJson,
+        string forkNodeId,
+        string joinState)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentGraphJson);
+        ArgumentException.ThrowIfNullOrWhiteSpace(forkNodeId);
+        if (string.IsNullOrWhiteSpace(joinState))
+            return null;
+
+        if (!TryParseGraph(parentGraphJson, out var parentNodes, out _))
+            return null;
+
+        var nodeById = IndexNodesById(parentNodes);
+        if (!nodeById.TryGetValue(forkNodeId, out var forkNode))
+            return null;
+
+        var joinCandidates = CollectJoinCandidates(nodeById.Values, joinState);
+        if (joinCandidates.Count == 0)
+            return null;
+
+        var afterFork = FindJoinAfterFork(joinCandidates, ReadNodeTime(forkNode));
+        if (afterFork is not null)
+            return afterFork;
+
+        return ResolveJoinByVisitIndex(nodeById, forkNode, forkNodeId, joinCandidates);
+    }
+
+    /// <summary>1 分岐分の子グラフを親へマージし、Fork / Join（または Next）辺を張る。</summary>
+    private static void MergeBranch(
+        Dictionary<string, JsonObject> nodeById,
+        List<JsonObject> edges,
+        HashSet<string> edgeKeys,
+        BranchGraph branch)
+    {
+        if (string.IsNullOrWhiteSpace(branch.ChildGraphJson))
+            return;
+        if (!TryParseGraph(branch.ChildGraphJson, out var childNodes, out var childEdges))
+            return;
+
+        MergeChildNodes(nodeById, childNodes);
+        MergeChildEdges(edges, edgeKeys, childEdges);
+
+        var childNodeIds = CollectNodeIds(childNodes);
+        var childTargets = CollectEdgeEndpointIds(childEdges, "to");
+        var childSources = CollectEdgeEndpointIds(childEdges, "from");
+        var attachmentRoots = ResolveBranchAttachmentRoots(
+            childNodes,
+            childNodeIds,
+            childTargets,
+            branch.BranchState);
+        var terminals = childNodeIds.Where(id => !childSources.Contains(id)).ToList();
+
+        AttachForkEdges(nodeById, edges, edgeKeys, branch.ForkNodeId, attachmentRoots);
+        AttachJoinOrNextEdges(nodeById, edges, edgeKeys, branch, terminals);
+    }
+
+    private static void MergeChildNodes(
+        Dictionary<string, JsonObject> nodeById,
+        IReadOnlyList<JsonObject> childNodes)
+    {
+        foreach (var childNode in childNodes)
+        {
+            var nodeId = ReadString(childNode, NodeIdProperty);
+            if (string.IsNullOrWhiteSpace(nodeId) || nodeById.ContainsKey(nodeId))
+                continue;
+            nodeById[nodeId] = childNode.DeepClone()!.AsObject();
+        }
+    }
+
+    private static void MergeChildEdges(
+        List<JsonObject> edges,
+        HashSet<string> edgeKeys,
+        IReadOnlyList<JsonObject> childEdges)
+    {
+        foreach (var childEdge in childEdges)
+        {
+            var key = EdgeKey(childEdge);
+            if (!edgeKeys.Add(key))
+                continue;
+            edges.Add(childEdge.DeepClone()!.AsObject());
+        }
+    }
+
+    private static void AttachForkEdges(
+        Dictionary<string, JsonObject> nodeById,
+        List<JsonObject> edges,
+        HashSet<string> edgeKeys,
+        string forkNodeId,
+        IReadOnlyList<string> attachmentRoots)
+    {
+        if (!nodeById.ContainsKey(forkNodeId))
+            return;
+
+        foreach (var rootId in attachmentRoots)
+            TryAddEdge(edges, edgeKeys, forkNodeId, rootId, (int)EdgeType.Fork);
+    }
+
+    private static void AttachJoinOrNextEdges(
+        Dictionary<string, JsonObject> nodeById,
+        List<JsonObject> edges,
+        HashSet<string> edgeKeys,
+        BranchGraph branch,
+        IReadOnlyList<string> terminals)
+    {
+        if (string.IsNullOrWhiteSpace(branch.JoinNodeId)
+            || !nodeById.ContainsKey(branch.JoinNodeId))
+            return;
+
+        foreach (var terminalId in terminals)
+        {
+            if (!nodeById.TryGetValue(terminalId, out var terminalNode))
+                continue;
+
+            var terminalState = ReadString(terminalNode, StateNameProperty);
+            // 枝先頭状態の終端だけ Join 辺。ネスト内側 Join などは Next（定義の next に相当）。
+            var edgeType = IsBranchHeadState(terminalState, branch.BranchState)
+                ? EdgeType.Join
+                : EdgeType.Next;
+            TryAddEdge(
+                edges,
+                edgeKeys,
+                terminalId,
+                branch.JoinNodeId,
+                (int)edgeType);
+        }
+    }
+
+    /// <summary>
+    /// 親 Fork から繋ぐ入口。定義の <paramref name="branchState"/> ノードがあればそれだけを使う。
+    /// </summary>
+    private static List<string> ResolveBranchAttachmentRoots(
+        IReadOnlyList<JsonObject> childNodes,
+        HashSet<string> childNodeIds,
+        HashSet<string> childTargets,
+        string branchState)
+    {
+        if (!string.IsNullOrWhiteSpace(branchState))
+        {
+            var branchHeadIds = childNodes
+                .Where(n =>
+                {
+                    var id = ReadString(n, NodeIdProperty);
+                    var state = ReadString(n, StateNameProperty);
+                    return !string.IsNullOrWhiteSpace(id)
+                        && childNodeIds.Contains(id)
+                        && IsBranchHeadState(state, branchState);
+                })
+                .Select(n => ReadString(n, NodeIdProperty)!)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            if (branchHeadIds.Count > 0)
+                return branchHeadIds;
+        }
+
+        return childNodeIds.Where(id => !childTargets.Contains(id)).ToList();
+    }
+
+    private static Dictionary<string, JsonObject> IndexNodesById(IEnumerable<JsonObject> nodes) =>
+        nodes
+            .Where(n => ReadString(n, NodeIdProperty) is { Length: > 0 })
+            .ToDictionary(n => ReadString(n, NodeIdProperty)!, StringComparer.Ordinal);
+
+    private static HashSet<string> CollectNodeIds(IEnumerable<JsonObject> nodes) =>
+        nodes
+            .Select(n => ReadString(n, NodeIdProperty))
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Cast<string>()
+            .ToHashSet(StringComparer.Ordinal);
+
+    private static HashSet<string> CollectEdgeEndpointIds(
+        IEnumerable<JsonObject> edges,
+        string propertyName) =>
+        edges
+            .Select(e => ReadString(e, propertyName))
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Cast<string>()
+            .ToHashSet(StringComparer.Ordinal);
+
+    private static List<JoinCandidate> CollectJoinCandidates(
+        IEnumerable<JsonObject> nodes,
+        string joinState) =>
+        nodes
+            .Select(n => new JoinCandidate(
+                ReadString(n, NodeIdProperty),
+                ReadNodeTime(n),
+                string.Equals(
+                    ReadString(n, NodeTypeProperty),
+                    JoinNodeType,
+                    StringComparison.OrdinalIgnoreCase),
+                ReadString(n, StateNameProperty)))
+            .Where(x =>
+                !string.IsNullOrWhiteSpace(x.Id)
+                && string.Equals(x.StateName, joinState, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(x => x.IsJoin)
+            .ThenBy(x => x.Time ?? DateTime.MaxValue)
+            .ThenBy(x => x.Id, StringComparer.Ordinal)
+            .ToList();
+
+    private static string? FindJoinAfterFork(
+        IReadOnlyList<JoinCandidate> joinCandidates,
+        DateTime? forkTime)
+    {
+        if (forkTime is null)
+            return null;
+
+        var afterFork = joinCandidates
+            .Where(x => x.Time is null || x.Time >= forkTime)
+            .OrderBy(x => x.Time ?? DateTime.MaxValue)
+            .ThenBy(x => x.Id, StringComparer.Ordinal)
+            .ToList();
+        return afterFork.Count > 0 ? afterFork[0].Id : null;
+    }
+
+    private static string? ResolveJoinByVisitIndex(
+        Dictionary<string, JsonObject> nodeById,
+        JsonObject forkNode,
+        string forkNodeId,
+        IReadOnlyList<JoinCandidate> joinCandidates)
+    {
+        var forkStateName = ReadString(forkNode, StateNameProperty);
+        if (string.IsNullOrWhiteSpace(forkStateName))
+            return joinCandidates[0].Id;
+
+        var forkVisits = nodeById.Values
+            .Select(n => new
+            {
+                Id = ReadString(n, NodeIdProperty),
+                Time = ReadNodeTime(n),
+                StateName = ReadString(n, StateNameProperty)
+            })
+            .Where(x =>
+                !string.IsNullOrWhiteSpace(x.Id)
+                && string.Equals(x.StateName, forkStateName, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(x => x.Time ?? DateTime.MaxValue)
+            .ThenBy(x => x.Id, StringComparer.Ordinal)
+            .Select(x => x.Id!)
+            .ToList();
+
+        var joinVisits = joinCandidates
+            .OrderBy(x => x.Time ?? DateTime.MaxValue)
+            .ThenBy(x => x.Id, StringComparer.Ordinal)
+            .Select(x => x.Id!)
+            .ToList();
+
+        var forkIndex = forkVisits.FindIndex(id => string.Equals(id, forkNodeId, StringComparison.Ordinal));
+        if (forkIndex < 0 || forkIndex >= joinVisits.Count)
+            return null;
+
+        return joinVisits[forkIndex];
+    }
+
+    private static bool IsBranchHeadState(string? stateName, string branchState) =>
+        !string.IsNullOrWhiteSpace(stateName)
+        && !string.IsNullOrWhiteSpace(branchState)
+        && string.Equals(stateName, branchState, StringComparison.OrdinalIgnoreCase);
+
+    private static string? ReadString(JsonObject node, string propertyName) =>
+        node[propertyName]?.GetValue<string>();
+
+    private static DateTime? ReadNodeTime(JsonObject node)
+    {
+        if (TryReadTime(node, "completedAt", out var completedAt))
+            return completedAt;
+        if (TryReadTime(node, "startedAt", out var startedAt))
+            return startedAt;
+        return null;
+    }
+
+    private static bool TryReadTime(JsonObject node, string propertyName, out DateTime value)
+    {
+        value = default;
+        var raw = ReadString(node, propertyName);
+        if (string.IsNullOrWhiteSpace(raw))
+            return false;
+
+        return DateTime.TryParse(
+            raw,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out value);
+    }
+
+    private static void TryAddEdge(
+        List<JsonObject> edges,
+        HashSet<string> edgeKeys,
+        string from,
+        string to,
+        int type)
+    {
+        var edge = new JsonObject
+        {
+            ["from"] = from,
+            ["to"] = to,
+            ["type"] = type
+        };
+        var key = EdgeKey(edge);
+        if (!edgeKeys.Add(key))
+            return;
+        edges.Add(edge);
+    }
+
+    private static string EdgeKey(JsonObject edge)
+    {
+        var from = ReadString(edge, "from") ?? string.Empty;
+        var to = ReadString(edge, "to") ?? string.Empty;
+        var type = edge["type"]?.ToJsonString() ?? string.Empty;
+        return $"{from}\u001f{to}\u001f{type}";
+    }
+
+    private static bool TryParseGraph(
+        string graphJson,
+        out List<JsonObject> nodes,
+        out List<JsonObject> edges)
+    {
+        nodes = [];
+        edges = [];
+        try
+        {
+            var root = JsonNode.Parse(graphJson) as JsonObject;
+            if (root is null)
+                return false;
+
+            if (root["nodes"] is JsonArray nodeArray)
+            {
+                nodes = nodeArray
+                    .OfType<JsonObject>()
+                    .Select(n => n.DeepClone()!.AsObject())
+                    .ToList();
+            }
+
+            if (root["edges"] is JsonArray edgeArray)
+            {
+                edges = edgeArray
+                    .OfType<JsonObject>()
+                    .Select(e => e.DeepClone()!.AsObject())
+                    .ToList();
+            }
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private sealed record JoinCandidate(
+        string? Id,
+        DateTime? Time,
+        bool IsJoin,
+        string? StateName);
+}

--- a/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
@@ -175,6 +175,48 @@ public sealed class ForkExpansionHandlerTests
         Assert.True(snapshot.IsCompleted);
     }
 
+    /// <summary>
+    /// ネスト: 内側 Join 完了後の次が親側 Join（ローカル未充足）のとき、物理子は終端する。
+    /// </summary>
+    [Fact]
+    public async Task CompletePhysicalJoin_WhenNextIsUnsatisfiedOuterJoin_MarksChildCompleted()
+    {
+        // Arrange
+        var def = CreateNestedForkMidChildDefinition();
+        var engine = ExecutionEngineTestHarness.Create(maxParallelism: 2);
+        var forked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        engine.SetForkExpansionHandler(_ =>
+        {
+            forked.TrySetResult(true);
+            return Task.CompletedTask;
+        });
+
+        var childId = engine.Start(def, initialState: "InnerFork");
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await forked.Task.WaitAsync(timeout.Token).ConfigureAwait(false);
+        await Task.Delay(50).ConfigureAwait(false);
+
+        // Act — 内側 Join のみ充足。外側 Join の依存（OuterFast / InnerFork）は子に無い。
+        engine.CompletePhysicalJoin(
+            childId,
+            "InnerJoin",
+            new Dictionary<string, object?>
+            {
+                ["InnerA"] = "a",
+                ["InnerB"] = "b"
+            });
+        await Task.Delay(300).ConfigureAwait(false);
+        var snapshot = engine.GetSnapshot(childId);
+
+        // Assert
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot.IsCompleted);
+        Assert.False(snapshot.IsFailed);
+        var graph = engine.ExportExecutionGraph(childId);
+        Assert.Contains("InnerJoin", graph, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"stateName\":\"OuterJoin\"", graph, StringComparison.Ordinal);
+    }
+
     /// <summary>initialState 指定時はその状態から開始する。</summary>
     [Fact]
     public async Task Start_WithInitialStateOverride_StartsAtBranch()
@@ -243,6 +285,63 @@ public sealed class ForkExpansionHandlerTests
             ["A"] = DefaultStateExecutor.Create(new ImmediateState()),
             ["B"] = DefaultStateExecutor.Create(new ImmediateState()),
             ["After"] = DefaultStateExecutor.Create(new ImmediateState())
+        })
+    };
+
+    private static CompiledWorkflowDefinition CreateNestedForkMidChildDefinition() => new()
+    {
+        Name = "NestedForkMidChild",
+        InitialState = "OuterFork",
+        Transitions = new Dictionary<string, IReadOnlyDictionary<string, TransitionTarget>>
+        {
+            ["OuterFork"] = new Dictionary<string, TransitionTarget>
+            {
+                ["Completed"] = new TransitionTarget { Fork = ["OuterFast", "InnerFork"] }
+            },
+            ["OuterFast"] = new Dictionary<string, TransitionTarget>
+            {
+                ["Completed"] = new TransitionTarget { Next = "OuterJoin" }
+            },
+            ["InnerFork"] = new Dictionary<string, TransitionTarget>
+            {
+                ["Completed"] = new TransitionTarget { Fork = ["InnerA", "InnerB"] }
+            },
+            ["InnerA"] = new Dictionary<string, TransitionTarget>
+            {
+                ["Completed"] = new TransitionTarget { Next = "InnerJoin" }
+            },
+            ["InnerB"] = new Dictionary<string, TransitionTarget>
+            {
+                ["Completed"] = new TransitionTarget { Next = "InnerJoin" }
+            },
+            ["InnerJoin"] = new Dictionary<string, TransitionTarget>
+            {
+                ["Joined"] = new TransitionTarget { Next = "OuterJoin" }
+            },
+            ["OuterJoin"] = new Dictionary<string, TransitionTarget>
+            {
+                ["Joined"] = new TransitionTarget { End = true }
+            }
+        },
+        ForkTable = new Dictionary<string, IReadOnlyList<string>>
+        {
+            ["OuterFork"] = ["OuterFast", "InnerFork"],
+            ["InnerFork"] = ["InnerA", "InnerB"]
+        },
+        JoinTable = new Dictionary<string, IReadOnlyList<string>>
+        {
+            ["InnerJoin"] = ["InnerA", "InnerB"],
+            ["OuterJoin"] = ["OuterFast", "InnerFork"]
+        },
+        WaitEventRouteTable = new Dictionary<string, IReadOnlyDictionary<string, WaitEventRouteDefinition>>(
+            StringComparer.OrdinalIgnoreCase),
+        StateExecutorFactory = new DictionaryStateExecutorFactory(new Dictionary<string, IStateExecutor>
+        {
+            ["OuterFork"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["OuterFast"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["InnerFork"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["InnerA"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["InnerB"] = DefaultStateExecutor.Create(new ImmediateState())
         })
     };
 

--- a/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
@@ -66,6 +66,62 @@ public sealed class ForkExpansionHandlerTests
         Assert.True(snapshot.IsCompleted);
     }
 
+    /// <summary>CompletePhysicalJoin の Context マージ後、親から $.states / $.vars を読める。</summary>
+    [Fact]
+    public async Task CompletePhysicalJoin_MergesChildContext_LastWins()
+    {
+        // Arrange
+        var def = CreateForkDefinitionWithAfterJoin();
+        var engine = ExecutionEngineTestHarness.Create(maxParallelism: 2);
+        var forked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        engine.SetForkExpansionHandler(_ =>
+        {
+            forked.TrySetResult(true);
+            return Task.CompletedTask;
+        });
+
+        var parentId = engine.Start(def);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await forked.Task.WaitAsync(timeout.Token).ConfigureAwait(false);
+        await Task.Delay(50).ConfigureAwait(false);
+
+        // Act
+        engine.CompletePhysicalJoin(
+            parentId,
+            "Join1",
+            new Dictionary<string, object?>
+            {
+                ["A"] = "a-out",
+                ["B"] = "b-out"
+            },
+            [
+                new PhysicalJoinContextFragment(
+                    new Dictionary<string, object?>
+                    {
+                        ["A"] = new Dictionary<string, object?> { ["output"] = "first-a" }
+                    },
+                    new Dictionary<string, object?> { ["shared"] = "first" }),
+                new PhysicalJoinContextFragment(
+                    new Dictionary<string, object?>
+                    {
+                        ["A"] = new Dictionary<string, object?> { ["output"] = "second-a" },
+                        ["B"] = new Dictionary<string, object?> { ["output"] = "b-val" }
+                    },
+                    new Dictionary<string, object?> { ["shared"] = "second" })
+            ]);
+        await Task.Delay(400).ConfigureAwait(false);
+        var checkpoint = engine.ExportCheckpoint(parentId);
+
+        // Assert
+        Assert.NotNull(checkpoint);
+        Assert.True(checkpoint.IsCompleted);
+        Assert.NotNull(checkpoint.Context.States);
+        Assert.True(checkpoint.Context.States.ContainsKey("A"));
+        Assert.Equal("second-a", checkpoint.Context.States["A"]!.Value.GetProperty("output").GetString());
+        Assert.Equal("b-val", checkpoint.Context.States["B"]!.Value.GetProperty("output").GetString());
+        Assert.Equal("second", checkpoint.Context.Vars!.Value.GetProperty("shared").GetString());
+    }
+
     /// <summary>ハンドラ登録時は論理 Fork せず、写像済み分岐を通知する。</summary>
     [Fact]
     public async Task SetForkExpansionHandler_DoesNotScheduleBranches_AndNotifiesPlans()
@@ -163,6 +219,30 @@ public sealed class ForkExpansionHandlerTests
             ["Start"] = DefaultStateExecutor.Create(new ImmediateState()),
             ["A"] = DefaultStateExecutor.Create(new ImmediateState()),
             ["B"] = DefaultStateExecutor.Create(new ImmediateState())
+        })
+    };
+
+    private static CompiledWorkflowDefinition CreateForkDefinitionWithAfterJoin() => new()
+    {
+        Name = "ForkExpansionHandlerWithAfterJoin",
+        InitialState = "Start",
+        Transitions = new Dictionary<string, IReadOnlyDictionary<string, TransitionTarget>>
+        {
+            ["Start"] = new Dictionary<string, TransitionTarget> { ["Completed"] = new TransitionTarget { Fork = ["A", "B"] } },
+            ["A"] = new Dictionary<string, TransitionTarget> { ["Completed"] = new TransitionTarget { Next = "Join1" } },
+            ["B"] = new Dictionary<string, TransitionTarget> { ["Completed"] = new TransitionTarget { Next = "Join1" } },
+            ["Join1"] = new Dictionary<string, TransitionTarget> { ["Joined"] = new TransitionTarget { Next = "After" } },
+            ["After"] = new Dictionary<string, TransitionTarget> { ["Completed"] = new TransitionTarget { End = true } }
+        },
+        ForkTable = new Dictionary<string, IReadOnlyList<string>> { ["Start"] = ["A", "B"] },
+        JoinTable = new Dictionary<string, IReadOnlyList<string>> { ["Join1"] = ["A", "B"] },
+        WaitEventRouteTable = new Dictionary<string, IReadOnlyDictionary<string, WaitEventRouteDefinition>>(StringComparer.OrdinalIgnoreCase),
+        StateExecutorFactory = new DictionaryStateExecutorFactory(new Dictionary<string, IStateExecutor>
+        {
+            ["Start"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["A"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["B"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["After"] = DefaultStateExecutor.Create(new ImmediateState())
         })
     };
 

--- a/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
@@ -1,0 +1,117 @@
+using Statevia.Core.Engine.Abstractions;
+using Statevia.Core.Engine.Definition;
+using Statevia.Core.Engine.Engine;
+using Statevia.Core.Engine.Execution;
+using Xunit;
+
+namespace Statevia.Core.Engine.Tests.Engine;
+
+/// <summary>Hosted 向け Fork 展開ハンドラ差し替え。</summary>
+public sealed class ForkExpansionHandlerTests
+{
+    /// <summary>ハンドラ登録時は論理 Fork せず、写像済み分岐を通知する。</summary>
+    [Fact]
+    public async Task SetForkExpansionHandler_DoesNotScheduleBranches_AndNotifiesPlans()
+    {
+        // Arrange
+        var def = CreateForkDefinition();
+        var engine = ExecutionEngineTestHarness.Create(maxParallelism: 2);
+        ForkExpansionEvent? captured = null;
+        var notified = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        engine.SetForkExpansionHandler(evt =>
+        {
+            captured = evt;
+            notified.TrySetResult(true);
+            return Task.CompletedTask;
+        });
+
+        // Act
+        var executionId = engine.Start(def);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await notified.Task.WaitAsync(timeout.Token).ConfigureAwait(false);
+        await Task.Delay(100).ConfigureAwait(false);
+        var snapshot = engine.GetSnapshot(executionId);
+
+        // Assert
+        Assert.NotNull(captured);
+        Assert.Equal(executionId, captured.ExecutionId);
+        Assert.Equal("Start", captured.ForkState);
+        Assert.Equal(2, captured.Branches.Count);
+        Assert.Contains(captured.Branches, b => b.BranchState == "A");
+        Assert.Contains(captured.Branches, b => b.BranchState == "B");
+        Assert.NotNull(snapshot);
+        Assert.False(snapshot.IsCompleted);
+        Assert.False(snapshot.IsFailed);
+    }
+
+    /// <summary>ハンドラ未登録時は従来どおり Fork/Join で完了する。</summary>
+    [Fact]
+    public async Task WithoutForkExpansionHandler_LogicalForkStillCompletes()
+    {
+        // Arrange
+        var def = CreateForkDefinition();
+        var engine = ExecutionEngineTestHarness.Create(maxParallelism: 2);
+
+        // Act
+        var executionId = engine.Start(def);
+        await Task.Delay(500).ConfigureAwait(false);
+        var snapshot = engine.GetSnapshot(executionId);
+
+        // Assert
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot.IsCompleted);
+    }
+
+    /// <summary>initialState 指定時はその状態から開始する。</summary>
+    [Fact]
+    public async Task Start_WithInitialStateOverride_StartsAtBranch()
+    {
+        // Arrange
+        var def = CreateForkDefinition();
+        var engine = ExecutionEngineTestHarness.Create(maxParallelism: 1);
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        engine.SetNodeCompletedHandler(_ =>
+        {
+            completed.TrySetResult(true);
+            return Task.CompletedTask;
+        });
+
+        // Act
+        var executionId = engine.Start(def, initialState: "A");
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await completed.Task.WaitAsync(timeout.Token).ConfigureAwait(false);
+        var graph = engine.ExportExecutionGraph(executionId);
+
+        // Assert
+        Assert.Contains("A", graph, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"Start\"", graph, StringComparison.Ordinal);
+    }
+
+    private static CompiledWorkflowDefinition CreateForkDefinition() => new()
+    {
+        Name = "ForkExpansionHandlerSample",
+        InitialState = "Start",
+        Transitions = new Dictionary<string, IReadOnlyDictionary<string, TransitionTarget>>
+        {
+            ["Start"] = new Dictionary<string, TransitionTarget> { ["Completed"] = new TransitionTarget { Fork = ["A", "B"] } },
+            ["A"] = new Dictionary<string, TransitionTarget> { ["Completed"] = new TransitionTarget { Next = "Join1" } },
+            ["B"] = new Dictionary<string, TransitionTarget> { ["Completed"] = new TransitionTarget { Next = "Join1" } },
+            ["Join1"] = new Dictionary<string, TransitionTarget> { ["Joined"] = new TransitionTarget { End = true } }
+        },
+        ForkTable = new Dictionary<string, IReadOnlyList<string>> { ["Start"] = ["A", "B"] },
+        JoinTable = new Dictionary<string, IReadOnlyList<string>> { ["Join1"] = ["A", "B"] },
+        WaitEventRouteTable = new Dictionary<string, IReadOnlyDictionary<string, WaitEventRouteDefinition>>(StringComparer.OrdinalIgnoreCase),
+        StateExecutorFactory = new DictionaryStateExecutorFactory(new Dictionary<string, IStateExecutor>
+        {
+            ["Start"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["A"] = DefaultStateExecutor.Create(new ImmediateState()),
+            ["B"] = DefaultStateExecutor.Create(new ImmediateState())
+        })
+    };
+
+    private sealed class ImmediateState : IState<Unit, Unit>
+    {
+        public Task<Unit> ExecuteAsync(StateContext ctx, Unit input, CancellationToken ct) =>
+            Task.FromResult(Unit.Value);
+    }
+}

--- a/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
@@ -9,6 +9,63 @@ namespace Statevia.Core.Engine.Tests.Engine;
 /// <summary>Hosted 向け Fork 展開ハンドラ差し替え。</summary>
 public sealed class ForkExpansionHandlerTests
 {
+    /// <summary>Hosted ハンドラ登録時、分岐子が Join へ遷移すると子は終端する。</summary>
+    [Fact]
+    public async Task SetForkExpansionHandler_ChildTransitionToJoin_MarksCompleted()
+    {
+        // Arrange
+        var def = CreateForkDefinition();
+        var engine = ExecutionEngineTestHarness.Create(maxParallelism: 1);
+        engine.SetForkExpansionHandler(_ => Task.CompletedTask);
+
+        // Act
+        var executionId = engine.Start(def, initialState: "A");
+        await Task.Delay(300).ConfigureAwait(false);
+        var snapshot = engine.GetSnapshot(executionId);
+
+        // Assert
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot.IsCompleted);
+        Assert.False(snapshot.IsFailed);
+    }
+
+    /// <summary>CompletePhysicalJoin は候補 input で Join を充足し親を進める。</summary>
+    [Fact]
+    public async Task CompletePhysicalJoin_RunsJoinAndCompletesWhenEnd()
+    {
+        // Arrange
+        var def = CreateForkDefinition();
+        var engine = ExecutionEngineTestHarness.Create(maxParallelism: 2);
+        var unloaded = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        engine.SetForkExpansionHandler(async evt =>
+        {
+            // Hosted: 親は Fork 後に分岐を走らせない（Unload 相当の待機）。
+            await Task.Yield();
+            unloaded.TrySetResult(true);
+        });
+
+        var parentId = engine.Start(def);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await unloaded.Task.WaitAsync(timeout.Token).ConfigureAwait(false);
+        await Task.Delay(50).ConfigureAwait(false);
+
+        // Act
+        engine.CompletePhysicalJoin(
+            parentId,
+            "Join1",
+            new Dictionary<string, object?>
+            {
+                ["A"] = "a-out",
+                ["B"] = "b-out"
+            });
+        await Task.Delay(300).ConfigureAwait(false);
+        var snapshot = engine.GetSnapshot(parentId);
+
+        // Assert
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot.IsCompleted);
+    }
+
     /// <summary>ハンドラ登録時は論理 Fork せず、写像済み分岐を通知する。</summary>
     [Fact]
     public async Task SetForkExpansionHandler_DoesNotScheduleBranches_AndNotifiesPlans()

--- a/core/engine/Statevia.Core.Engine.Tests/Engine/WorkflowExecutionContextTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Engine/WorkflowExecutionContextTests.cs
@@ -126,4 +126,32 @@ public class WorkflowExecutionContextTests
         Assert.Equal(TimeSpan.Zero, utcNow.Offset);
         Assert.Equal(DateTimeOffset.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), today);
     }
+
+    /// <summary>MergeStateEntries / MergeVars は後から適用した断片が同一キーで勝つ。</summary>
+    [Fact]
+    public void MergeStateEntriesAndVars_LaterFragmentWinsOnConflict()
+    {
+        // Arrange
+        var context = WorkflowExecutionContext.Create(null);
+        context.MergeStateEntries(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = new Dictionary<string, object?> { ["output"] = 1 }
+        });
+        context.MergeVars(new Dictionary<string, object?> { ["shared"] = "first", ["onlyFirst"] = true });
+
+        // Act
+        context.MergeStateEntries(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = new Dictionary<string, object?> { ["output"] = 99 },
+            ["B"] = new Dictionary<string, object?> { ["output"] = 2 }
+        });
+        context.MergeVars(new Dictionary<string, object?> { ["shared"] = "second" });
+        var root = context.ToPathRoot();
+
+        // Assert
+        Assert.Equal(99, SimpleJsonPathResolver.Resolve(root, "$.states.A.output").Value);
+        Assert.Equal(2, SimpleJsonPathResolver.Resolve(root, "$.states.B.output").Value);
+        Assert.Equal("second", SimpleJsonPathResolver.Resolve(root, "$.vars.shared").Value);
+        Assert.Equal(true, SimpleJsonPathResolver.Resolve(root, "$.vars.onlyFirst").Value);
+    }
 }

--- a/core/engine/Statevia.Core.Engine/Abstractions/ForkExpansionEvent.cs
+++ b/core/engine/Statevia.Core.Engine/Abstractions/ForkExpansionEvent.cs
@@ -1,0 +1,23 @@
+namespace Statevia.Core.Engine.Abstractions;
+
+/// <summary>Fork 物理展開ハンドラへ渡す 1 分岐分の計画。</summary>
+/// <param name="BranchState">分岐先頭状態名。</param>
+/// <param name="MappedInput">親 Context で評価済みの入力。</param>
+public sealed record ForkBranchExpansionPlan(string BranchState, object? MappedInput);
+
+/// <summary>
+/// Hosted Runtime が論理 Fork の代わりに子 execution を起動するときの通知。
+/// </summary>
+/// <remarks>
+/// <para>ハンドラ未登録時は Engine が従来どおり同一インスタンス上で分岐を Schedule する。</para>
+/// <para>ハンドラ登録時は Engine は分岐を Schedule せず、本イベントのみ発火する。</para>
+/// </remarks>
+/// <param name="ExecutionId">親 execution ID（Engine 上の文字列 ID）。</param>
+/// <param name="ForkState">Fork 遷移元の状態名（ForkTable キー）。</param>
+/// <param name="SourceNodeId">Fork 遷移を起こしたグラフノード ID。</param>
+/// <param name="Branches">分岐先頭と写像済み input。</param>
+public sealed record ForkExpansionEvent(
+    string ExecutionId,
+    string ForkState,
+    string SourceNodeId,
+    IReadOnlyList<ForkBranchExpansionPlan> Branches);

--- a/core/engine/Statevia.Core.Engine/Abstractions/IExecutionEngine.cs
+++ b/core/engine/Statevia.Core.Engine/Abstractions/IExecutionEngine.cs
@@ -87,14 +87,19 @@ public interface IExecutionEngine
     /// <param name="executionId">親実行インスタンス ID（ロード済みであること）。</param>
     /// <param name="joinStateName">充足させる Join 状態名。</param>
     /// <param name="branchOutputs">分岐先頭状態名 → 子終端 output。</param>
+    /// <param name="contextMerges">
+    /// 親 Context へ投影する子 Context 断片（適用順。省略可）。
+    /// </param>
     /// <remarks>
     /// <para>既に同一 Join を開始済みなら no-op。</para>
     /// <para>Host が <c>execution_branches</c> で充足を確認したあとに呼び出す。</para>
+    /// <para><paramref name="contextMerges"/> は Join 実行前に適用し、後続状態の <c>$.states</c> / <c>$.vars</c> 解決に使う。</para>
     /// </remarks>
     void CompletePhysicalJoin(
         string executionId,
         string joinStateName,
-        IReadOnlyDictionary<string, object?> branchOutputs);
+        IReadOnlyDictionary<string, object?> branchOutputs,
+        IReadOnlyList<PhysicalJoinContextFragment>? contextMerges = null);
 
     /// <summary>再開可能なランタイム状態をエクスポートする。</summary>
     /// <param name="executionId">実行インスタンス ID。</param>

--- a/core/engine/Statevia.Core.Engine/Abstractions/IExecutionEngine.cs
+++ b/core/engine/Statevia.Core.Engine/Abstractions/IExecutionEngine.cs
@@ -74,8 +74,27 @@ public interface IExecutionEngine
     /// <remarks>
     /// <para>登録時は論理 Fork（同一インスタンス上の分岐 Schedule）を行わず、ハンドラのみ呼び出す。</para>
     /// <para>未登録時は従来どおり論理 Fork する（スタンドアロン Engine）。</para>
+    /// <para>
+    /// 登録時、分岐子が Join 状態へ遷移しようとした場合は親が集約するため、
+    /// 子インスタンスは当該 output で <c>MarkCompleted</c> する。
+    /// </para>
     /// </remarks>
     void SetForkExpansionHandler(Func<ForkExpansionEvent, Task>? handler);
+
+    /// <summary>
+    /// Hosted 物理子の完了事実を親 JoinTracker へ反映し、充足していれば Join 状態を実行する。
+    /// </summary>
+    /// <param name="executionId">親実行インスタンス ID（ロード済みであること）。</param>
+    /// <param name="joinStateName">充足させる Join 状態名。</param>
+    /// <param name="branchOutputs">分岐先頭状態名 → 子終端 output。</param>
+    /// <remarks>
+    /// <para>既に同一 Join を開始済みなら no-op。</para>
+    /// <para>Host が <c>execution_branches</c> で充足を確認したあとに呼び出す。</para>
+    /// </remarks>
+    void CompletePhysicalJoin(
+        string executionId,
+        string joinStateName,
+        IReadOnlyDictionary<string, object?> branchOutputs);
 
     /// <summary>再開可能なランタイム状態をエクスポートする。</summary>
     /// <param name="executionId">実行インスタンス ID。</param>

--- a/core/engine/Statevia.Core.Engine/Abstractions/IExecutionEngine.cs
+++ b/core/engine/Statevia.Core.Engine/Abstractions/IExecutionEngine.cs
@@ -10,7 +10,12 @@ public interface IExecutionEngine
     /// <param name="definition">コンパイル済みワークフロー定義。</param>
     /// <param name="executionId">使用する実行インスタンス ID。省略時はエンジンが生成する。</param>
     /// <param name="input">初期状態の <see cref="IStateExecutor.ExecuteAsync"/> に渡す入力（省略時は <c>null</c>）。</param>
-    string Start(CompiledWorkflowDefinition definition, string? executionId = null, object? input = null);
+    /// <param name="initialState">開始状態名。省略時は <see cref="CompiledWorkflowDefinition.InitialState"/>。</param>
+    string Start(
+        CompiledWorkflowDefinition definition,
+        string? executionId = null,
+        object? input = null,
+        string? initialState = null);
 
     /// <summary>
     /// 待機中 Wait ノードを指定イベントで再開する（ランタイム正本）。
@@ -62,6 +67,15 @@ public interface IExecutionEngine
     /// </summary>
     /// <remarks>単体 DLL 利用時は未登録のままでよい（メモリ常駐）。</remarks>
     void SetSuspendHandler(Func<string, string, Task>? handler);
+
+    /// <summary>
+    /// Fork 到達時の物理子展開ハンドラを登録または解除します。
+    /// </summary>
+    /// <remarks>
+    /// <para>登録時は論理 Fork（同一インスタンス上の分岐 Schedule）を行わず、ハンドラのみ呼び出す。</para>
+    /// <para>未登録時は従来どおり論理 Fork する（スタンドアロン Engine）。</para>
+    /// </remarks>
+    void SetForkExpansionHandler(Func<ForkExpansionEvent, Task>? handler);
 
     /// <summary>再開可能なランタイム状態をエクスポートする。</summary>
     /// <param name="executionId">実行インスタンス ID。</param>

--- a/core/engine/Statevia.Core.Engine/Abstractions/PhysicalJoinContextFragment.cs
+++ b/core/engine/Statevia.Core.Engine/Abstractions/PhysicalJoinContextFragment.cs
@@ -1,0 +1,13 @@
+namespace Statevia.Core.Engine.Abstractions;
+
+/// <summary>
+/// Hosted 物理 Join 充足時に親 Execution Context へ投影する子 1 件分の断片。
+/// </summary>
+/// <remarks>
+/// <para>リスト順が適用順。同一 <c>states</c> 名・同一 <c>vars</c> キーは後勝ち（D5）。</para>
+/// </remarks>
+/// <param name="States">子の完了済み State エントリ（stateName → `{ output: … }`）。</param>
+/// <param name="Vars">子終端時点の vars オブジェクト（辞書想定）。</param>
+public sealed record PhysicalJoinContextFragment(
+    IReadOnlyDictionary<string, object?>? States,
+    object? Vars);

--- a/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
+++ b/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
@@ -786,7 +786,8 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
     public void CompletePhysicalJoin(
         string executionId,
         string joinStateName,
-        IReadOnlyDictionary<string, object?> branchOutputs)
+        IReadOnlyDictionary<string, object?> branchOutputs,
+        IReadOnlyList<PhysicalJoinContextFragment>? contextMerges = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(executionId);
         ArgumentException.ThrowIfNullOrWhiteSpace(joinStateName);
@@ -802,6 +803,17 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
         {
             throw new InvalidOperationException(
                 $"Join state '{joinStateName}' is not defined for execution '{executionId}'.");
+        }
+
+        if (contextMerges is { Count: > 0 })
+        {
+            foreach (var fragment in contextMerges)
+            {
+                if (fragment.States is { Count: > 0 })
+                    instance.Context.MergeStateEntries(fragment.States);
+                if (fragment.Vars is not null)
+                    instance.Context.MergeVars(fragment.Vars);
+            }
         }
 
         foreach (var (branchState, branchOutput) in branchOutputs)

--- a/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
+++ b/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
@@ -37,6 +37,7 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
     private readonly ConcurrentDictionary<string, EventProvider> _eventProviders = new();
     private Func<string, Task>? _nodeCompletedHandler;
     private Func<string, string, Task>? _suspendHandler;
+    private Func<ForkExpansionEvent, Task>? _forkExpansionHandler;
 
     /// <summary>
     /// 依存を注入してエンジンを構築する。
@@ -64,16 +65,23 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
     }
 
     /// <inheritdoc />
-    public string Start(CompiledWorkflowDefinition definition, string? executionId = null, object? input = null)
+    public string Start(
+        CompiledWorkflowDefinition definition,
+        string? executionId = null,
+        object? input = null,
+        string? initialState = null)
     {
         ArgumentNullException.ThrowIfNull(definition);
         executionId ??= _executionIdGenerator.NewExecutionId();
+        var startState = string.IsNullOrWhiteSpace(initialState)
+            ? definition.InitialState
+            : initialState.Trim();
         var eventProvider = CreateEventProvider(executionId);
         var instance = _instanceFactory.Create(definition, executionId);
         _instances[executionId] = instance;
         _eventProviders[executionId] = eventProvider;
-        _executionLog.LogExecutionStarted(executionId, definition.Name, definition.InitialState);
-        _ = RunExecutionAsync(instance, eventProvider, input);
+        _executionLog.LogExecutionStarted(executionId, definition.Name, startState);
+        _ = RunExecutionAsync(instance, eventProvider, input, startState);
         return executionId;
     }
 
@@ -108,6 +116,36 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
         catch (Exception ex)
         {
             _executionLog.LogExecutionRunFailed(ex, executionId, "suspend-handler");
+        }
+#pragma warning restore CA1031
+    }
+
+    private void NotifyForkExpansion(
+        string executionId,
+        string forkState,
+        string sourceNodeId,
+        IReadOnlyList<ForkBranchExpansionPlan> branches)
+    {
+        var handler = _forkExpansionHandler;
+        if (handler is null)
+            return;
+
+        var evt = new ForkExpansionEvent(executionId, forkState, sourceNodeId, branches);
+        _ = NotifyForkExpansionAsync(handler, evt);
+    }
+
+    private async Task NotifyForkExpansionAsync(
+        Func<ForkExpansionEvent, Task> handler,
+        ForkExpansionEvent evt)
+    {
+        try
+        {
+            await handler(evt).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Fork 展開通知失敗は呼び出し元の再試行／親 Failed に委ね、Engine ループは止めない
+        catch (Exception ex)
+        {
+            _executionLog.LogExecutionRunFailed(ex, evt.ExecutionId, "fork-expansion-handler");
         }
 #pragma warning restore CA1031
     }
@@ -267,6 +305,12 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
     public void SetSuspendHandler(Func<string, string, Task>? handler)
     {
         _suspendHandler = handler;
+    }
+
+    /// <inheritdoc />
+    public void SetForkExpansionHandler(Func<ForkExpansionEvent, Task>? handler)
+    {
+        _forkExpansionHandler = handler;
     }
 
     /// <inheritdoc />
@@ -436,13 +480,17 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
         }
     }
 
-    private async Task RunExecutionAsync(ExecutionInstance instance, EventProvider eventProvider, object? input)
+    private async Task RunExecutionAsync(
+        ExecutionInstance instance,
+        EventProvider eventProvider,
+        object? input,
+        string startState)
     {
         instance.InitializeContext(input);
-        var initialInput = ApplyStateInput(instance, instance.Definition.InitialState, input);
+        var initialInput = ApplyStateInput(instance, startState, input);
         try
         {
-            await ScheduleStateAsync(instance, eventProvider, instance.Definition.InitialState, null, null, initialInput).ConfigureAwait(false);
+            await ScheduleStateAsync(instance, eventProvider, startState, null, null, initialInput).ConfigureAwait(false);
         }
 #pragma warning disable CA1031 // 例外種別に依らず捕捉し、実行失敗は MarkFailed により観測する
         catch (Exception ex)
@@ -671,20 +719,58 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
             _executionLog.LogExecutionCompleted(instance.ExecutionId, instance.Definition.Name);
             return;
         }
+
+        ScheduleTransitionContinuation(instance, eventProvider, stateName, transition, output, nodeId);
+    }
+
+    /// <summary>
+    /// Fork / Next 遷移を Hosted 展開または同一インスタンス Schedule に振り分ける。
+    /// </summary>
+    private void ScheduleTransitionContinuation(
+        ExecutionInstance instance,
+        EventProvider eventProvider,
+        string stateName,
+        TransitionResult transition,
+        object? output,
+        string nodeId)
+    {
         if (transition.Fork != null)
         {
-            // Broadcast: 同一 output を各分岐の先頭状態へ渡す（workflow-input-output-spec §3.3）。
-            foreach (var nextState in transition.Fork)
+            // Broadcast: 同一 output を各分岐の先頭状態へ写像（workflow-input-output-spec §3.3）。
+            var plans = transition.Fork
+                .Select(nextState => new ForkBranchExpansionPlan(
+                    nextState,
+                    ApplyStateInput(instance, nextState, output)))
+                .ToList();
+
+            if (_forkExpansionHandler is not null)
             {
-                var mappedForkInput = ApplyStateInput(instance, nextState, output);
-                _ = ScheduleStateAsync(instance, eventProvider, nextState, nodeId, EdgeType.Fork, mappedForkInput);
+                // Hosted: 物理子展開。同一インスタンス上では分岐を走らせない。
+                NotifyForkExpansion(instance.ExecutionId, stateName, nodeId, plans);
+                return;
             }
+
+            foreach (var plan in plans)
+            {
+                _ = ScheduleStateAsync(
+                    instance,
+                    eventProvider,
+                    plan.BranchState,
+                    nodeId,
+                    EdgeType.Fork,
+                    plan.MappedInput);
+            }
+
+            return;
         }
-        else if (transition.Next != null)
+
+        if (transition.Next is null)
         {
-            var mappedInput = ApplyStateInput(instance, transition.Next, output);
-            _ = ScheduleStateAsync(instance, eventProvider, transition.Next, nodeId, EdgeType.Next, mappedInput);
+            return;
         }
+
+        var mappedInput = ApplyStateInput(instance, transition.Next, output);
+        _ = ScheduleStateAsync(instance, eventProvider, transition.Next, nodeId, EdgeType.Next, mappedInput);
     }
 
     private object? ApplyStateInput(ExecutionInstance instance, string targetState, object? rawInput)

--- a/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
+++ b/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
@@ -506,6 +506,18 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
         var def = instance.Definition;
         if (def.JoinTable.ContainsKey(stateName))
         {
+            // Hosted 物理子: 親側 Join に到達してもローカル事実が揃わないときは
+            // Join を実行せず子 execution として終端する（ネスト Fork の内側→外側 Join）。
+            // 通常のアクション完了時の「next が Join なら MarkCompleted」と同契約。
+            if (_forkExpansionHandler is not null
+                && !instance.JoinTracker.IsJoinReadyToExecute(stateName))
+            {
+                instance.MarkCompleted(input);
+                _executionLog.LogExecutionCompleted(instance.ExecutionId, instance.Definition.Name);
+                await NotifyNodeCompletedAsync(instance.ExecutionId).ConfigureAwait(false);
+                return;
+            }
+
             await RunJoinStateAsync(instance, eventProvider, stateName, fromNodeId, edgeType).ConfigureAwait(false);
             return;
         }

--- a/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
+++ b/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
@@ -769,8 +769,47 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
             return;
         }
 
+        // Hosted 物理子: Join は親が集約する。子は分岐終端として完了する。
+        if (_forkExpansionHandler is not null
+            && instance.Definition.JoinTable.ContainsKey(transition.Next))
+        {
+            instance.MarkCompleted(output);
+            _executionLog.LogExecutionCompleted(instance.ExecutionId, instance.Definition.Name);
+            return;
+        }
+
         var mappedInput = ApplyStateInput(instance, transition.Next, output);
         _ = ScheduleStateAsync(instance, eventProvider, transition.Next, nodeId, EdgeType.Next, mappedInput);
+    }
+
+    /// <inheritdoc />
+    public void CompletePhysicalJoin(
+        string executionId,
+        string joinStateName,
+        IReadOnlyDictionary<string, object?> branchOutputs)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(joinStateName);
+        ArgumentNullException.ThrowIfNull(branchOutputs);
+
+        if (!_instances.TryGetValue(executionId, out var instance)
+            || !_eventProviders.TryGetValue(executionId, out var eventProvider))
+        {
+            throw new InvalidOperationException($"Execution '{executionId}' is not loaded.");
+        }
+
+        if (!instance.Definition.JoinTable.ContainsKey(joinStateName))
+        {
+            throw new InvalidOperationException(
+                $"Join state '{joinStateName}' is not defined for execution '{executionId}'.");
+        }
+
+        foreach (var (branchState, branchOutput) in branchOutputs)
+        {
+            instance.JoinTracker.RecordFact(branchState, Fact.Completed, branchOutput);
+        }
+
+        _ = RunJoinStateAsync(instance, eventProvider, joinStateName, fromNodeId: null, edgeType: null);
     }
 
     private object? ApplyStateInput(ExecutionInstance instance, string targetState, object? rawInput)

--- a/core/engine/Statevia.Core.Engine/Engine/WorkflowExecutionContext.cs
+++ b/core/engine/Statevia.Core.Engine/Engine/WorkflowExecutionContext.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-
+using System.Text.Json;
 using Statevia.Core.Engine.Abstractions;
 using Statevia.Core.Engine.Definition;
 
@@ -111,6 +111,65 @@ public sealed class WorkflowExecutionContext
         lock (_lock)
         {
             return _states.ContainsKey(stateName);
+        }
+    }
+
+    /// <summary>
+    /// 完了済み State エントリを一括投影する（既存キーは上書き＝後勝ち）。
+    /// </summary>
+    /// <param name="states">stateName → `{ output: … }` 形式のエントリ。</param>
+    public void MergeStateEntries(IReadOnlyDictionary<string, object?> states)
+    {
+        ArgumentNullException.ThrowIfNull(states);
+        lock (_lock)
+        {
+            foreach (var (stateName, entry) in states)
+            {
+                if (string.IsNullOrWhiteSpace(stateName))
+                    continue;
+                _states[stateName] = CloneForIsolation(entry);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 子終端 vars を親 vars へトップレベルキー単位でマージする（既存キーは上書き＝後勝ち）。
+    /// </summary>
+    /// <param name="vars">辞書形式の vars。それ以外は無視する。</param>
+    public void MergeVars(object? vars)
+    {
+        if (vars is null)
+            return;
+
+        IReadOnlyDictionary<string, object?>? source = vars switch
+        {
+            IReadOnlyDictionary<string, object?> typed => typed,
+            JsonElement { ValueKind: JsonValueKind.Object } element => element.EnumerateObject()
+                .ToDictionary(
+                    prop => prop.Name,
+                    prop => (object?)prop.Value.Clone(),
+                    StringComparer.OrdinalIgnoreCase),
+            System.Collections.IDictionary untyped => untyped.Keys
+                .Cast<object>()
+                .Where(k => k is string)
+                .ToDictionary(
+                    k => (string)k,
+                    k => untyped[k],
+                    StringComparer.OrdinalIgnoreCase),
+            _ => null
+        };
+        if (source is null || source.Count == 0)
+            return;
+
+        lock (_lock)
+        {
+            var root = EnsureVarsDictionary();
+            foreach (var (key, value) in source)
+            {
+                if (string.IsNullOrWhiteSpace(key))
+                    continue;
+                root[key] = CloneForIsolation(value);
+            }
         }
     }
 

--- a/core/engine/Statevia.Core.Engine/Join/IJoinTracker.cs
+++ b/core/engine/Statevia.Core.Engine/Join/IJoinTracker.cs
@@ -14,4 +14,11 @@ public interface IJoinTracker
     IReadOnlyList<string> GetJoinSourceNodeIds(string joinStateName);
     /// <summary>Join 状態が完了ポリシーを満たして実行可能かを判定し、未実行なら開始済みとしてマークします。</summary>
     bool TryBeginJoinExecution(string joinStateName);
+
+    /// <summary>
+    /// Join の依存事実が揃い、まだ開始されていないとき実行可能か（開始マークはしない）。
+    /// </summary>
+    /// <param name="joinStateName">Join 状態名。</param>
+    /// <returns>実行可能なら <see langword="true"/>。</returns>
+    bool IsJoinReadyToExecute(string joinStateName);
 }

--- a/core/engine/Statevia.Core.Engine/Join/JoinTracker.cs
+++ b/core/engine/Statevia.Core.Engine/Join/JoinTracker.cs
@@ -123,16 +123,7 @@ public sealed class JoinTracker : IJoinTracker
             {
                 return false;
             }
-            if (!_joinTable.TryGetValue(joinStateName, out var dependencies) || dependencies.Count == 0)
-            {
-                return false;
-            }
-            if (!_joinStateResults.TryGetValue(joinStateName, out var results))
-            {
-                return false;
-            }
-            if (!_completionPolicies.TryGetValue(joinStateName, out var completionPolicy)
-                || !completionPolicy.IsSatisfied(results))
+            if (!IsJoinReadyToExecuteUnlocked(joinStateName))
             {
                 return false;
             }
@@ -140,6 +131,32 @@ public sealed class JoinTracker : IJoinTracker
             _startedJoins.Add(joinStateName);
             return true;
         }
+    }
+
+    /// <summary>
+    /// Join の依存事実が揃い、まだ開始されていないときに実行可能か（開始マークはしない）。
+    /// </summary>
+    /// <param name="joinStateName">Join 状態名。</param>
+    /// <returns>実行可能なら <see langword="true"/>。</returns>
+    public bool IsJoinReadyToExecute(string joinStateName)
+    {
+        lock (_lock)
+        {
+            if (_startedJoins.Contains(joinStateName))
+                return false;
+
+            return IsJoinReadyToExecuteUnlocked(joinStateName);
+        }
+    }
+
+    private bool IsJoinReadyToExecuteUnlocked(string joinStateName)
+    {
+        if (!_joinTable.TryGetValue(joinStateName, out var dependencies) || dependencies.Count == 0)
+            return false;
+        if (!_joinStateResults.TryGetValue(joinStateName, out var results))
+            return false;
+        return _completionPolicies.TryGetValue(joinStateName, out var completionPolicy)
+            && completionPolicy.IsSatisfied(results);
     }
 
     /// <summary>可変状態をチェックポイントへエクスポートする。</summary>

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,10 +111,11 @@ Guide のあと、なぜそうなっているかを理解する。
 
 ## Future（将来構想）
 
-**未実装**の構想のみ。現行仕様と混同しないこと。
+契約・実装の正本ではない。論理到達像と成熟度・フェーズ展望。現行仕様と混同しないこと。
 
 | ドキュメント | 内容 |
 | --- | --- |
+| [product-roadmap.md](future/product-roadmap.md) | 能力成熟度（ある／部分／ない）と Near / Mid / Long |
 | [platform-architecture.md](future/platform-architecture.md) | プラットフォーム構成（将来構想） |
 
 一覧: [future/README.md](future/README.md)

--- a/docs/concepts/durability.md
+++ b/docs/concepts/durability.md
@@ -3,9 +3,9 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Concept |
-| Version | 1.3 |
-| 更新日 | 2026-08-04 |
-| 関連 | [../specifications/data-integration.md](../specifications/data-integration.md) |
+| Version | 1.4 |
+| 更新日 | 2026-08-09 |
+| 関連 | [../specifications/data-integration.md](../specifications/data-integration.md), [../specifications/execution/fork-join.md](../specifications/execution/fork-join.md) |
 
 ---
 
@@ -18,8 +18,11 @@ Statevia は実行の進行を **PostgreSQL** 上の projection と **event_stor
 - **実行の read-model**（一覧・GET execution・GET graph）: `executions` と `execution_graph_snapshots` 等の DB projection
 - **定義**: `definitions` / `definition_versions`（immutable 版）
 - **イベント履歴**: `event_store` への append（同一トランザクション内で projection と整合）
+- **Hosted Fork の親子リンク / Join 充足**: `execution_branches`（親の durable Wait ではない）
 
 in-process の `GetSnapshot` はデバッグやコールバック経路向けであり、HTTP API の正本ではありません。
+
+親の `GET …/graph` / `GET …/events` は、物理子を論理 1 実行に見せるため **GET 時合成**する。永続 snapshot / `event_store` への親への二重書き込みはしない（契約の詳細は [fork-join.md](../specifications/execution/fork-join.md)）。
 
 ## 開始とミューテーション
 
@@ -37,8 +40,15 @@ in-process の `GetSnapshot` はデバッグやコールバック経路向けで
 
 ステップ完了ごとに checkpoint を更新し、Unload は durable Wait 到達または終端に限定します。recovery で Action が再実行されうる場合、Action 側の冪等（または適用済み検知）を前提とします。
 
+## Hosted Fork と耐久
+
+- Fork 展開・子 Start・親子リンクは `execution_branches` と work item で耐久化する。展開一時失敗はリトライし、上限後に親 Failed。
+- 子終端は親向け予約 Resume（`statevia.event.child.completed`）で起こし、Join を再評価する。
+- ネスト Fork も同一経路で再帰分割する。循環再入時の Join hydrate など残課題は実装フォローアップの対象。
+
 ## 次に読むもの
 
 - データ連携契約: [specifications/data-integration.md](../specifications/data-integration.md)
+- Fork / Join（物理子・合成読みモデル）: [specifications/execution/fork-join.md](../specifications/execution/fork-join.md)
 - DB スキーマ参照: [reference/database-schema.md](../reference/database-schema.md)
 - Event Store の設計判断: [decisions/event-store.md](../decisions/event-store.md)

--- a/docs/concepts/execution-model.md
+++ b/docs/concepts/execution-model.md
@@ -3,9 +3,9 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Concept |
-| Version | 1.0 |
-| 更新日 | 2026-07-07 |
-| 関連 | [../specifications/execution/](../specifications/execution/) |
+| Version | 1.1 |
+| 更新日 | 2026-08-09 |
+| 関連 | [../specifications/execution/](../specifications/execution/), [../specifications/execution/fork-join.md](../specifications/execution/fork-join.md) |
 
 ---
 
@@ -29,13 +29,15 @@
 
 並列分岐と合流は**制御ノード**としてグラフに表現されます。Join は依存する分岐の完了事実を待ち、すべて揃った時点で次へ進みます。
 
+**Hosted Runtime** では Fork を親＋物理子 execution に展開し、親子リンクと Join 充足は `execution_branches` が正本です。定義語彙は透過のまま、UI 向け graph / events は GET 時に論理 1 実行へ合成します。詳細は [fork-join.md](../specifications/execution/fork-join.md)。
+
 ### 5. Wait と Cancel
 
-EventWait など durable な待機は operational projection と整合します。キャンセルは協調的: 要求は Command として受理されますが、遷移はキャンセルが処理された**事実**まで保留されます。
+EventWait など durable な待機は operational projection と整合します。キャンセルは協調的: 要求は Command として受理されますが、遷移はキャンセルが処理された**事実**まで保留されます。物理 Fork 下の分岐 Wait は子 execution へ配送し、親 Cancel は未終端子へカスケードします。
 
 ### 6. 実行グラフの可視化
 
-Engine は実行時グラフ（ノード ID、状態名、attempt、waitKey 等）をエクスポートします。HTTP GET の read-model は DB projection を正とし、in-process スナップショットと一致しない場合がある点に注意してください。
+Engine は実行時グラフ（ノード ID、状態名、attempt、waitKey 等）をエクスポートします。HTTP GET の read-model は DB projection を正とし、in-process スナップショットと一致しない場合がある点に注意してください。親の物理 Fork がある場合、GET graph は合成後の論理見え方を返します（合成ノードの `workerId` は子から引き継ぎ）。
 
 ## Specification への対応
 

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -71,6 +71,7 @@ Markdown 執筆ルールは [`DOCUMENTATION-STANDARD.md`](DOCUMENTATION-STANDARD
 - **XML ドキュメント**: `public` / `internal` の型・メンバーに `/// <summary>` 等を付ける。`private` は意図が自明でない箇所のみ。
 - **テスト**: メソッドごとに日本語の `/// <summary>` と **`// Arrange` / `// Act` / `// Assert`** 区切り。1 テスト 1 シナリオ（AAA）。
 - **セキュリティ**: 外部入力の検証、認可・テナント境界、機密情報の非出力（ログ・エラー応答含む）。
+- **構造化ログ**: `ILogger.Log*`（`LogWarning` / `LogError` 等）を直接呼ばない。`[LoggerMessage]` のソース生成 partial（例: `*LogMessages.cs`）経由で出す。キー命名は [`reference/logging-property-keys.md`](reference/logging-property-keys.md)。
 - **Options 検証（Service API）**: `AddOptions<T>().Bind()` した設定は、次の分類で扱う。キー別の許容範囲・不正時挙動は [`reference/environment-variables.md`](reference/environment-variables.md) を参照する。
   - **A（起動失敗）**: 範囲外・矛盾など既定では安全に動けない値 → `.Validate()` + `ValidateOnStart()`。メッセージはキー名と制約のみ（値は出さない）。
   - **B（警告＋既定値）**: 未設定・空で既定値により安全に動ける → Warning ログのうえ既定値で続行。サイレント補正は禁止。

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -3,17 +3,18 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Future |
-| Version | 1.0 |
-| 更新日 | 2026-07-07 |
+| Version | 1.1 |
+| 更新日 | 2026-08-08 |
 
 ---
 
-**現時点では未実装の構想** のみ。現行の挙動・契約は [`../specifications/`](../specifications/) および [`../architecture/`](../architecture/) を参照すること。
+契約・実装の正本ではない。論理到達像と成熟度・フェーズ展望を置く。現行の挙動・契約は [`../specifications/`](../specifications/) および [`../architecture/`](../architecture/) を参照すること。
 
 ## ドキュメント
 
 | ドキュメント | 内容 |
 | --- | --- |
+| [`product-roadmap.md`](product-roadmap.md) | 能力成熟度（ある／部分／ない）と Near / Mid / Long |
 | [`platform-architecture.md`](platform-architecture.md) | プラットフォーム構成（将来構想） |
 
 入口の索引では [`../README.md`](../README.md) の **Future** セクション（最後）にのみ掲載する。

--- a/docs/future/product-roadmap.md
+++ b/docs/future/product-roadmap.md
@@ -3,9 +3,9 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Future |
-| Version | 1.0.0 |
-| 更新日 | 2026-08-08 |
-| 関連 | [platform-architecture.md](platform-architecture.md), [../architecture/overview.md](../architecture/overview.md), [../specifications/platform/audit-and-repro.md](../specifications/platform/audit-and-repro.md) |
+| Version | 1.0.1 |
+| 更新日 | 2026-08-09 |
+| 関連 | [platform-architecture.md](platform-architecture.md), [../architecture/overview.md](../architecture/overview.md), [../specifications/execution/fork-join.md](../specifications/execution/fork-join.md), [../specifications/platform/audit-and-repro.md](../specifications/platform/audit-and-repro.md) |
 
 ---
 
@@ -17,7 +17,7 @@
 
 ## 1. 現状の読み方
 
-現在の改修重心は **ワークフロー Runtime（物理 Fork・耐久・合成読取）** である。認証・テナント・Action Modules・Wait / Resume は既に厚く、運用前提で使える核が揃っている。一方、運用 KPI・監査チェーン・分析・SaaS 運用境界は仕様先行または未着手が多い。
+Hosted の **物理 Fork MVP**（親子展開・Join・合成 graph / events・公開 [fork-join.md](../specifications/execution/fork-join.md)）は一通り揃った。Near の残は循環 Join 耐久やネスト合成のエッジ、Wait UI・容量指針など。認証・テナント・Action Modules・Wait / Resume は既に厚い。運用 KPI・監査チェーン・分析・SaaS 運用境界は仕様先行または未着手が多い。
 
 判断基準の優先順は次のとおりとする。
 
@@ -45,7 +45,7 @@
 ```mermaid
 flowchart LR
   subgraph near [Near_Workflow]
-    PhysFork[PhysicalFork_仕上げ]
+    PhysFork[PhysicalFork_followups]
     WaitUI[WaitEvents_UI]
     CapDocs[容量・分離運用指針]
   end
@@ -72,8 +72,8 @@ flowchart LR
 
 | 状態 | 内容 | ギャップ / 備考 |
 | --- | --- | --- |
-| **ある** | FSM、Definition 版管理（immutable append）、Start / Cancel / Resume、Wait 複数イベント、DelayWait、checkpoint / work queue / OwnershipRecovery、論理 Fork / Join、Action Catalog / Policy、InProcess / OutOfProcess / Container、Module Source（Filesystem / OCI / S3 / Git）＋署名・TrustLevel、DB projection 正本＋ graph ＋ SSE、Studio（定義・実行・ダッシュボード）、JWT / API キー＋テナント＋ Execution Security Snapshot | 公開契約: [definition.md](../specifications/definition.md)、[api-http.md](../specifications/api-http.md)、[execution/](../specifications/execution/)、[actions/platform.md](../specifications/actions/platform.md)、[security-runtime.md](../specifications/platform/security-runtime.md) |
-| **部分** | 物理 Fork（親＋子 execution・合成 graph / events）、Scheduler / Worker の任意プロセス分離、Action-level retry（定義 parse のみ）、Module 複数版共存（設計確定・実装未）、Graph Editor の `wait.events` UI | ネスト / 循環 / recovery の仕上げ、公開 `fork-join` 契約への同期、既定分離切替の判断が残る |
+| **ある** | FSM、Definition 版管理（immutable append）、Start / Cancel / Resume、Wait 複数イベント、DelayWait、checkpoint / work queue / OwnershipRecovery、論理 Fork / Join、**Hosted 物理 Fork MVP**（`execution_branches`・予約 Resume・Join 後 Context マージ・GET 時合成 graph / events・公開 [fork-join.md](../specifications/execution/fork-join.md)）、Action Catalog / Policy、InProcess / OutOfProcess / Container、Module Source（Filesystem / OCI / S3 / Git）＋署名・TrustLevel、DB projection 正本＋ graph ＋ SSE、Studio（定義・実行・ダッシュボード）、JWT / API キー＋テナント＋ Execution Security Snapshot | 公開契約: [definition.md](../specifications/definition.md)、[api-http.md](../specifications/api-http.md)、[execution/](../specifications/execution/)、[actions/platform.md](../specifications/actions/platform.md)、[security-runtime.md](../specifications/platform/security-runtime.md) |
+| **部分** | 物理 Fork のエッジ（循環再入の Join hydrate、ネスト合成の幽霊枝）、Scheduler / Worker の任意プロセス分離、Action-level retry（定義 parse のみ）、Module 複数版共存（設計確定・実装未）、Graph Editor の `wait.events` UI | 終端時の合成固定は Mid。既定分離切替の判断が残る |
 | **ない** | Wasm ランタイム、Marketplace Module Source、Connectors 製品化、統一 WebSocket Push | [platform-architecture.md](platform-architecture.md) の到達像側 |
 
 ### 4.2 運用・監視・可観測性
@@ -122,13 +122,14 @@ flowchart LR
 
 ### 5.1 Near（信頼性クローズ）
 
-1. 物理 Fork MVP 仕上げ（ネスト / recovery、循環・幽霊枝などの follow-up、公開 [fork-join.md](../specifications/execution/fork-join.md) 契約への同期）
-2. Studio Graph Editor の `wait.events` 編集ギャップ解消（Engine / API 契約との一致）
-3. Worker / Scheduler 既定分離の判断、容量ガイドの公開置き場
+1. ~~物理 Fork MVP（親子展開・合成読取・公開 fork-join 同期）~~ → **完了**（2026-08）
+2. 物理 Fork follow-up（循環再入時の Join hydrate、ネスト合成の幽霊枝）
+3. Studio Graph Editor の `wait.events` 編集ギャップ解消（Engine / API 契約との一致）
+4. Worker / Scheduler 既定分離の判断、容量ガイドの公開置き場
 
 ### 5.2 Mid（運用・監査・分析の製品化）
 
-1. 合成 read model の終端固定（終端後の都度合成コスト削減）
+1. 合成 read model の終端固定（終端後の都度合成コスト削減。Running 中は GET 時合成のまま）
 2. 可観測性: readiness / 依存ヘルス、メトリクス、分散トレース（OpenTelemetry 方向）
 3. 監査: actor 埋込 → hash chain の段階適用（[audit-and-repro.md](../specifications/platform/audit-and-repro.md) に実装を寄せる）
 4. 実行分析 Phase 1（ノードイベント投影＋読取 API）
@@ -151,8 +152,8 @@ flowchart LR
 | --- | --- | --- |
 | Platform API（Auth・Tenants・Definitions・Executions） | **ある** | OIDC 等は将来 |
 | Definition Platform（Schema / Validate / Compile / Version / Package / Sign） | **ある**（大半） | Packaging / 版共存の一部は部分 |
-| Execution Platform（Dispatcher / Runtime / FSM / Wait / Retry / Recovery） | **部分** | FSM / Wait / Recovery はある。物理 Fork・Action retry は部分 |
-| Projection（Read Models / Timeline / Graph） | **ある**（単一実行） | 物理 Fork 合成は部分。終端固定は Mid |
+| Execution Platform（Dispatcher / Runtime / FSM / Wait / Retry / Recovery） | **ある**（中核）＋**部分**（エッジ） | 物理 Fork MVP・FSM / Wait / Recovery はある。循環 Join follow-up・Action retry は部分 |
+| Projection（Read Models / Timeline / Graph） | **ある**（GET 時合成含む） | 親 graph / events の物理 Fork 合成はある。終端固定は Mid |
 | Realtime（SSE / WebSocket） | **部分** | SSE（GraphUpdated）あり。WebSocket / 統一 Push はない |
 | Action Runtime（Builtin / Modules / Connectors） | **部分** | Builtin / Modules はある。Connectors 製品化はない |
 | Persistence（Definition / Event / Snapshot / Artifact / Read） | **ある**（中核） | Artifact / Snapshot の製品境界は運用依存 |

--- a/docs/future/product-roadmap.md
+++ b/docs/future/product-roadmap.md
@@ -1,0 +1,169 @@
+# 製品ロードマップ（成熟度と展望）
+
+| 項目 | 値 |
+| --- | --- |
+| 種別 | Future |
+| Version | 1.0.0 |
+| 更新日 | 2026-08-08 |
+| 関連 | [platform-architecture.md](platform-architecture.md), [../architecture/overview.md](../architecture/overview.md), [../specifications/platform/audit-and-repro.md](../specifications/platform/audit-and-repro.md) |
+
+---
+
+契約・実装の正本ではない。**能力の成熟度（ある／部分／ない）と推奨フェーズ順**を示す展望ドキュメントである。現行の振る舞い・契約は [`../specifications/`](../specifications/) および [`../architecture/`](../architecture/) を参照すること。
+
+論理プラットフォームの到達像図は [platform-architecture.md](platform-architecture.md) を参照する。本書はその図と突き合わせるための成熟度マップである。
+
+---
+
+## 1. 現状の読み方
+
+現在の改修重心は **ワークフロー Runtime（物理 Fork・耐久・合成読取）** である。認証・テナント・Action Modules・Wait / Resume は既に厚く、運用前提で使える核が揃っている。一方、運用 KPI・監査チェーン・分析・SaaS 運用境界は仕様先行または未着手が多い。
+
+判断基準の優先順は次のとおりとする。
+
+1. 実行正しさ（Runtime）
+2. 観測・説明責任（可観測性・監査・分析）
+3. SaaS 運用境界（テナント制御・シークレット・可用性）
+4. プラットフォーム拡張（Wasm・Marketplace・外部 Transport 等）
+
+---
+
+## 2. 成熟度の定義
+
+| 状態 | 意味 |
+| --- | --- |
+| **ある** | 実装と公開 docs があり、運用前提で使える |
+| **部分** | 骨格・一部実装・仕様のみのいずれか。ギャップを併記する |
+| **ない** | 製品機能として未提供（Future 構想を含む） |
+
+---
+
+## 3. フェーズ概観
+
+日付コミットメントは置かない。依存関係に基づく Near / Mid / Long のみ示す。
+
+```mermaid
+flowchart LR
+  subgraph near [Near_Workflow]
+    PhysFork[PhysicalFork_仕上げ]
+    WaitUI[WaitEvents_UI]
+    CapDocs[容量・分離運用指針]
+  end
+  subgraph mid [Mid_OpsProduct]
+    Materialize[合成ReadModel固定]
+    Observ[Metrics_Tracing_Health]
+    AuditFill[Audit_actor_hash]
+    Analytics[実行分析_Phase1]
+  end
+  subgraph long [Long_SaaSPlatform]
+    SaaSCtl[Moduleテナント制御]
+    Secrets[KMS_Secrets]
+    HA[HA_Backup_SLA]
+    Ext[Wasm_Marketplace_Transport]
+  end
+  near --> mid --> long
+```
+
+---
+
+## 4. 能力成熟度マトリクス
+
+### 4.1 ワークフロー（Definition / Execution / Actions / UI）
+
+| 状態 | 内容 | ギャップ / 備考 |
+| --- | --- | --- |
+| **ある** | FSM、Definition 版管理（immutable append）、Start / Cancel / Resume、Wait 複数イベント、DelayWait、checkpoint / work queue / OwnershipRecovery、論理 Fork / Join、Action Catalog / Policy、InProcess / OutOfProcess / Container、Module Source（Filesystem / OCI / S3 / Git）＋署名・TrustLevel、DB projection 正本＋ graph ＋ SSE、Studio（定義・実行・ダッシュボード）、JWT / API キー＋テナント＋ Execution Security Snapshot | 公開契約: [definition.md](../specifications/definition.md)、[api-http.md](../specifications/api-http.md)、[execution/](../specifications/execution/)、[actions/platform.md](../specifications/actions/platform.md)、[security-runtime.md](../specifications/platform/security-runtime.md) |
+| **部分** | 物理 Fork（親＋子 execution・合成 graph / events）、Scheduler / Worker の任意プロセス分離、Action-level retry（定義 parse のみ）、Module 複数版共存（設計確定・実装未）、Graph Editor の `wait.events` UI | ネスト / 循環 / recovery の仕上げ、公開 `fork-join` 契約への同期、既定分離切替の判断が残る |
+| **ない** | Wasm ランタイム、Marketplace Module Source、Connectors 製品化、統一 WebSocket Push | [platform-architecture.md](platform-architecture.md) の到達像側 |
+
+### 4.2 運用・監視・可観測性
+
+| 状態 | 内容 | ギャップ / 備考 |
+| --- | --- | --- |
+| **ある** | 構造化ログ（`[LoggerMessage]`）、相関 ID（`traceparent` / `X-Trace-Id`）、IO-14 マスキング、`GET /v1/health`、Docker / split-runtime ガイド、実行ダッシュボード＋ SSE | [logging-property-keys.md](../reference/logging-property-keys.md)、[io-log-masking.md](../specifications/platform/io-log-masking.md)、[operations-docker.md](../guides/operations-docker.md)、[push-api.md](../specifications/ui/push-api.md) |
+| **部分** | 死活のみのヘルス、容量・負荷の公開指針 | readiness / 依存チェックなし。容量 Reference・負荷試験ガイドは未整備 |
+| **ない** | Prometheus / OpenTelemetry メトリクス・分散トレース、アラート / SLO、正式な負荷試験ガイド | [data-integration.md](../specifications/data-integration.md) はメトリクスを将来対応と記載 |
+
+### 4.3 監査
+
+| 状態 | 内容 | ギャップ / 備考 |
+| --- | --- | --- |
+| **ある** | append-only `event_store`、実行 events API、actor / correlation 列のスキーマ、Execution Security Snapshot、監査・再現性の契約文書 | [audit-and-repro.md](../specifications/platform/audit-and-repro.md)、[execution-security-snapshot.md](../specifications/platform/execution-security-snapshot.md) |
+| **部分** | イベント履歴による「何が起きたか」 | actor / correlation / causation の書込が未配線。監査専用テーブルの活用が未整備 |
+| **ない** | hash chain 実装、管理操作（設定・Module 配置等）の監査、夜間 hash 検証ジョブ | Level 2 設計は仕様のみ |
+
+### 4.4 分析
+
+| 状態 | 内容 | ギャップ / 備考 |
+| --- | --- | --- |
+| **ある** | 実行一覧・詳細・グラフ（運用 UI） | BI / KPI 製品ではない |
+| **部分** | BI 指標の構想（成功率・待機時間等）、実行分析の内部検討 | 公開製品機能としては未提供 |
+| **ない** | ノードライフサイクル投影 API、テナント横断 KPI / DWH、Replay UI | [audit-and-repro.md](../specifications/platform/audit-and-repro.md) §7 の方向性のみ |
+
+### 4.5 SaaS 向けセキュリティ
+
+| 状態 | 内容 | ギャップ / 備考 |
+| --- | --- | --- |
+| **ある** | Password＋JWT、API キー（hash 保存）、permission keys、テナント lifecycle（Active / Suspended / Archived）、QueryFilter fail-closed、Module 署名 / TrustLevel、実行モード下限（Tenant Policy）、テナント別 Module パス、テナントブートストラップ | [security-runtime.md](../specifications/platform/security-runtime.md)、[permission-keys.md](../reference/permission-keys.md)、[operations-tenant-bootstrap.md](../guides/operations-tenant-bootstrap.md) |
+| **部分** | OIDC / PAT（設計余地）、Module 配置境界、シークレット管理 | Module 配置は運用者 FS 信頼境界。`ISecretResolver` / KMS 連携は未実装 |
+| **ない** | テナント容量・数量上限、Marketplace、保存時暗号化の製品機能、SAML / mTLS、クロステナント federation | federation は現行契約で不採用 |
+
+### 4.6 可用性・耐久性
+
+| 状態 | 内容 | ギャップ / 備考 |
+| --- | --- | --- |
+| **ある** | PostgreSQL 正本、`FOR UPDATE SKIP LOCKED` work queue、lease / fencing、OwnershipRecovery、EventDelivery リトライ、command dedup、API 内 Hosted 既定 On＋任意プロセス分離 | [durability.md](../concepts/durability.md)、[operations-docker.md](../guides/operations-docker.md) |
+| **部分** | 複数 Worker による水平スケール（同一 PG）、split-runtime | 単一 PG compose 前提。容量 / SLA 未公開。既定分離切替は後続判断 |
+| **ない** | マネージド HA、バックアップ / リストア ランブック、マルチリージョン、外部メッセージバス本線（Kafka 等）、正式 SLA | [platform-architecture.md](platform-architecture.md) の Transport / Infra 到達像 |
+
+---
+
+## 5. フェーズロードマップ
+
+### 5.1 Near（信頼性クローズ）
+
+1. 物理 Fork MVP 仕上げ（ネスト / recovery、循環・幽霊枝などの follow-up、公開 [fork-join.md](../specifications/execution/fork-join.md) 契約への同期）
+2. Studio Graph Editor の `wait.events` 編集ギャップ解消（Engine / API 契約との一致）
+3. Worker / Scheduler 既定分離の判断、容量ガイドの公開置き場
+
+### 5.2 Mid（運用・監査・分析の製品化）
+
+1. 合成 read model の終端固定（終端後の都度合成コスト削減）
+2. 可観測性: readiness / 依存ヘルス、メトリクス、分散トレース（OpenTelemetry 方向）
+3. 監査: actor 埋込 → hash chain の段階適用（[audit-and-repro.md](../specifications/platform/audit-and-repro.md) に実装を寄せる）
+4. 実行分析 Phase 1（ノードイベント投影＋読取 API）
+5. Action: Container 運用成熟、Org / Project Policy 階層、Module version 共存
+
+### 5.3 Long（SaaS プラットフォーム）
+
+1. Module テナント制御（存在確認・認可・容量 / 数量上限）、設定の Secret / DB 化
+2. HA / バックアップ / RPO-RTO ランブック、外部 Transport
+3. OIDC、Wasm / Marketplace / Connectors、Realtime 統一（WebSocket 等）
+4. [platform-architecture.md](platform-architecture.md) の論理到達像へ収束
+
+---
+
+## 6. 論理構成図との対応
+
+[platform-architecture.md](platform-architecture.md) のブロックごとの現状ステータス。
+
+| 論理ブロック | 現状 | メモ |
+| --- | --- | --- |
+| Platform API（Auth・Tenants・Definitions・Executions） | **ある** | OIDC 等は将来 |
+| Definition Platform（Schema / Validate / Compile / Version / Package / Sign） | **ある**（大半） | Packaging / 版共存の一部は部分 |
+| Execution Platform（Dispatcher / Runtime / FSM / Wait / Retry / Recovery） | **部分** | FSM / Wait / Recovery はある。物理 Fork・Action retry は部分 |
+| Projection（Read Models / Timeline / Graph） | **ある**（単一実行） | 物理 Fork 合成は部分。終端固定は Mid |
+| Realtime（SSE / WebSocket） | **部分** | SSE（GraphUpdated）あり。WebSocket / 統一 Push はない |
+| Action Runtime（Builtin / Modules / Connectors） | **部分** | Builtin / Modules はある。Connectors 製品化はない |
+| Persistence（Definition / Event / Snapshot / Artifact / Read） | **ある**（中核） | Artifact / Snapshot の製品境界は運用依存 |
+| Infrastructure Transport（Kafka 等） | **ない** | 現状はプロセス内 Hosted ＋ PG |
+| Secrets / KMS | **ない** | 設定は env / appsettings 前提 |
+| Observability（Logs / Metrics / Tracing / Audit） | **部分** | Logs はある。Metrics / Tracing / Audit チェーンは薄い |
+
+---
+
+## 7. 更新ルール
+
+- 実装が「ある」に上がったら本表を更新し、契約・説明は [`../specifications/`](../specifications/) 側へ昇格する。
+- 内部作業チケットや作業用 Spec フォルダへのリンクは置かない（[`DOCUMENTATION-STANDARD.md`](../DOCUMENTATION-STANDARD.md)）。
+- 四半期などの日付固定はしない。依存関係が変わったときに Near / Mid / Long の並びを見直す。

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -1,7 +1,9 @@
 # スキーマ定義
 
-Version: 1.15
+Version: 1.16
 Project: 実行型ステートマシン
+
+**Version 1.16（2026-08-06）**: `execution_branches` 追加（Hosted Fork 物理子の親子リンク正本。`fork_state` / `join_state` / `branch_state` は定義の状態名空間）。
 
 **Version 1.7（2026-05-27）**: task 8 — `execution_cursors` / `execution_waits` 追加（operational projection / EventWait durable wait）。
 
@@ -64,6 +66,7 @@ Service API（C#）の EF Core マイグレーションで管理する PostgreSQ
 | execution_cursors | ExecutionSpace | 現在位置の operational projection（read-model 正本外） |
 | execution_waits | ExecutionSpace | durable wait（EventWait / CallbackWait / DelayWait）の永続化 |
 | execution_wait_subscriptions | ExecutionSpace | Wait の subscribe 購読行（topic / correlation 厳密一致） |
+| execution_branches | ExecutionSpace | Fork 物理子の親子リンク正本（親 Join 集約用） |
 | execution_runtime_checkpoints | ExecutionSpace | 再開可能なランタイム状態の文書ストア（現行 Postgres 物理テーブル。契約は `IExecutionCheckpointStore`）。Worker 所有・fencing 列を含む |
 | execution_work_items | ExecutionSpace | Start / Resume / Cancel を配送する lease 付き耐久キュー |
 | command_dedup | 信頼性 | コマンド冪等（Start 等の `X-Idempotency-Key`） |
@@ -293,6 +296,24 @@ Wait の `subscribe` 購読（1 Wait ノードあたり 0 件以上）。`POST /
 | created_at | timestamptz | NOT NULL | 作成日時 |
 
 **外部キー:** `(execution_id, node_id)` → `execution_waits` ON DELETE CASCADE。**インデックス:** `(topic, correlation_key)`。照合は両列の厳密一致（NULL 比較なし）。
+
+### 2.10.2c execution_branches
+
+Hosted Runtime が Fork を物理子 execution に展開したときの親子リンク正本。Join 充足判定・合成グラフの材料。
+
+| カラム | 型 | 制約 | 説明 |
+| --- | --- | --- | --- |
+| parent_execution_id | uuid | PK, FK → executions, NOT NULL | 親（ネスト時は親役）execution |
+| fork_state | varchar(256) | PK, NOT NULL | ForkTable キー（定義の状態名。実行短名 UUID ではない） |
+| branch_state | varchar(256) | PK, NOT NULL | 分岐先頭状態名 |
+| execution_id | uuid | UNIQUE, FK → executions, NOT NULL | 子 execution |
+| join_state | varchar(256) | NOT NULL | Join 状態名 |
+| status | varchar(64) | NOT NULL | Running / Completed / Failed / Cancelled |
+| output_json | jsonb | NULL | 終端 output 退避（任意） |
+| created_at | timestamptz | NOT NULL | 作成日時 |
+| updated_at | timestamptz | NOT NULL | 更新日時 |
+
+**主キー:** `(parent_execution_id, fork_state, branch_state)`。**一意:** `execution_id`。両 FK は `executions` へ ON DELETE CASCADE。
 
 ### 2.10.2b execution_runtime_checkpoints
 

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -301,7 +301,7 @@ Wait の `subscribe` 購読（1 Wait ノードあたり 0 件以上）。`POST /
 
 ### 2.10.2c execution_branches
 
-Hosted Runtime が Fork を物理子 execution に展開したときの親子リンク正本。Join 充足判定・合成グラフの材料。
+Hosted Runtime が Fork を物理子 execution に展開したときの親子リンク正本。Join 充足判定・合成グラフの材料。振る舞い契約（展開リトライ、予約 Resume、兄弟参照不可、GET 時合成）は [fork-join.md](../specifications/execution/fork-join.md)。
 
 | カラム | 型 | 制約 | 説明 |
 | --- | --- | --- | --- |

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -3,7 +3,7 @@
 Version: 1.16
 Project: 実行型ステートマシン
 
-**Version 1.16（2026-08-06）**: `execution_branches` 追加（Hosted Fork 物理子の親子リンク正本。`fork_state` / `join_state` / `branch_state` は定義の状態名空間）。
+**Version 1.16（2026-08-06）**: `execution_branches` 追加（Hosted Fork 物理子の親子リンク正本。`fork_node_id` は実行ノード ID、`join_state` / `branch_state` は定義の状態名空間）。
 
 **Version 1.7（2026-05-27）**: task 8 — `execution_cursors` / `execution_waits` 追加（operational projection / EventWait durable wait）。
 
@@ -304,7 +304,7 @@ Hosted Runtime が Fork を物理子 execution に展開したときの親子リ
 | カラム | 型 | 制約 | 説明 |
 | --- | --- | --- | --- |
 | parent_execution_id | uuid | PK, FK → executions, NOT NULL | 親（ネスト時は親役）execution |
-| fork_state | varchar(256) | PK, NOT NULL | ForkTable キー（定義の状態名。実行短名 UUID ではない） |
+| fork_node_id | varchar(64) | PK, NOT NULL | 親実行グラフ上の Fork 到達インスタンス（実行ノード ID） |
 | branch_state | varchar(256) | PK, NOT NULL | 分岐先頭状態名 |
 | execution_id | uuid | UNIQUE, FK → executions, NOT NULL | 子 execution |
 | join_state | varchar(256) | NOT NULL | Join 状態名 |
@@ -313,7 +313,7 @@ Hosted Runtime が Fork を物理子 execution に展開したときの親子リ
 | created_at | timestamptz | NOT NULL | 作成日時 |
 | updated_at | timestamptz | NOT NULL | 更新日時 |
 
-**主キー:** `(parent_execution_id, fork_state, branch_state)`。**一意:** `execution_id`。両 FK は `executions` へ ON DELETE CASCADE。
+**主キー:** `(parent_execution_id, fork_node_id, branch_state)`。**一意:** `execution_id`。両 FK は `executions` へ ON DELETE CASCADE。
 
 ### 2.10.2b execution_runtime_checkpoints
 

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -1,7 +1,9 @@
 # スキーマ定義
 
-Version: 1.16
+Version: 1.17
 Project: 実行型ステートマシン
+
+**Version 1.17（2026-08-07）**: `execution_branches` に `states_json` / `vars_json` を追加（Join 後の親 Context マージ用）。
 
 **Version 1.16（2026-08-06）**: `execution_branches` 追加（Hosted Fork 物理子の親子リンク正本。`fork_node_id` は実行ノード ID、`join_state` / `branch_state` は定義の状態名空間）。
 
@@ -310,6 +312,8 @@ Hosted Runtime が Fork を物理子 execution に展開したときの親子リ
 | join_state | varchar(256) | NOT NULL | Join 状態名 |
 | status | varchar(64) | NOT NULL | Running / Completed / Failed / Cancelled |
 | output_json | jsonb | NULL | 終端 output 退避（任意） |
+| states_json | jsonb | NULL | 子終端時点の `states`（Join 後の親 Context マージ用。任意） |
+| vars_json | jsonb | NULL | 子終端時点の `vars`（Join 後の親 Context マージ用。任意） |
 | created_at | timestamptz | NOT NULL | 作成日時 |
 | updated_at | timestamptz | NOT NULL | 更新日時 |
 

--- a/docs/reference/logging-property-keys.md
+++ b/docs/reference/logging-property-keys.md
@@ -4,6 +4,12 @@
 
 Service API と Engine の構造化ログで、同じ概念に同じキー名を使う。
 
+## 出力手段（必須）
+
+- **`ILogger.LogInformation` / `LogWarning` / `LogError` 等を直接呼ばない。**
+- `[LoggerMessage]`（ソース生成）の partial メソッド経由で出す（例: `ExecutionServiceLogMessages`、`ForkExpansionLogMessages`）。
+- 新規カテゴリは `*LogMessages.cs` にまとめ、EventId 帯が既存と衝突しないようにする。
+
 ## Message テンプレート（Service API）
 
 - **ラベル**（`=` の左）: **PascalCase**（例: `TraceId`, `TenantId`）
@@ -18,6 +24,8 @@ Service API と Engine の構造化ログで、同じ概念に同じキー名を
 | 相関 ID | `TraceId` | API / Engine | `traceparent` / `X-Trace-Id` から解決 |
 | テナント | `TenantId` | API | 解決済み `tenants.tenant_id`（UUID）。未解決パスでは null |
 | ワークフロー ID | `ExecutionId` | API enrich / 実行系 / Engine | route `{id}` 由来（display ID の場合あり） |
+| 親ワークフロー ID | `ParentExecutionId` | Fork 展開 | 物理子展開時の親 |
+| Fork ノード ID | `ForkNodeId` | Fork 展開 | 親実行グラフ上の Fork 到達インスタンス |
 | 状態名 | `StateName` | Engine | State 実行ログ・Warning |
 | 定義 ID | `DefinitionId` | API enrich | route `{id}` 由来（display ID の場合あり） |
 | グラフ定義 ID | `GraphDefinitionId` | API enrich | route `{graphId}` |

--- a/docs/samples/ui-cyclic-fork.yaml
+++ b/docs/samples/ui-cyclic-fork.yaml
@@ -1,0 +1,75 @@
+# =============================================================================
+# 公式サンプル: 循環 Fork / Join（nodes 形式・version: 1）
+# -----------------------------------------------------------------------------
+# 配置: docs/samples/ui-cyclic-fork.yaml
+#
+# Fork → 並列枝 → Join のあと、イベントで同じ Fork に戻れる。
+# 再到達のたびに親グラフ上で別 nodeId の Fork / Join が生え、
+# 合成辺は Join 到達 nodeId に固定される（循環対応）。
+#
+# 起動 input 例: {}
+# 操作:
+#   1. 実行開始 → 1 周目の Fork/Join まで進む（decide で待機）
+#   2. Resume / Publish「Again」→ Fork 再到達（2 周目）
+#   3. 「Finish」→ 終了
+#
+# CLI の Statevia.Service.Cli は states 形式のみ。本ファイルは Service API 経由で検証してください。
+# =============================================================================
+
+version: 1
+
+workflow:
+  id: sample.cyclic.fork
+  name: CyclicForkSample
+  description: >
+    Fork1 → Task1a/Task1b → Join1 → decide。
+    decide で Again なら同じ Fork1 へ戻り、Finish で終端する。
+    循環 Join 依存（Join 同士の相互待機）ではなく、制御フローの Fork 再到達。
+
+nodes:
+  - id: cycle.start
+    type: start
+    label: 開始
+    next: cycle.fork
+
+  - id: cycle.fork
+    type: fork
+    label: 並列ラウンド
+    branches:
+      - cycle.work.a
+      - cycle.work.b
+
+  - id: cycle.work.a
+    type: action
+    label: 作業 A
+    action: noop
+    input:
+      lane: a
+    next: cycle.join
+
+  - id: cycle.work.b
+    type: action
+    label: 作業 B
+    action: sleep
+    input:
+      duration: 1s
+      lane: b
+    next: cycle.join
+
+  - id: cycle.join
+    type: join
+    label: ラウンド合流
+    mode: all
+    next: cycle.decide
+
+  # 自己遷移禁止のため、Join 直後に別ノードで分岐する
+  - id: cycle.decide
+    type: wait
+    label: 再実行するか
+    events:
+      Again: cycle.fork
+      Finish: cycle.end
+
+  - id: cycle.end
+    type: end
+    label: 完了

--- a/docs/samples/ui-nested-fork.yaml
+++ b/docs/samples/ui-nested-fork.yaml
@@ -1,0 +1,91 @@
+# =============================================================================
+# 公式サンプル: ネスト Fork / Join（nodes 形式・version: 1）
+# -----------------------------------------------------------------------------
+# 配置: docs/samples/ui-nested-fork.yaml
+#
+# 外側 Fork の一方の枝先頭が内側 Fork。内側 Join の next が外側 Join。
+# nodes 変換は「枝が Join を供給する」（直接 next、またはネスト Fork→内側 Join→外口）
+# で外側 Join と照合する。
+#
+# 起動 input 例: {}
+# CLI の Statevia.Service.Cli は states 形式のみ。本ファイルは Service API 経由で検証してください。
+# =============================================================================
+
+version: 1
+
+workflow:
+  id: sample.nested.fork
+  name: NestedForkSample
+  description: >
+    外側並列（即時枝 + 内側並列）→ 内側合流 → 外側合流 → 完了。
+    Hosted では外側・内側とも物理子 execution に展開される。
+
+nodes:
+  - id: nest.start
+    type: start
+    label: 開始
+    next: nest.outer.fork
+
+  - id: nest.outer.fork
+    type: fork
+    label: 外側並列
+    branches:
+      - nest.outer.fast
+      - nest.inner.fork
+
+  - id: nest.outer.fast
+    type: action
+    label: 外側・即時処理
+    action: noop
+    input:
+      lane: outer-fast
+    next: nest.outer.join
+
+  - id: nest.inner.fork
+    type: fork
+    label: 内側並列
+    branches:
+      - nest.inner.a
+      - nest.inner.b
+
+  - id: nest.inner.a
+    type: action
+    label: 内側 A
+    action: sleep
+    input:
+      duration: 1s
+      lane: inner-a
+    next: nest.inner.join
+
+  - id: nest.inner.b
+    type: action
+    label: 内側 B
+    action: sleep
+    input:
+      duration: 2s
+      lane: inner-b
+    next: nest.inner.join
+
+  - id: nest.inner.join
+    type: join
+    label: 内側合流
+    mode: all
+    next: nest.outer.join
+
+  - id: nest.outer.join
+    type: join
+    label: 外側合流
+    mode: all
+    next: nest.notify
+
+  - id: nest.notify
+    type: action
+    label: 完了通知
+    action: noop
+    input:
+      phase: nested-done
+    next: nest.end
+
+  - id: nest.end
+    type: end
+    label: 完了

--- a/docs/specifications/definition.md
+++ b/docs/specifications/definition.md
@@ -559,6 +559,7 @@ Service API の **`GET /v1/definitions/schema/nodes`** が返すスキーマに�
 - **wait**: 正本は **`events`**（イベント名 → 次ノード ID）。単一イベントの旧形式 `event` + `next` も受理し、Loader が `events` へ正規化する。`timeout`（ISO 8601 duration）は現行変換では未使用。
 - **fork**: `branches` に並列ブランチのノード ID の配列。
 - **join**: すべてのブランチの完了を待ち、`next` へ進む。
+  - Join と Fork の対応: 各枝先頭が当該 Join を**供給**する一意の Fork を選ぶ。供給は (1) 枝の `next` が直接 Join、または (2) 枝先頭が内側 Fork で、その内側 Join の `next` 連鎖が当該 Join に到達すること（ネスト）。`Join.all` は外側 Fork の枝先頭集合になる。例: [`docs/samples/ui-nested-fork.yaml`](../samples/ui-nested-fork.yaml)。
 
 ### 2.3 例（Nodes 形式・抜粋）
 

--- a/docs/specifications/definition.md
+++ b/docs/specifications/definition.md
@@ -561,7 +561,7 @@ Service API の **`GET /v1/definitions/schema/nodes`** が返すスキーマに�
 - **wait**: 正本は **`events`**（イベント名 → 次ノード ID）。単一イベントの旧形式 `event` + `next` も受理し、Loader が `events` へ正規化する。`timeout`（ISO 8601 duration）は現行変換では未使用。
 - **fork**: `branches` に並列ブランチのノード ID の配列。
 - **join**: すべてのブランチの完了を待ち、`next` へ進む。
-  - Join と Fork の対応: 各枝先頭が当該 Join を**供給**する一意の Fork を選ぶ。供給は (1) 枝の `next` が直接 Join、または (2) 枝先頭が内側 Fork で、その内側 Join の `next` 連鎖が当該 Join に到達すること（ネスト）。`Join.all` は外側 Fork の枝先頭集合になる。例: [`docs/samples/ui-nested-fork.yaml`](../samples/ui-nested-fork.yaml)。
+  - Join と Fork の対応: 各枝先頭が当該 Join を**供給**する一意の Fork を選ぶ。供給は (1) 枝の `next` が直接 Join、または (2) 枝先頭が内側 Fork で、その内側 Join の `next` 連鎖が当該 Join に到達すること（ネスト）。`Join.all` は外側 Fork の枝先頭集合になる。例: [`docs/samples/ui-nested-fork.yaml`](../samples/ui-nested-fork.yaml)。Fork 再到達（循環）の例: [`docs/samples/ui-cyclic-fork.yaml`](../samples/ui-cyclic-fork.yaml)。
 
 ### 2.3 例（Nodes 形式・抜粋）
 

--- a/docs/specifications/definition.md
+++ b/docs/specifications/definition.md
@@ -3,9 +3,9 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Specification |
-| Version | 1.5.0 |
-| 更新日 | 2026-07-29 |
-| 関連 | [concepts/definition.md](../concepts/definition.md), [execution/wait-cancel.md](execution/wait-cancel.md) |
+| Version | 1.5.1 |
+| 更新日 | 2026-08-09 |
+| 関連 | [concepts/definition.md](../concepts/definition.md), [execution/wait-cancel.md](execution/wait-cancel.md), [execution/fork-join.md](execution/fork-join.md) |
 
 ---
 
@@ -240,6 +240,8 @@ Wait は **Signal**（`events`）と **Subscribe**（`subscribe`）の二モー�
 
 - **join.all**: 完了を待つ状態名のリスト。すべてが完了すると `Joined` 事実が発生し、`on.Joined` で次へ遷移できる。
 - Join 状態は合成ノードとして実行され、**`action` は指定しない**（`wait` と同様に `action` 併記は Level 1 検証エラー）。
+- **Hosted Runtime**: Fork は物理子 execution に展開される。定義語彙（`fork` / `join.all` / `$.states…`）は維持する。実行時契約（兄弟参照不可・Join 後の親 Context マージ・読みモデル合成）は [execution/fork-join.md](execution/fork-join.md) を正とする。
+- **兄弟参照**: Join 前に同一 Fork の兄弟の `$.states…` / `$.vars…` を参照してはならない。Join 後は親へマージされた結果のみ参照できる（キー衝突は後勝ち）。
 
 ### 1.5 例（States 形式）
 
@@ -725,7 +727,7 @@ Nodes 形式は、実行前に **states 形式の CompiledWorkflowDefinition に
 - 状態名（states 形式）またはノード ID（nodes 形式）は一意とする。
 - 自己遷移（A → A）は禁止。
 - Join の all / branches は既存の状態・ノードを参照する。
-- Fork と Join は制御構造であり、実行順序の保証範囲は実装に依存する。
+- Fork と Join は制御構造であり、実行順序の保証範囲は実装に依存する。Hosted では [execution/fork-join.md](execution/fork-join.md) の物理子契約に従う。
 - Wait は指定イベントで再開する待機を表す。
 
 ---

--- a/docs/specifications/execution/execution-graph.md
+++ b/docs/specifications/execution/execution-graph.md
@@ -3,9 +3,9 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Specification |
-| Version | 1.1 |
-| 更新日 | 2026-05-11 |
-| 関連 | [api-http.md](../api-http.md), [concepts/execution-model.md](../../concepts/execution-model.md) |
+| Version | 1.2 |
+| 更新日 | 2026-08-09 |
+| 関連 | [api-http.md](../api-http.md), [concepts/execution-model.md](../../concepts/execution-model.md), [fork-join.md](fork-join.md) |
 
 ---
 
@@ -14,6 +14,7 @@
 - **MUST**: JSON キーは **camelCase** とする。
 - **MUST**: 実行グラフの `edges[*].from` / `to` は**実行ノード ID**（`nodes[*].nodeId`）を指す（定義キャンバスの nodeId とは別）。
 - **MUST**: HTTP GET graph の正本は DB projection と整合させる（in-process export はデバッグ用途）。
+- **MUST**: Hosted で物理 Fork がある親の `GET …/graph` は、永続生グラフを **GET 時に論理 Fork/Join へ合成**して返す（UI は分割非認知。[fork-join.md](fork-join.md)）。
 - **SHOULD**: `input` / `output` を外部ログへ載せる前に IO-14 に従いマスキングする。
 
 ---
@@ -104,7 +105,7 @@
 | `output` | `any \| null` | 任意 | 状態出力。`object` としてシリアライズ |
 | `input` | `any \| null` | 任意 | 当該状態実行に渡された入力（説明責任・Join 合成入力の記録に利用） |
 | `attempt` | `number` | 必須 | 試行回数（現行実装では主に `1`） |
-| `workerId` | `string \| null` | 任意 | ワーカー識別子。現行では未指定時に `nodeId` と同値が入ることがある |
+| `workerId` | `string \| null` | 任意 | ワーカー識別子。現行では未指定時に `nodeId` と同値が入ることがある。親グラフの **合成表示**では、分岐を実行した子グラフの `workerId` を引き継ぐ |
 | `waitKey` | `string \| null` | 任意 | 単一イベント Wait の互換キー（`allowedEvents` が 1 件のときそのイベント名。複数イベント時は `null`） |
 | `allowedEvents` | `string[] \| null` | 任意 | Wait ノードの許可イベント名一覧（`WaitEventRouteTable` のキー）。非 Wait では `null` |
 | `canceledByExecution` | `boolean` | 必須 | 実行全体のキャンセルにより当該ノードがキャンセル扱いになったか |
@@ -204,9 +205,10 @@ JSON プロパティ名は **camelCase** のため、C# の `From` / `To` は **
 
 ## 7. API/UI 境界
 
-- `GET /v1/executions/{id}/graph` の本文は、本書の **`nodes` / `edges` 構造をそのまま** `execution_graph_snapshots` から返す（キー名・意味はエンジン `ExportJson` と一致）。
+- `GET /v1/executions/{id}/graph` の本文は、本書の **`nodes` / `edges` 構造**を返す（キー名・意味はエンジン `ExportJson` と一致）。
+- 永続は `execution_graph_snapshots` の生グラフ。Hosted の親 execution で物理子がある場合、応答は **GET 時合成**後の論理 Fork/Join グラフになる（合成規則・Join 辺の `nodeId` 固定は [fork-join.md](fork-join.md)）。
 - API は実行グラフの `conditionRouting` を透過的に返却する。
-- UI は `conditionRouting` を再評価しない（表示専用データとして扱う）。
+- UI は `conditionRouting` を再評価しない（表示専用データとして扱う）。物理子や `execution_branches` を意識しない。
 - UI が定義グラフ（`GET /v1/graphs/{graphId}`）と合成するときは、**実行ノードの `nodeId` と定義ノードの `nodeId`（状態名）が一致しない**前提で、`stateName` やエッジの `from`/`to` を用いて対応付ける（`ui/studio/features/executions/lib/mergeGraph.ts`）。
 
 詳細は `docs/specifications/api-http.md` を参照。

--- a/docs/specifications/execution/fork-join.md
+++ b/docs/specifications/execution/fork-join.md
@@ -3,9 +3,9 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Specification |
-| Version | 1.0 |
-| 更新日 | 2026-07-07 |
-| 関連 | [fsm.md](fsm.md) |
+| Version | 1.1 |
+| 更新日 | 2026-08-09 |
+| 関連 | [fsm.md](fsm.md), [../definition.md](../definition.md), [wait-cancel.md](wait-cancel.md), [execution-graph.md](execution-graph.md), [../../concepts/durability.md](../../concepts/durability.md), [../../reference/database-schema.md](../../reference/database-schema.md) |
 
 ---
 
@@ -13,6 +13,10 @@
 
 - **MUST**: Fork / Join は**制御ノード**であり、通常の状態（State）ではない。
 - **MUST**: Join は依存する全分岐から所定の事実が揃うまで次へ進んではならない。
+- **MUST**: **Hosted Runtime** では Fork 到達時に各分岐を**物理子 execution** として展開する（論理 Fork 互換フラグは設けない）。
+- **MUST**: **Join 前**は同一 Fork の兄弟分岐同士が互いの `$.states…` / `$.vars…` / Context を参照してはならない。
+- **MUST**: **Join 後（成功）**は子の `states` / `vars` を親 Execution Context へマージし、親の後続から `$.states.<Name>.output` 等を解決できること。キー衝突は子完了信号の**適用順で後勝ち**（Failed にしない）。
+- **MUST**: 親の `GET …/graph` / `GET …/events` は、UI が物理分割を意識しないよう **GET 時に論理 1 実行へ合成**する（永続への二重書き込みはしない）。
 - **SHOULD**: Fork は定義上で並列開始する状態集合を明示する。
 
 ---
@@ -23,11 +27,60 @@ Fork は複数の状態を同時に開始します。
 
 例：A -> Fork -> [B, C]
 
+### Hosted Runtime（物理子 execution）
+
+Hosted（Service API / Runtime Worker）では、親が Fork に到達すると Runtime が次を行う。
+
+1. 各分岐先頭に対し子 `executionId` を作成し、親子リンクを **`execution_branches`** に永続化する。
+2. 親の `ExecutionSecuritySnapshot` を子へ**継承**する（初版は再評価しない）。
+3. 各子へ `Start` work item を enqueue する（`InitialState` = 分岐先頭、input は定義の写像）。
+4. 親は分岐本体を自インスタンスでは走らず、Join 待ちに入る（Unload 可）。
+
+識別の軸:
+
+| 列 | 意味 |
+| --- | --- |
+| `fork_node_id` | 親実行グラフ上の Fork **到達**インスタンス（実行ノード ID）。循環再到達の区別に使う |
+| `join_state` / `branch_state` | 定義の状態名空間（Join 解決・子開始状態） |
+| `execution_id` | 子 execution |
+| `status` | 分岐完了事実の要約（Running / Completed / Failed / Cancelled） |
+
+スキーマ詳細は [database-schema.md](../../reference/database-schema.md)（`execution_branches`）を参照。
+
+展開の一時失敗では親をすぐ Failed にしない。**展開リトライ**し、試行上限超過後に残子を Cancel したうえで親を **Failed** にする。展開成功後の子失敗は Join 規則に従う。
+
+スタンドアロン Engine（Host なし）は従来の**論理 Fork**（同一 execution 上の並列）を維持してよい。
+
+### ネスト
+
+子の中の Fork も同一メカニズムで再帰的に物理分割する。
+
+---
+
 ## Join
 
 Join は複数の状態からの事実を待ってから次に進みます。
 
 例：Join(E) = all(B, C)
+
+### Hosted での集約
+
+- Join 充足の正本は **`execution_branches`**（親を Engine の durable Wait に載せない）。
+- 子が終端すると、親向け `Resume`（`mode=event`）に予約イベント名 **`statevia.event.child.completed`** を載せて enqueue する。
+- Worker は当該予約イベントを Engine の通常 Wait Resume ではなく **Join 再評価**へ振る。
+- 全必須分岐が Completed → Join 充足。いずれかが Failed / Cancelled → 親へ失敗／キャンセル伝播。
+
+### Context マージと兄弟参照
+
+| 時点 | 契約 |
+| --- | --- |
+| Join 前 | 兄弟分岐間の `$.states…` / `$.vars…` / Context 参照は**不可**。使えるのは Fork 時の親→子 input 写像のみ |
+| Join 後（成功） | 各子の完了 `states` と終端 `vars` を親 Context へマージ。後続の `input.path: $.states.A.output` 等は親上で解決する。同一キー衝突は適用順の**後勝ち** |
+| Join 失敗／Cancel 伝播 | 不完全な Context マージは必須としない |
+
+定義 DSL 上の候補 input 辞書（分岐キー → 子 output）の形は従来どおり維持する。詳細の記述例は [definition.md](../definition.md) の Fork/Join と input 節を参照。
+
+---
 
 ## ルール
 
@@ -35,7 +88,31 @@ Join は複数の状態からの事実を待ってから次に進みます。
 - Join は依存状態が事実を生成するたびに評価されます。
 - 必須状態のいずれかが失敗またはキャンセルされた場合、Join は失敗します。
 - Fork は実行順序を保証しません。
+- 親 Cancel は未終端の物理子へ Cancel をカスケードする（[wait-cancel.md](wait-cancel.md)）。
+- 分岐上の Wait へのイベント配送は**子 execution** を正とする（親 ID への誤配送を解決または拒否する）。
 
-## ネストされた Fork / Join
+---
 
-Fork と Join はネストして組み合わせることができます。Join ノードは他の Join ノードに依存することができます。
+## 読みモデル（UI は分割非認知）
+
+クライアント／UI は物理子や `execution_branches` を意識しない。親の読み取り API が論理 1 実行に見せる。
+
+### 実行グラフ（`GET …/graph`）
+
+- 永続 `execution_graph_snapshots` は親／子それぞれの**生グラフ**のまま。
+- 親 GET 時に論理 Fork/Join へ**合成**する。
+- 合成ノードの **`workerId`（必要なら `attempt`）は当該分岐を実行した子グラフから引き継ぐ**。
+- Join 辺は Join 到達の実行 `nodeId` に固定する（状態名のみでは循環再到達で曖昧）。
+- 親 Fork からの Fork 辺は `branch_state` ノードへだけ張り、親 Join への Join 辺は枝先頭状態の終端に限る。ネスト内側 Join → 外側 Join は Next とし、定義にない合流枝に見えないようにする。
+
+詳細契約は [execution-graph.md](execution-graph.md)。
+
+### イベントタイムライン（`GET …/events`）
+
+- 親と再帰子孫の `event_store` を **GET 時合成**する（親への二重 append はしない）。
+- 並び: `occurred_at` 昇順。同刻は親（ルート）優先 → `execution_id` → 永続 `seq`。
+- 応答の `seq` は**合成通番**。`afterSeq` は合成 seq 基準のページング。
+- **子孫**の `WorkflowStarted` / `WorkflowCancelled` は落とす。子孫の `EventPublished` と親のマップ対象型は残す。
+- `GraphUpdated` の patch は合成グラフ由来。タイムライン上の `executionId` は親の displayId。
+
+配送（子 ID 正本）と表示合成は別関心である。

--- a/docs/specifications/execution/wait-cancel.md
+++ b/docs/specifications/execution/wait-cancel.md
@@ -3,9 +3,9 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Specification |
-| Version | 1.3 |
-| 更新日 | 2026-08-03 |
-| 関連 | [fsm.md](fsm.md), [../definition.md](../definition.md), [concepts/execution-model.md](../../concepts/execution-model.md) |
+| Version | 1.4 |
+| 更新日 | 2026-08-09 |
+| 関連 | [fsm.md](fsm.md), [../definition.md](../definition.md), [fork-join.md](fork-join.md), [concepts/execution-model.md](../../concepts/execution-model.md) |
 
 ---
 
@@ -47,6 +47,10 @@ Wait は定義の許可イベントのいずれかが発生するまで状態実
 
 Fork 並列 Wait や複数イベント Wait では必ず Resume（nodeId + eventName）を使う。
 
+### Hosted 物理 Fork での配送
+
+Hosted では分岐が物理子 execution になるため、分岐上の Wait へのイベント／Resume は**子の `execution_id`** を正とする。親 ID 宛てに届いた場合は子へ解決し、解決不能なら 422。topic ingress（Subscribe）も購読行の子 `execution_id` を用いる。表示用の親イベントタイムライン合成とは別関心である（[fork-join.md](fork-join.md)）。
+
 ### Topic / key ingress（Subscribe）
 
 `POST /v1/events` は `{ topic, key?, payload? }` を受け付けます（`topic` 必須。`event` は送らない）。照合は `execution_wait_subscriptions` で、正規化後の **topic かつ key の厳密一致**です。`key` 省略・空白は `""` です。一致した各購読の `resume_event_name` で Resume ワークを投入し、対象が 0 件でも `204 No Content` を返します。`payload` は将来の Wait 入力拡張のため受理しますが、この段階では再開値に反映しません。
@@ -59,6 +63,7 @@ Wait 定義側は `wait.subscribe`（topic 必須・key 任意・next 必須）�
 - エンジンは実行中の状態を強制終了しません。
 - Cancelled は実行が実際に停止したときにのみ発行されます。
 - 依存状態は自動的にキャンセルされます。
+- Hosted で親を Cancel した場合、未終端の物理子へ Cancel work item をカスケードする（[fork-join.md](fork-join.md)）。
 
 ## 状態
 

--- a/infrastructure/Statevia.Infrastructure.Persistence/CoreDbContext.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/CoreDbContext.cs
@@ -107,6 +107,11 @@ internal class CoreDbContext : DbContext, ICoreDatabase
         public const string CheckpointJson = "checkpoint_json";
         public const string OwnerWorkerId = "owner_worker_id";
         public const string OwnerGeneration = "owner_generation";
+        public const string ParentExecutionId = "parent_execution_id";
+        public const string ForkState = "fork_state";
+        public const string JoinState = "join_state";
+        public const string BranchState = "branch_state";
+        public const string OutputJson = "output_json";
     }
 
     private static class ColumnTypes
@@ -138,6 +143,7 @@ internal class CoreDbContext : DbContext, ICoreDatabase
     public DbSet<ExecutionCursorRow> ExecutionCursors => Set<ExecutionCursorRow>();
     public DbSet<ExecutionWaitRow> ExecutionWaits => Set<ExecutionWaitRow>();
     public DbSet<ExecutionWaitSubscriptionRow> ExecutionWaitSubscriptions => Set<ExecutionWaitSubscriptionRow>();
+    public DbSet<ExecutionBranchRow> ExecutionBranches => Set<ExecutionBranchRow>();
     public DbSet<ExecutionCheckpointDocument> ExecutionCheckpoints => Set<ExecutionCheckpointDocument>();
     public DbSet<ExecutionWorkItemRow> ExecutionWorkItems => Set<ExecutionWorkItemRow>();
     public DbSet<CommandDedupRow> CommandDedup => Set<CommandDedupRow>();
@@ -373,6 +379,35 @@ internal class CoreDbContext : DbContext, ICoreDatabase
             e.HasOne<ExecutionWaitRow>()
                 .WithMany()
                 .HasForeignKey(x => new { x.ExecutionId, x.NodeId })
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // execution_branches（Fork 物理子の親子リンク正本）
+        modelBuilder.Entity<ExecutionBranchRow>(e =>
+        {
+            e.ToTable("execution_branches");
+            e.HasKey(x => new { x.ParentExecutionId, x.ForkState, x.BranchState });
+            e.Property(x => x.ParentExecutionId).HasColumnName(Columns.ParentExecutionId);
+            e.Property(x => x.ExecutionId).HasColumnName(Columns.ExecutionId);
+            e.Property(x => x.ForkState).HasMaxLength(256).HasColumnName(Columns.ForkState);
+            e.Property(x => x.JoinState).HasMaxLength(256).HasColumnName(Columns.JoinState);
+            e.Property(x => x.BranchState).HasMaxLength(256).HasColumnName(Columns.BranchState);
+            e.Property(x => x.Status).HasMaxLength(64).HasColumnName(Columns.Status);
+            e.Property(x => x.OutputJson)
+                .HasColumnName(Columns.OutputJson)
+                .HasColumnType(ColumnTypes.Jsonb);
+            e.Property(x => x.CreatedAt).HasColumnName(Columns.CreatedAt);
+            e.Property(x => x.UpdatedAt).HasColumnName(Columns.UpdatedAt);
+            e.HasIndex(x => x.ExecutionId).IsUnique();
+            e.HasIndex(x => x.ParentExecutionId);
+
+            e.HasOne<ExecutionRow>()
+                .WithMany()
+                .HasForeignKey(x => x.ParentExecutionId)
+                .OnDelete(DeleteBehavior.Cascade);
+            e.HasOne<ExecutionRow>()
+                .WithMany()
+                .HasForeignKey(x => x.ExecutionId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 

--- a/infrastructure/Statevia.Infrastructure.Persistence/CoreDbContext.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/CoreDbContext.cs
@@ -108,7 +108,7 @@ internal class CoreDbContext : DbContext, ICoreDatabase
         public const string OwnerWorkerId = "owner_worker_id";
         public const string OwnerGeneration = "owner_generation";
         public const string ParentExecutionId = "parent_execution_id";
-        public const string ForkState = "fork_state";
+        public const string ForkNodeId = "fork_node_id";
         public const string JoinState = "join_state";
         public const string BranchState = "branch_state";
         public const string OutputJson = "output_json";
@@ -386,10 +386,10 @@ internal class CoreDbContext : DbContext, ICoreDatabase
         modelBuilder.Entity<ExecutionBranchRow>(e =>
         {
             e.ToTable("execution_branches");
-            e.HasKey(x => new { x.ParentExecutionId, x.ForkState, x.BranchState });
+            e.HasKey(x => new { x.ParentExecutionId, x.ForkNodeId, x.BranchState });
             e.Property(x => x.ParentExecutionId).HasColumnName(Columns.ParentExecutionId);
             e.Property(x => x.ExecutionId).HasColumnName(Columns.ExecutionId);
-            e.Property(x => x.ForkState).HasMaxLength(256).HasColumnName(Columns.ForkState);
+            e.Property(x => x.ForkNodeId).HasMaxLength(64).HasColumnName(Columns.ForkNodeId);
             e.Property(x => x.JoinState).HasMaxLength(256).HasColumnName(Columns.JoinState);
             e.Property(x => x.BranchState).HasMaxLength(256).HasColumnName(Columns.BranchState);
             e.Property(x => x.Status).HasMaxLength(64).HasColumnName(Columns.Status);

--- a/infrastructure/Statevia.Infrastructure.Persistence/CoreDbContext.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/CoreDbContext.cs
@@ -112,6 +112,8 @@ internal class CoreDbContext : DbContext, ICoreDatabase
         public const string JoinState = "join_state";
         public const string BranchState = "branch_state";
         public const string OutputJson = "output_json";
+        public const string StatesJson = "states_json";
+        public const string VarsJson = "vars_json";
     }
 
     private static class ColumnTypes
@@ -395,6 +397,12 @@ internal class CoreDbContext : DbContext, ICoreDatabase
             e.Property(x => x.Status).HasMaxLength(64).HasColumnName(Columns.Status);
             e.Property(x => x.OutputJson)
                 .HasColumnName(Columns.OutputJson)
+                .HasColumnType(ColumnTypes.Jsonb);
+            e.Property(x => x.StatesJson)
+                .HasColumnName(Columns.StatesJson)
+                .HasColumnType(ColumnTypes.Jsonb);
+            e.Property(x => x.VarsJson)
+                .HasColumnName(Columns.VarsJson)
                 .HasColumnType(ColumnTypes.Jsonb);
             e.Property(x => x.CreatedAt).HasColumnName(Columns.CreatedAt);
             e.Property(x => x.UpdatedAt).HasColumnName(Columns.UpdatedAt);

--- a/infrastructure/Statevia.Infrastructure.Persistence/DependencyInjection/PersistenceServiceCollectionExtensions.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/DependencyInjection/PersistenceServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class PersistenceServiceCollectionExtensions
         services.AddScoped<IExecutionRepository, ExecutionRepository>();
         services.AddScoped<IExecutionCursorRepository, ExecutionCursorRepository>();
         services.AddScoped<IExecutionWaitRepository, ExecutionWaitRepository>();
+        services.AddScoped<IExecutionBranchRepository, ExecutionBranchRepository>();
         services.AddScoped<IExecutionWorkQueue, ExecutionWorkQueue>();
         services.AddScoped<IExecutionCheckpointStore, PostgresExecutionCheckpointStore>();
         services.AddScoped<ICommandDedupRepository, CommandDedupRepository>();

--- a/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260805155602_AddExecutionBranches.Designer.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260805155602_AddExecutionBranches.Designer.cs
@@ -303,10 +303,10 @@ namespace Statevia.Infrastructure.Persistence.Migrations
                         .HasColumnType("uuid")
                         .HasColumnName("parent_execution_id");
 
-                    b.Property<string>("ForkState")
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
-                        .HasColumnName("fork_state");
+                    b.Property<string>("ForkNodeId")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)")
+                        .HasColumnName("fork_node_id");
 
                     b.Property<string>("BranchState")
                         .HasMaxLength(256)
@@ -341,7 +341,7 @@ namespace Statevia.Infrastructure.Persistence.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
 
-                    b.HasKey("ParentExecutionId", "ForkState", "BranchState");
+                    b.HasKey("ParentExecutionId", "ForkNodeId", "BranchState");
 
                     b.HasIndex("ExecutionId")
                         .IsUnique();

--- a/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260805155602_AddExecutionBranches.Designer.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260805155602_AddExecutionBranches.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Statevia.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Statevia.Infrastructure.Persistence;
 namespace Statevia.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(CoreDbContext))]
-    partial class CoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805155602_AddExecutionBranches")]
+    partial class AddExecutionBranches
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260805155602_AddExecutionBranches.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260805155602_AddExecutionBranches.cs
@@ -16,7 +16,7 @@ namespace Statevia.Infrastructure.Persistence.Migrations
                 columns: table => new
                 {
                     parent_execution_id = table.Column<Guid>(type: "uuid", nullable: false),
-                    fork_state = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    fork_node_id = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
                     branch_state = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
                     execution_id = table.Column<Guid>(type: "uuid", nullable: false),
                     join_state = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
@@ -27,7 +27,7 @@ namespace Statevia.Infrastructure.Persistence.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_execution_branches", x => new { x.parent_execution_id, x.fork_state, x.branch_state });
+                    table.PrimaryKey("PK_execution_branches", x => new { x.parent_execution_id, x.fork_node_id, x.branch_state });
                     table.ForeignKey(
                         name: "FK_execution_branches_executions_execution_id",
                         column: x => x.execution_id,

--- a/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260805155602_AddExecutionBranches.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260805155602_AddExecutionBranches.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Statevia.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExecutionBranches : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "execution_branches",
+                columns: table => new
+                {
+                    parent_execution_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    fork_state = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    branch_state = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    execution_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    join_state = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    status = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    output_json = table.Column<string>(type: "jsonb", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_execution_branches", x => new { x.parent_execution_id, x.fork_state, x.branch_state });
+                    table.ForeignKey(
+                        name: "FK_execution_branches_executions_execution_id",
+                        column: x => x.execution_id,
+                        principalTable: "executions",
+                        principalColumn: "execution_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_execution_branches_executions_parent_execution_id",
+                        column: x => x.parent_execution_id,
+                        principalTable: "executions",
+                        principalColumn: "execution_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_execution_branches_execution_id",
+                table: "execution_branches",
+                column: "execution_id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_execution_branches_parent_execution_id",
+                table: "execution_branches",
+                column: "parent_execution_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "execution_branches");
+        }
+    }
+}

--- a/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260807093411_AddExecutionBranchContextJson.Designer.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260807093411_AddExecutionBranchContextJson.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Statevia.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Statevia.Infrastructure.Persistence;
 namespace Statevia.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(CoreDbContext))]
-    partial class CoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807093411_AddExecutionBranchContextJson")]
+    partial class AddExecutionBranchContextJson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260807093411_AddExecutionBranchContextJson.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Migrations/20260807093411_AddExecutionBranchContextJson.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Statevia.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExecutionBranchContextJson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "states_json",
+                table: "execution_branches",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "vars_json",
+                table: "execution_branches",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "states_json",
+                table: "execution_branches");
+
+            migrationBuilder.DropColumn(
+                name: "vars_json",
+                table: "execution_branches");
+        }
+    }
+}

--- a/infrastructure/Statevia.Infrastructure.Persistence/Migrations/CoreDbContextModelSnapshot.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Migrations/CoreDbContextModelSnapshot.cs
@@ -300,10 +300,10 @@ namespace Statevia.Infrastructure.Persistence.Migrations
                         .HasColumnType("uuid")
                         .HasColumnName("parent_execution_id");
 
-                    b.Property<string>("ForkState")
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
-                        .HasColumnName("fork_state");
+                    b.Property<string>("ForkNodeId")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)")
+                        .HasColumnName("fork_node_id");
 
                     b.Property<string>("BranchState")
                         .HasMaxLength(256)
@@ -338,7 +338,7 @@ namespace Statevia.Infrastructure.Persistence.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
 
-                    b.HasKey("ParentExecutionId", "ForkState", "BranchState");
+                    b.HasKey("ParentExecutionId", "ForkNodeId", "BranchState");
 
                     b.HasIndex("ExecutionId")
                         .IsUnique();

--- a/infrastructure/Statevia.Infrastructure.Persistence/Repositories/ExecutionBranchRepository.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Repositories/ExecutionBranchRepository.cs
@@ -23,7 +23,7 @@ internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
             var existing = await db.ExecutionBranches
                 .FirstOrDefaultAsync(
                     x => x.ParentExecutionId == branch.ParentExecutionId
-                         && x.ForkState == branch.ForkState
+                         && x.ForkNodeId == branch.ForkNodeId
                          && x.BranchState == branch.BranchState,
                     ct)
                 .ConfigureAwait(false);
@@ -34,7 +34,7 @@ internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
                 {
                     ParentExecutionId = branch.ParentExecutionId,
                     ExecutionId = branch.ExecutionId,
-                    ForkState = branch.ForkState,
+                    ForkNodeId = branch.ForkNodeId,
                     JoinState = branch.JoinState,
                     BranchState = branch.BranchState,
                     Status = branch.Status,
@@ -48,7 +48,7 @@ internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
             if (existing.ExecutionId != branch.ExecutionId)
             {
                 throw new InvalidOperationException(
-                    $"execution_branches conflict: parent={branch.ParentExecutionId:D} fork={branch.ForkState} branch={branch.BranchState} already bound to execution {existing.ExecutionId:D}.");
+                    $"execution_branches conflict: parent={branch.ParentExecutionId:D} forkNode={branch.ForkNodeId} branch={branch.BranchState} already bound to execution {existing.ExecutionId:D}.");
             }
         }
     }
@@ -61,22 +61,22 @@ internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
         await uow.GetDb().ExecutionBranches.AsNoTracking()
             .Where(x => x.ParentExecutionId == parentExecutionId)
             .OrderBy(x => x.CreatedAt)
-            .ThenBy(x => x.ForkState)
+            .ThenBy(x => x.ForkNodeId)
             .ThenBy(x => x.BranchState)
             .ToListAsync(ct)
             .ConfigureAwait(false);
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<ExecutionBranchRow>> ListByParentAndForkAsync(
+    public async Task<IReadOnlyList<ExecutionBranchRow>> ListByParentAndForkNodeAsync(
         ICoreUnitOfWork uow,
         Guid parentExecutionId,
-        string forkState,
+        string forkNodeId,
         CancellationToken ct)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(forkState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(forkNodeId);
 
         return await uow.GetDb().ExecutionBranches.AsNoTracking()
-            .Where(x => x.ParentExecutionId == parentExecutionId && x.ForkState == forkState)
+            .Where(x => x.ParentExecutionId == parentExecutionId && x.ForkNodeId == forkNodeId)
             .OrderBy(x => x.CreatedAt)
             .ThenBy(x => x.BranchState)
             .ToListAsync(ct)
@@ -96,20 +96,20 @@ internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
     public async Task<bool> TryUpdateStatusAsync(
         ICoreUnitOfWork uow,
         Guid parentExecutionId,
-        string forkState,
+        string forkNodeId,
         string branchState,
         ExecutionBranchStatusUpdate update,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(update);
-        ArgumentException.ThrowIfNullOrWhiteSpace(forkState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(forkNodeId);
         ArgumentException.ThrowIfNullOrWhiteSpace(branchState);
         ArgumentException.ThrowIfNullOrWhiteSpace(update.Status);
 
         var row = await uow.GetDb().ExecutionBranches
             .FirstOrDefaultAsync(
                 x => x.ParentExecutionId == parentExecutionId
-                     && x.ForkState == forkState
+                     && x.ForkNodeId == forkNodeId
                      && x.BranchState == branchState,
                 ct)
             .ConfigureAwait(false);
@@ -128,7 +128,7 @@ internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
     private static void ValidateBranch(ExecutionBranchRow branch)
     {
         ArgumentNullException.ThrowIfNull(branch);
-        ArgumentException.ThrowIfNullOrWhiteSpace(branch.ForkState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branch.ForkNodeId);
         ArgumentException.ThrowIfNullOrWhiteSpace(branch.JoinState);
         ArgumentException.ThrowIfNullOrWhiteSpace(branch.BranchState);
         ArgumentException.ThrowIfNullOrWhiteSpace(branch.Status);

--- a/infrastructure/Statevia.Infrastructure.Persistence/Repositories/ExecutionBranchRepository.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Repositories/ExecutionBranchRepository.cs
@@ -39,6 +39,8 @@ internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
                     BranchState = branch.BranchState,
                     Status = branch.Status,
                     OutputJson = branch.OutputJson,
+                    StatesJson = branch.StatesJson,
+                    VarsJson = branch.VarsJson,
                     CreatedAt = branch.CreatedAt,
                     UpdatedAt = branch.UpdatedAt
                 });
@@ -121,6 +123,10 @@ internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
         row.UpdatedAt = update.UpdatedAt;
         if (update.OutputJson is not null)
             row.OutputJson = update.OutputJson;
+        if (update.StatesJson is not null)
+            row.StatesJson = update.StatesJson;
+        if (update.VarsJson is not null)
+            row.VarsJson = update.VarsJson;
 
         return true;
     }

--- a/infrastructure/Statevia.Infrastructure.Persistence/Repositories/ExecutionBranchRepository.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Repositories/ExecutionBranchRepository.cs
@@ -1,0 +1,142 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Statevia.Infrastructure.Persistence.Repositories;
+
+/// <summary><c>execution_branches</c> 永続化。</summary>
+internal sealed class ExecutionBranchRepository : IExecutionBranchRepository
+{
+    /// <inheritdoc />
+    public async Task InsertBranchesIdempotentAsync(
+        ICoreUnitOfWork uow,
+        IReadOnlyList<ExecutionBranchRow> branches,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(branches);
+        if (branches.Count == 0)
+            return;
+
+        var db = uow.GetDb();
+        foreach (var branch in branches)
+        {
+            ValidateBranch(branch);
+
+            var existing = await db.ExecutionBranches
+                .FirstOrDefaultAsync(
+                    x => x.ParentExecutionId == branch.ParentExecutionId
+                         && x.ForkState == branch.ForkState
+                         && x.BranchState == branch.BranchState,
+                    ct)
+                .ConfigureAwait(false);
+
+            if (existing is null)
+            {
+                db.ExecutionBranches.Add(new ExecutionBranchRow
+                {
+                    ParentExecutionId = branch.ParentExecutionId,
+                    ExecutionId = branch.ExecutionId,
+                    ForkState = branch.ForkState,
+                    JoinState = branch.JoinState,
+                    BranchState = branch.BranchState,
+                    Status = branch.Status,
+                    OutputJson = branch.OutputJson,
+                    CreatedAt = branch.CreatedAt,
+                    UpdatedAt = branch.UpdatedAt
+                });
+                continue;
+            }
+
+            if (existing.ExecutionId != branch.ExecutionId)
+            {
+                throw new InvalidOperationException(
+                    $"execution_branches conflict: parent={branch.ParentExecutionId:D} fork={branch.ForkState} branch={branch.BranchState} already bound to execution {existing.ExecutionId:D}.");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ExecutionBranchRow>> ListByParentExecutionIdAsync(
+        ICoreUnitOfWork uow,
+        Guid parentExecutionId,
+        CancellationToken ct) =>
+        await uow.GetDb().ExecutionBranches.AsNoTracking()
+            .Where(x => x.ParentExecutionId == parentExecutionId)
+            .OrderBy(x => x.CreatedAt)
+            .ThenBy(x => x.ForkState)
+            .ThenBy(x => x.BranchState)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ExecutionBranchRow>> ListByParentAndForkAsync(
+        ICoreUnitOfWork uow,
+        Guid parentExecutionId,
+        string forkState,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(forkState);
+
+        return await uow.GetDb().ExecutionBranches.AsNoTracking()
+            .Where(x => x.ParentExecutionId == parentExecutionId && x.ForkState == forkState)
+            .OrderBy(x => x.CreatedAt)
+            .ThenBy(x => x.BranchState)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionBranchRow?> GetByChildExecutionIdAsync(
+        ICoreUnitOfWork uow,
+        Guid childExecutionId,
+        CancellationToken ct) =>
+        await uow.GetDb().ExecutionBranches.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.ExecutionId == childExecutionId, ct)
+            .ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task<bool> TryUpdateStatusAsync(
+        ICoreUnitOfWork uow,
+        Guid parentExecutionId,
+        string forkState,
+        string branchState,
+        ExecutionBranchStatusUpdate update,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        ArgumentException.ThrowIfNullOrWhiteSpace(forkState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branchState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(update.Status);
+
+        var row = await uow.GetDb().ExecutionBranches
+            .FirstOrDefaultAsync(
+                x => x.ParentExecutionId == parentExecutionId
+                     && x.ForkState == forkState
+                     && x.BranchState == branchState,
+                ct)
+            .ConfigureAwait(false);
+
+        if (row is null)
+            return false;
+
+        row.Status = update.Status;
+        row.UpdatedAt = update.UpdatedAt;
+        if (update.OutputJson is not null)
+            row.OutputJson = update.OutputJson;
+
+        return true;
+    }
+
+    private static void ValidateBranch(ExecutionBranchRow branch)
+    {
+        ArgumentNullException.ThrowIfNull(branch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branch.ForkState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branch.JoinState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branch.BranchState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branch.Status);
+        if (branch.ParentExecutionId == Guid.Empty)
+            throw new ArgumentException("ParentExecutionId is required.", nameof(branch));
+        if (branch.ExecutionId == Guid.Empty)
+            throw new ArgumentException("ExecutionId is required.", nameof(branch));
+        if (branch.ParentExecutionId == branch.ExecutionId)
+            throw new ArgumentException("ParentExecutionId and ExecutionId must differ.", nameof(branch));
+    }
+}

--- a/infrastructure/Statevia.Infrastructure.Persistence/Repositories/ExecutionWorkQueue.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Repositories/ExecutionWorkQueue.cs
@@ -5,6 +5,10 @@ using System.Data;
 namespace Statevia.Infrastructure.Persistence.Repositories;
 
 /// <summary>PostgreSQL の行ロックを使用する永続実行ワークキュー。</summary>
+/// <remarks>
+/// 単独 DbContext で即コミットする API と、呼び出し側 <see cref="ICoreUnitOfWork"/> に参加する API を提供する。
+/// Fork 子展開など原子性が必要な経路は後者を使う。
+/// </remarks>
 internal sealed class ExecutionWorkQueue(IDbContextFactory<CoreDbContext> dbFactory) : IExecutionWorkQueue
 {
     /// <inheritdoc />
@@ -12,6 +16,13 @@ internal sealed class ExecutionWorkQueue(IDbContextFactory<CoreDbContext> dbFact
     {
         ArgumentNullException.ThrowIfNull(item);
         return EnqueueManyAsync([item], ct);
+    }
+
+    /// <inheritdoc />
+    public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        return EnqueueManyAsync(uow, [item], ct);
     }
 
     /// <inheritdoc />
@@ -24,6 +35,18 @@ internal sealed class ExecutionWorkQueue(IDbContextFactory<CoreDbContext> dbFact
         await using var db = await dbFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         db.ExecutionWorkItems.AddRange(items);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task EnqueueManyAsync(ICoreUnitOfWork uow, IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(uow);
+        ArgumentNullException.ThrowIfNull(items);
+        if (items.Count == 0)
+            return Task.CompletedTask;
+
+        uow.GetDb().ExecutionWorkItems.AddRange(items);
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/service/api/Statevia.Service.Api.Tests/Application/Definition/NodesWorkflowDefinitionLoaderTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Definition/NodesWorkflowDefinitionLoaderTests.cs
@@ -36,6 +36,66 @@ public sealed class NodesWorkflowDefinitionLoaderTests
         Assert.True(definition.States["endNode"].On![Fact.Completed].End);
     }
 
+    /// <summary>ネスト Fork（枝先頭が内側 Fork）でも外側 Join.All が外側枝先頭になる。</summary>
+    [Fact]
+    public void Load_NestedForkJoin_BuildsOuterJoinAllFromOuterBranchHeads()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: NestedFork
+            nodes:
+              - id: start
+                type: start
+                next: outerFork
+              - id: outerFork
+                type: fork
+                branches: [outerFast, innerFork]
+              - id: outerFast
+                type: action
+                action: noop
+                next: outerJoin
+              - id: innerFork
+                type: fork
+                branches: [innerA, innerB]
+              - id: innerA
+                type: action
+                action: noop
+                next: innerJoin
+              - id: innerB
+                type: action
+                action: noop
+                next: innerJoin
+              - id: innerJoin
+                type: join
+                mode: all
+                next: outerJoin
+              - id: outerJoin
+                type: join
+                mode: all
+                next: endNode
+              - id: endNode
+                type: end
+            """;
+
+        // Act
+        var definition = _loader.Load(yaml);
+
+        // Assert
+        var inner = definition.States["innerJoin"].Join;
+        Assert.NotNull(inner);
+        Assert.Contains("innerA", inner.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("innerB", inner.All, StringComparer.OrdinalIgnoreCase);
+
+        var outer = definition.States["outerJoin"].Join;
+        Assert.NotNull(outer);
+        Assert.Equal(2, outer.All.Count);
+        Assert.Contains("outerFast", outer.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("innerFork", outer.All, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("innerA", outer.All, StringComparer.OrdinalIgnoreCase);
+    }
+
     /// <summary>fork / join（mode: all）から Join.All が構築される。</summary>
     [Fact]
     public void Load_ForkJoin_BuildsJoinAll()

--- a/service/api/Statevia.Service.Api.Tests/Infrastructure/Persistence/ExecutionWorkQueueUnitOfWorkTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Infrastructure/Persistence/ExecutionWorkQueueUnitOfWorkTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Persistence.Repositories;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Infrastructure.Persistence;
+
+/// <summary>
+/// UoW 参加型 <see cref="IExecutionWorkQueue.EnqueueManyAsync(ICoreUnitOfWork, IReadOnlyList{ExecutionWorkItemRow}, CancellationToken)"/> の検証。
+/// </summary>
+public sealed class ExecutionWorkQueueUnitOfWorkTests
+{
+    /// <summary>UoW 経由の enqueue は SaveChanges 後にのみ永続化される。</summary>
+    [Fact]
+    public async Task EnqueueManyAsync_WithUnitOfWork_PersistsOnlyAfterSaveChanges()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var queue = new ExecutionWorkQueue(db.Factory);
+        var workItemId = Guid.NewGuid();
+        var executionId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Start,
+            Payload = "{}",
+            AvailableAt = now,
+            Attempts = 0,
+            CreatedAt = now
+        };
+
+        // Act — SaveChanges 前は別コンテキストから見えない
+        await using (var uow = await uowFactory.CreateAsync())
+        {
+            await queue.EnqueueManyAsync(uow, [item], CancellationToken.None);
+
+            await using (var verifyBefore = new CoreDbContext(db.Options))
+            {
+                var beforeCount = await verifyBefore.ExecutionWorkItems.CountAsync(x => x.WorkItemId == workItemId);
+                Assert.Equal(0, beforeCount);
+            }
+
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Assert
+        await using var verifyAfter = new CoreDbContext(db.Options);
+        var after = await verifyAfter.ExecutionWorkItems.SingleAsync(x => x.WorkItemId == workItemId);
+        Assert.Equal(executionId, after.ExecutionId);
+        Assert.Equal(ExecutionWorkItemKinds.Start, after.Kind);
+    }
+
+    /// <summary>空リストは例外なく何もしない。</summary>
+    [Fact]
+    public async Task EnqueueManyAsync_WithUnitOfWork_EmptyList_NoOp()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var queue = new ExecutionWorkQueue(db.Factory);
+
+        // Act
+        await using var uow = await uowFactory.CreateAsync();
+        await queue.EnqueueManyAsync(uow, [], CancellationToken.None);
+        await uow.SaveChangesAsync(CancellationToken.None);
+
+        // Assert
+        await using var verify = new CoreDbContext(db.Options);
+        Assert.Equal(0, await verify.ExecutionWorkItems.CountAsync());
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Persistence/Repositories/ExecutionBranchRepositoryTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Persistence/Repositories/ExecutionBranchRepositoryTests.cs
@@ -24,8 +24,8 @@ public sealed class ExecutionBranchRepositoryTests
 
         var branches = new[]
         {
-            CreateBranch(parentId, childA, "Start", "Join1", "A", now),
-            CreateBranch(parentId, childB, "Start", "Join1", "B", now)
+            CreateBranch(parentId, childA, "n1", "Join1", "A", now),
+            CreateBranch(parentId, childB, "n1", "Join1", "B", now)
         };
 
         // Act
@@ -59,7 +59,7 @@ public sealed class ExecutionBranchRepositoryTests
         var now = DateTime.UtcNow;
         await SeedExecutionsAsync(db.Options, now, parentId, childId);
 
-        var branch = CreateBranch(parentId, childId, "Start", "Join1", "A", now);
+        var branch = CreateBranch(parentId, childId, "n1", "Join1", "A", now);
         await using (var uow1 = await uowFactory.CreateAsync())
         {
             await repo.InsertBranchesIdempotentAsync(uow1, [branch], CancellationToken.None);
@@ -95,7 +95,7 @@ public sealed class ExecutionBranchRepositoryTests
         {
             await repo.InsertBranchesIdempotentAsync(
                 uow1,
-                [CreateBranch(parentId, child1, "Start", "Join1", "A", now)],
+                [CreateBranch(parentId, child1, "n1", "Join1", "A", now)],
                 CancellationToken.None);
             await uow1.SaveChangesAsync(CancellationToken.None);
         }
@@ -104,7 +104,7 @@ public sealed class ExecutionBranchRepositoryTests
         await using var uow2 = await uowFactory.CreateAsync();
         var act = () => repo.InsertBranchesIdempotentAsync(
             uow2,
-            [CreateBranch(parentId, child2, "Start", "Join1", "A", now)],
+            [CreateBranch(parentId, child2, "n1", "Join1", "A", now)],
             CancellationToken.None);
 
         // Assert
@@ -128,7 +128,7 @@ public sealed class ExecutionBranchRepositoryTests
         {
             await repo.InsertBranchesIdempotentAsync(
                 uow1,
-                [CreateBranch(parentId, childId, "Start", "Join1", "A", now)],
+                [CreateBranch(parentId, childId, "n1", "Join1", "A", now)],
                 CancellationToken.None);
             await uow1.SaveChangesAsync(CancellationToken.None);
         }
@@ -140,7 +140,7 @@ public sealed class ExecutionBranchRepositoryTests
         var updated = await repo.TryUpdateStatusAsync(
             uow2,
             parentId,
-            "Start",
+            "n1",
             "A",
             new ExecutionBranchStatusUpdate(
                 ExecutionBranchStatuses.Completed,
@@ -175,7 +175,7 @@ public sealed class ExecutionBranchRepositoryTests
         {
             await repo.InsertBranchesIdempotentAsync(
                 uow,
-                [CreateBranch(parentId, childId, "Start", "Join1", "A", now)],
+                [CreateBranch(parentId, childId, "n1", "Join1", "A", now)],
                 CancellationToken.None);
             await uow.SaveChangesAsync(CancellationToken.None);
         }
@@ -193,7 +193,7 @@ public sealed class ExecutionBranchRepositoryTests
     private static ExecutionBranchRow CreateBranch(
         Guid parentId,
         Guid childId,
-        string forkState,
+        string forkNodeId,
         string joinState,
         string branchState,
         DateTime now) =>
@@ -201,7 +201,7 @@ public sealed class ExecutionBranchRepositoryTests
         {
             ParentExecutionId = parentId,
             ExecutionId = childId,
-            ForkState = forkState,
+            ForkNodeId = forkNodeId,
             JoinState = joinState,
             BranchState = branchState,
             Status = ExecutionBranchStatuses.Running,

--- a/service/api/Statevia.Service.Api.Tests/Persistence/Repositories/ExecutionBranchRepositoryTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Persistence/Repositories/ExecutionBranchRepositoryTests.cs
@@ -1,0 +1,236 @@
+using Microsoft.EntityFrameworkCore;
+using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Persistence.Repositories;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Persistence.Repositories;
+
+/// <summary><see cref="ExecutionBranchRepository"/> の永続化シナリオ。</summary>
+public sealed class ExecutionBranchRepositoryTests
+{
+    /// <summary>InsertBranchesIdempotentAsync は新規行を挿入する。</summary>
+    [Fact]
+    public async Task InsertBranchesIdempotentAsync_InsertsNewRows()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var repo = new ExecutionBranchRepository();
+        var parentId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var childB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedExecutionsAsync(db.Options, now, parentId, childA, childB);
+
+        var branches = new[]
+        {
+            CreateBranch(parentId, childA, "Start", "Join1", "A", now),
+            CreateBranch(parentId, childB, "Start", "Join1", "B", now)
+        };
+
+        // Act
+        await using var uow = await uowFactory.CreateAsync();
+        await repo.InsertBranchesIdempotentAsync(uow, branches, CancellationToken.None);
+        await uow.SaveChangesAsync(CancellationToken.None);
+
+        // Assert
+        await using var verify = new CoreDbContext(db.Options);
+        var rows = await verify.ExecutionBranches
+            .Where(x => x.ParentExecutionId == parentId)
+            .OrderBy(x => x.BranchState)
+            .ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("A", rows[0].BranchState);
+        Assert.Equal(childA, rows[0].ExecutionId);
+        Assert.Equal("B", rows[1].BranchState);
+        Assert.Equal(childB, rows[1].ExecutionId);
+    }
+
+    /// <summary>同一キー再挿入は execution_id 一致なら冪等に何もしない。</summary>
+    [Fact]
+    public async Task InsertBranchesIdempotentAsync_IsIdempotentWhenExecutionIdMatches()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var repo = new ExecutionBranchRepository();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedExecutionsAsync(db.Options, now, parentId, childId);
+
+        var branch = CreateBranch(parentId, childId, "Start", "Join1", "A", now);
+        await using (var uow1 = await uowFactory.CreateAsync())
+        {
+            await repo.InsertBranchesIdempotentAsync(uow1, [branch], CancellationToken.None);
+            await uow1.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Act
+        await using var uow2 = await uowFactory.CreateAsync();
+        await repo.InsertBranchesIdempotentAsync(uow2, [branch], CancellationToken.None);
+        await uow2.SaveChangesAsync(CancellationToken.None);
+
+        // Assert
+        await using var verify = new CoreDbContext(db.Options);
+        var count = await verify.ExecutionBranches.CountAsync(x => x.ParentExecutionId == parentId);
+        Assert.Equal(1, count);
+    }
+
+    /// <summary>同一キーで異なる execution_id は衝突として失敗する。</summary>
+    [Fact]
+    public async Task InsertBranchesIdempotentAsync_ThrowsWhenExecutionIdConflicts()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var repo = new ExecutionBranchRepository();
+        var parentId = Guid.NewGuid();
+        var child1 = Guid.NewGuid();
+        var child2 = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedExecutionsAsync(db.Options, now, parentId, child1, child2);
+
+        await using (var uow1 = await uowFactory.CreateAsync())
+        {
+            await repo.InsertBranchesIdempotentAsync(
+                uow1,
+                [CreateBranch(parentId, child1, "Start", "Join1", "A", now)],
+                CancellationToken.None);
+            await uow1.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Act
+        await using var uow2 = await uowFactory.CreateAsync();
+        var act = () => repo.InsertBranchesIdempotentAsync(
+            uow2,
+            [CreateBranch(parentId, child2, "Start", "Join1", "A", now)],
+            CancellationToken.None);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+    }
+
+    /// <summary>TryUpdateStatusAsync は status / output を更新する。</summary>
+    [Fact]
+    public async Task TryUpdateStatusAsync_UpdatesMatchingRow()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var repo = new ExecutionBranchRepository();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedExecutionsAsync(db.Options, now, parentId, childId);
+
+        await using (var uow1 = await uowFactory.CreateAsync())
+        {
+            await repo.InsertBranchesIdempotentAsync(
+                uow1,
+                [CreateBranch(parentId, childId, "Start", "Join1", "A", now)],
+                CancellationToken.None);
+            await uow1.SaveChangesAsync(CancellationToken.None);
+        }
+
+        var updatedAt = now.AddMinutes(1);
+
+        // Act
+        await using var uow2 = await uowFactory.CreateAsync();
+        var updated = await repo.TryUpdateStatusAsync(
+            uow2,
+            parentId,
+            "Start",
+            "A",
+            new ExecutionBranchStatusUpdate(
+                ExecutionBranchStatuses.Completed,
+                updatedAt,
+                """{"ok":true}"""),
+            CancellationToken.None);
+        await uow2.SaveChangesAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(updated);
+        await using var verify = new CoreDbContext(db.Options);
+        var row = await verify.ExecutionBranches.SingleAsync();
+        Assert.Equal(ExecutionBranchStatuses.Completed, row.Status);
+        Assert.Equal("""{"ok":true}""", row.OutputJson);
+        Assert.Equal(updatedAt, row.UpdatedAt);
+    }
+
+    /// <summary>GetByChildExecutionIdAsync は子 ID で取得する。</summary>
+    [Fact]
+    public async Task GetByChildExecutionIdAsync_ReturnsMatchingRow()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var repo = new ExecutionBranchRepository();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedExecutionsAsync(db.Options, now, parentId, childId);
+
+        await using (var uow = await uowFactory.CreateAsync())
+        {
+            await repo.InsertBranchesIdempotentAsync(
+                uow,
+                [CreateBranch(parentId, childId, "Start", "Join1", "A", now)],
+                CancellationToken.None);
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Act
+        await using var readUow = await uowFactory.CreateAsync();
+        var found = await repo.GetByChildExecutionIdAsync(readUow, childId, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(found);
+        Assert.Equal(parentId, found.ParentExecutionId);
+        Assert.Equal("Join1", found.JoinState);
+    }
+
+    private static ExecutionBranchRow CreateBranch(
+        Guid parentId,
+        Guid childId,
+        string forkState,
+        string joinState,
+        string branchState,
+        DateTime now) =>
+        new()
+        {
+            ParentExecutionId = parentId,
+            ExecutionId = childId,
+            ForkState = forkState,
+            JoinState = joinState,
+            BranchState = branchState,
+            Status = ExecutionBranchStatuses.Running,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+    private static async Task SeedExecutionsAsync(
+        DbContextOptions<CoreDbContext> options,
+        DateTime now,
+        params Guid[] executionIds)
+    {
+        await using var ctx = new CoreDbContext(options);
+        foreach (var id in executionIds)
+        {
+            ctx.Executions.Add(new ExecutionRow
+            {
+                ExecutionId = id,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = "Running",
+                StartedAt = now,
+                UpdatedAt = now,
+                CancelRequested = false,
+                RestartLost = false
+            });
+        }
+
+        await ctx.SaveChangesAsync();
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/DelayWaitSchedulerHostedServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/DelayWaitSchedulerHostedServiceTests.cs
@@ -50,11 +50,20 @@ public sealed class DelayWaitSchedulerHostedServiceTests
         public Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct) =>
             throw new NotImplementedException();
 
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            throw new NotImplementedException();
+
         public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
         {
             EnqueueManyCallCount++;
             return Task.CompletedTask;
         }
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
 
         public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
             string leaseOwner,

--- a/service/api/Statevia.Service.Api.Tests/Services/EventIngressServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/EventIngressServiceTests.cs
@@ -158,11 +158,20 @@ public sealed class EventIngressServiceTests
             return Task.CompletedTask;
         }
 
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            EnqueueAsync(item, ct);
+
         public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
         {
             Items.AddRange(items);
             return Task.CompletedTask;
         }
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            EnqueueManyAsync(items, ct);
 
         public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
             string leaseOwner,

--- a/service/api/Statevia.Service.Api.Tests/Services/EventIngressServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/EventIngressServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
 using Statevia.Core.Application.Contracts.Persistence;
 using Statevia.Core.Application.Services;
 using Statevia.Infrastructure.Persistence;
@@ -84,6 +85,33 @@ public sealed class EventIngressServiceTests
         Assert.Empty(workQueue.Items);
     }
 
+    /// <summary>購読は子 execution_id に紐づき、親 ID へ Resume しない。</summary>
+    [Fact]
+    public async Task PublishAsync_WhenSubscriptionOnChild_EnqueuesResumeForChildNotParent()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var transactions = new TestCoreTransactionExecutor(uowFactory);
+        var waits = new ExecutionWaitRepository(db.Factory);
+        var workQueue = new CapturingWorkQueue();
+        var service = new EventIngressService(transactions, waits, workQueue);
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedExecutionAsync(db, parentId, now);
+        await SeedSubscriptionAsync(db, childId, "ChildWait", "approval.needed", "req-1", "Approve", now);
+
+        // Act
+        await service.PublishAsync("approval.needed", "req-1", CancellationToken.None);
+
+        // Assert
+        Assert.Single(workQueue.Items);
+        Assert.Equal(childId, workQueue.Items[0].ExecutionId);
+        Assert.NotEqual(parentId, workQueue.Items[0].ExecutionId);
+        Assert.Equal(ExecutionWorkItemKinds.Resume, workQueue.Items[0].Kind);
+    }
+
     /// <summary>購読が空 key のとき key 付き配信は一致しない。</summary>
     [Fact]
     public async Task PublishAsync_EmptyKeySubscription_DoesNotMatchNonEmptyKey()
@@ -114,19 +142,8 @@ public sealed class EventIngressServiceTests
         string resumeEventName,
         DateTime createdAt)
     {
+        await SeedExecutionAsync(db, executionId, createdAt);
         await using var ctx = new CoreDbContext(db.Options);
-        ctx.Executions.Add(new ExecutionRow
-        {
-            ExecutionId = executionId,
-            TenantId = TestTenantIds.T1TenantId,
-            DefinitionId = Guid.NewGuid(),
-            DefinitionVersionId = Guid.NewGuid(),
-            Status = "Running",
-            StartedAt = createdAt,
-            UpdatedAt = createdAt,
-            CancelRequested = false,
-            RestartLost = false
-        });
         ctx.ExecutionWaits.Add(new ExecutionWaitRow
         {
             ExecutionId = executionId,
@@ -144,6 +161,27 @@ public sealed class EventIngressServiceTests
             CorrelationKey = correlationKey,
             ResumeEventName = resumeEventName,
             CreatedAt = createdAt
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task SeedExecutionAsync(InMemoryTestDatabase db, Guid executionId, DateTime createdAt)
+    {
+        await using var ctx = new CoreDbContext(db.Options);
+        if (await ctx.Executions.AnyAsync(x => x.ExecutionId == executionId))
+            return;
+
+        ctx.Executions.Add(new ExecutionRow
+        {
+            ExecutionId = executionId,
+            TenantId = TestTenantIds.T1TenantId,
+            DefinitionId = Guid.NewGuid(),
+            DefinitionVersionId = Guid.NewGuid(),
+            Status = "Running",
+            StartedAt = createdAt,
+            UpdatedAt = createdAt,
+            CancelRequested = false,
+            RestartLost = false
         });
         await ctx.SaveChangesAsync();
     }

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionProjectionUpdateQueueServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionProjectionUpdateQueueServiceTests.cs
@@ -19,7 +19,11 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
     {
         private Func<string, Task>? _nodeCompletedHandler;
 
-        public string Start(CompiledWorkflowDefinition definition, string? executionId = null, object? input = null) =>
+        public string Start(
+            CompiledWorkflowDefinition definition,
+            string? executionId = null,
+            object? input = null,
+            string? initialState = null) =>
             throw new NotSupportedException();
 
         public void ResumeWaitNode(string executionId, string nodeId, string eventName) =>
@@ -49,6 +53,10 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
         }
 
         public void SetSuspendHandler(Func<string, string, Task>? handler)
+        {
+        }
+
+        public void SetForkExpansionHandler(Func<ForkExpansionEvent, Task>? handler)
         {
         }
 

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionProjectionUpdateQueueServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionProjectionUpdateQueueServiceTests.cs
@@ -63,7 +63,8 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
         public void CompletePhysicalJoin(
             string executionId,
             string joinStateName,
-            IReadOnlyDictionary<string, object?> branchOutputs)
+            IReadOnlyDictionary<string, object?> branchOutputs,
+            IReadOnlyList<PhysicalJoinContextFragment>? contextMerges = null)
         {
         }
 

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionProjectionUpdateQueueServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionProjectionUpdateQueueServiceTests.cs
@@ -60,6 +60,13 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
         {
         }
 
+        public void CompletePhysicalJoin(
+            string executionId,
+            string joinStateName,
+            IReadOnlyDictionary<string, object?> branchOutputs)
+        {
+        }
+
         public ExecutionRuntimeCheckpoint? ExportCheckpoint(string executionId) => null;
 
         public void ImportCheckpoint(CompiledWorkflowDefinition definition, ExecutionRuntimeCheckpoint checkpoint)

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -117,7 +117,11 @@ public sealed class ExecutionServiceTests
         /// <summary>設定時、一致する <c>clientEventId</c> の Cancel で <see cref="ApplyResult.AlreadyApplied"/> を返す。</summary>
         public Guid? CancelAlreadyAppliedWhenClientEventIdEquals { get; set; }
 
-        public string Start(CompiledWorkflowDefinition definition, string? executionId = null, object? input = null)
+        public string Start(
+            CompiledWorkflowDefinition definition,
+            string? executionId = null,
+            object? input = null,
+            string? initialState = null)
         {
             StartCalled = true;
             LastDefinition = definition;
@@ -190,6 +194,11 @@ public sealed class ExecutionServiceTests
         }
 
         public void SetSuspendHandler(Func<string, string, Task>? handler)
+        {
+            // no-op for tests
+        }
+
+        public void SetForkExpansionHandler(Func<ForkExpansionEvent, Task>? handler)
         {
             // no-op for tests
         }

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -206,7 +206,8 @@ public sealed class ExecutionServiceTests
         public void CompletePhysicalJoin(
             string executionId,
             string joinStateName,
-            IReadOnlyDictionary<string, object?> branchOutputs)
+            IReadOnlyDictionary<string, object?> branchOutputs,
+            IReadOnlyList<PhysicalJoinContextFragment>? contextMerges = null)
         {
             // no-op for tests
         }

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -126,8 +126,21 @@ public sealed class ExecutionServiceTests
             StartCalled = true;
             LastDefinition = definition;
             LastInput = input;
-            LastEngineId = executionId;
-            return executionId ?? "generated";
+            var resolvedId = executionId ?? "generated";
+            LastEngineId = resolvedId;
+            // 実 Engine 同様、Start 後は投影可能な Running スナップショットを返す。
+            SnapshotToReturn ??= new ExecutionSnapshot
+            {
+                ExecutionId = resolvedId,
+                WorkflowName = definition.Name,
+                ActiveStates = string.IsNullOrWhiteSpace(initialState)
+                    ? Array.Empty<string>()
+                    : [initialState],
+                IsCompleted = false,
+                IsCancelled = false,
+                IsFailed = false
+            };
+            return resolvedId;
         }
 
         /// <summary>設定時、PublishEvent(executionId, name, clientEventId) がこの例外を投げる。</summary>
@@ -219,7 +232,15 @@ public sealed class ExecutionServiceTests
             // no-op for tests
         }
 
-        public bool Unload(string executionId) => false;
+        /// <summary><see cref="Unload"/> が呼ばれた回数。</summary>
+        public int UnloadCalls { get; private set; }
+
+        public bool Unload(string executionId)
+        {
+            UnloadCalls += 1;
+            SnapshotToReturn = null;
+            return true;
+        }
     }
 
     private sealed class FakeProjectionUpdateQueue : IExecutionProjectionUpdateQueue
@@ -1722,6 +1743,72 @@ public sealed class ExecutionServiceTests
         Assert.True(engine.CancelCalled);
         Assert.Empty(eventStore.Appended);
         Assert.Empty(dedupRepo.SavedRows);
+    }
+
+    /// <summary>
+    /// 終端検知時は Unload 前に投影キュー排水と最終投影を行い、不完全 graph のまま Completed が残らないこと。
+    /// </summary>
+    [Fact]
+    public async Task AwaitLocalExecutionLoadAsync_WhenTerminal_DrainsProjectsThenUnloads()
+    {
+        // Arrange
+        var executionId = Guid.NewGuid();
+        const string finalGraphJson = """{"nodes":[{"id":"a"},{"id":"b"},{"id":"c"},{"id":"d"}]}""";
+        using var sqlite = new SqliteTestDatabase();
+        var projectionQueue = new FakeProjectionUpdateQueue();
+        var engine = new FakeExecutionEngine
+        {
+            SnapshotToReturn = new ExecutionSnapshot
+            {
+                ExecutionId = executionId.ToString(),
+                WorkflowName = "wf",
+                ActiveStates = Array.Empty<string>(),
+                IsCompleted = true,
+                IsCancelled = false,
+                IsFailed = false
+            },
+            GraphJsonToReturn = finalGraphJson
+        };
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                Status = "Running",
+                StartedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                CancelRequested = false,
+                RestartLost = false
+            }
+        };
+
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            new StubDefinitionRepository(),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            projectionQueue);
+
+        // Act
+        await sut.AwaitLocalExecutionLoadAsync(executionId, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, projectionQueue.DrainCalls);
+        Assert.Equal(executionId, projectionQueue.LastDrainExecutionId);
+        Assert.Single(executionRepo.Updates);
+        Assert.Equal("Completed", executionRepo.Updates[0].Status);
+        Assert.Equal(finalGraphJson, executionRepo.Updates[0].GraphJson);
+        Assert.True(engine.UnloadCalls >= 1);
+        Assert.Null(engine.SnapshotToReturn);
     }
 
     /// <summary>非公開投影更新処理が実行行とスナップショットを更新する。</summary>

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -677,6 +677,9 @@ public sealed class ExecutionServiceTests
             return Task.FromResult(true);
         }
 
+        /// <summary>execution ごとの行。未設定時は <see cref="AfterSeqItems"/> を使う。</summary>
+        public Dictionary<Guid, List<EventStoreRow>> ItemsByExecutionId { get; } = new();
+
         public async Task<(IReadOnlyList<EventStoreRow> Items, bool HasMore)> ListAfterSeqAsync(
             ICoreUnitOfWork uow,
             Guid executionId,
@@ -686,7 +689,25 @@ public sealed class ExecutionServiceTests
         {
             _ = uow;
             await Task.Yield(); // async boundary for coverage
-            return ((IReadOnlyList<EventStoreRow>)AfterSeqItems, AfterSeqHasMore);
+            var source = ItemsByExecutionId.TryGetValue(executionId, out var keyed)
+                ? keyed
+                : AfterSeqItems;
+            var page = source
+                .Where(r => r.Seq > afterSeq)
+                .OrderBy(r => r.Seq)
+                .Take(limit + 1)
+                .ToList();
+            var hasMore = page.Count > limit;
+            if (!hasMore
+                && ItemsByExecutionId.Count == 0
+                && AfterSeqHasMore)
+            {
+                hasMore = true;
+            }
+
+            if (page.Count > limit)
+                page.RemoveAt(page.Count - 1);
+            return (page, hasMore);
         }
 
         public async Task<long> GetMaxSeqAsync(ICoreUnitOfWork uow, Guid executionId, CancellationToken ct = default)
@@ -1413,6 +1434,98 @@ public sealed class ExecutionServiceTests
         Assert.True(nodeB.CanceledByExecution.GetValueOrDefault());
         Assert.Equal("CANCELED", nodeB.Status);
         Assert.Equal("Wait", nodeB.StateName);
+    }
+
+    /// <summary>親 events GET で子孫の EventPublished を合成し、子 WorkflowStarted は落とす。</summary>
+    [Fact]
+    public async Task ListEventsAsync_ComposesDescendantEvents_AndDropsChildWorkflowStarted()
+    {
+        // Arrange
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var t0 = new DateTime(2026, 8, 8, 10, 0, 0, DateTimeKind.Utc);
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = parentId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                Status = "Running",
+                StartedAt = t0,
+                UpdatedAt = t0,
+                CancelRequested = false,
+                RestartLost = false
+            },
+            SnapshotByExecutionId = new ExecutionGraphSnapshotRow
+            {
+                ExecutionId = parentId,
+                GraphJson = """{"nodes":[{"nodeId":"a","stateName":"A"}],"edges":[]}""",
+                UpdatedAt = t0
+            }
+        };
+        var display = new FakeDisplayIdService
+        {
+            ResolveResultExecution = parentId,
+            GetDisplayIdResult = "eidCompose"
+        };
+        var eventStore = new FakeEventStoreRepository();
+        eventStore.ItemsByExecutionId[parentId] =
+        [
+            new EventStoreRow
+            {
+                ExecutionId = parentId,
+                Seq = 1,
+                Type = EventStoreEventType.WorkflowStarted.ToPersistedString(),
+                OccurredAt = t0
+            }
+        ];
+        eventStore.ItemsByExecutionId[childId] =
+        [
+            new EventStoreRow
+            {
+                ExecutionId = childId,
+                Seq = 1,
+                Type = EventStoreEventType.WorkflowStarted.ToPersistedString(),
+                OccurredAt = t0.AddSeconds(1)
+            },
+            new EventStoreRow
+            {
+                ExecutionId = childId,
+                Seq = 2,
+                Type = EventStoreEventType.EventPublished.ToPersistedString(),
+                OccurredAt = t0.AddSeconds(2)
+            }
+        ];
+        var coordinator = new FakeForkChildCoordinator { DescendantIds = [childId] };
+
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            display,
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            new StubDefinitionRepository(),
+            new FakeCommandDedupRepository(),
+            eventStore,
+            new FakeEventDeliveryDedupRepository(),
+            forkChildCoordinator: coordinator);
+
+        // Act
+        var res = await sut.ListEventsAsync("eidCompose", afterSeq: 0, limit: 10, CancellationToken.None);
+
+        // Assert
+        Assert.False(res.HasMore);
+        Assert.Equal(2, res.Events.Count);
+        Assert.Equal("ExecutionStatusChanged", res.Events[0].Type);
+        Assert.Equal("Running", res.Events[0].To);
+        Assert.Equal("GraphUpdated", res.Events[1].Type);
+        Assert.Equal("eidCompose", res.Events[1].ExecutionId);
+        Assert.Equal(1, res.Events[0].Seq);
+        Assert.Equal(2, res.Events[1].Seq);
     }
 
     /// <summary>取消要求で冪等一致かつ有効行があるとき副作用なく即時終了する。</summary>
@@ -4045,6 +4158,50 @@ public sealed class ExecutionServiceTests
             waitRepo: waitRepo);
     }
 
+    private sealed class FakeForkChildCoordinator : IForkChildExecutionCoordinator
+    {
+        public List<Guid> DescendantIds { get; init; } = [];
+
+        public Task<ForkExpansionResult> ExpandForkAsync(ForkExpansionRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<bool> NotifyChildTerminalAsync(
+            Guid childExecutionId,
+            string status,
+            string? outputJson,
+            string? statesJson,
+            string? varsJson,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<ForkJoinEvaluation> EvaluateJoinAsync(
+            Guid parentExecutionId,
+            string forkNodeId,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task CascadeCancelToRunningChildrenAsync(Guid parentExecutionId, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<ForkWaitDeliveryTarget?> TryResolveChildWaitDeliveryAsync(
+            Guid requestedExecutionId,
+            string? nodeId,
+            string eventName,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> ComposeReadModelGraphJsonAsync(
+            Guid executionId,
+            string baseGraphJson,
+            CancellationToken ct) =>
+            Task.FromResult(baseGraphJson);
+
+        public Task<IReadOnlyList<Guid>> ListDescendantExecutionIdsAsync(
+            Guid parentExecutionId,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<Guid>>(DescendantIds);
+    }
+
     private static ExecutionService BuildExecutionService(
         SqliteTestDatabase sqlite,
         IExecutionEngine engine,
@@ -4061,7 +4218,8 @@ public sealed class ExecutionServiceTests
         Microsoft.Extensions.Options.IOptions<EventDeliveryRetryOptions>? eventDeliveryRetryOptions = null,
         IExecutionMutationPersistence? mutationPersistence = null,
         IProjectAuthorizationService? projectAuthorization = null,
-        FakeExecutionWaitRepository? waitRepo = null)
+        FakeExecutionWaitRepository? waitRepo = null,
+        IForkChildExecutionCoordinator? forkChildCoordinator = null)
     {
         if (displayIds is not IDisplayIdWriteService displayIdWrites)
             throw new InvalidOperationException("Test display id service must implement IDisplayIdWriteService.");
@@ -4106,7 +4264,10 @@ public sealed class ExecutionServiceTests
             retryOptions,
             new FixedCorrelationIdAccessor(),
             new FakeExecutionCheckpointStore(),
-            projectionUpdateQueue);
+            projectionUpdateQueue,
+            workQueue: null,
+            ownershipTracker: null,
+            forkChildCoordinator: forkChildCoordinator);
     }
 
     /// <summary>Reader 付与テナントは Start（Executor）が 403。</summary>

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -203,6 +203,14 @@ public sealed class ExecutionServiceTests
             // no-op for tests
         }
 
+        public void CompletePhysicalJoin(
+            string executionId,
+            string joinStateName,
+            IReadOnlyDictionary<string, object?> branchOutputs)
+        {
+            // no-op for tests
+        }
+
         public ExecutionRuntimeCheckpoint? ExportCheckpoint(string executionId) => null;
 
         public void ImportCheckpoint(CompiledWorkflowDefinition definition, ExecutionRuntimeCheckpoint checkpoint)

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorCancelAndDeliveryTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorCancelAndDeliveryTests.cs
@@ -1,0 +1,313 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Persistence.Repositories;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>親 Cancel カスケードと分岐 Wait の子配送解決（タスク 6）。</summary>
+public sealed class ForkChildExecutionCoordinatorCancelAndDeliveryTests
+{
+    /// <summary>親 Cancel カスケードで Running 子だけに Cancel work item を enqueue する。</summary>
+    [Fact]
+    public async Task CascadeCancelToRunningChildrenAsync_EnqueuesCancelOnlyForRunningChildren()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childRunning = Guid.NewGuid();
+        var childCompleted = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childRunning, childCompleted, now);
+        await MarkBranchStatusAsync(
+            db.Options, parentId, childCompleted, ExecutionBranchStatuses.Completed, now);
+
+        var workQueue = new CapturingWorkQueue();
+        var sut = CreateSut(db, workQueue);
+
+        // Act
+        await sut.CascadeCancelToRunningChildrenAsync(parentId, CancellationToken.None);
+
+        // Assert
+        Assert.Single(workQueue.Items);
+        Assert.Equal(ExecutionWorkItemKinds.Cancel, workQueue.Items[0].Kind);
+        Assert.Equal(childRunning, workQueue.Items[0].ExecutionId);
+    }
+
+    /// <summary>親自身に Wait があるときは子へ振り替えない。</summary>
+    [Fact]
+    public async Task TryResolveChildWaitDeliveryAsync_WhenParentHasWait_ReturnsNull()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childId, Guid.NewGuid(), now);
+        await SeedWaitAsync(db.Options, parentId, "ParentWait", "Approve", now);
+        await SeedWaitAsync(db.Options, childId, "ChildWait", "Approve", now);
+        var sut = CreateSut(db, new CapturingWorkQueue());
+
+        // Act
+        var delivery = await sut.TryResolveChildWaitDeliveryAsync(
+            parentId, "ParentWait", "Approve", CancellationToken.None);
+
+        // Assert
+        Assert.Null(delivery);
+    }
+
+    /// <summary>親に Wait が無く子にだけあるとき、子 execution へ振り替える。</summary>
+    [Fact]
+    public async Task TryResolveChildWaitDeliveryAsync_WhenOnlyChildHasWait_ReturnsChildTarget()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var siblingId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childId, siblingId, now);
+        await SeedWaitAsync(db.Options, childId, "BranchWait", "Approve", now);
+        var sut = CreateSut(db, new CapturingWorkQueue());
+
+        // Act
+        var delivery = await sut.TryResolveChildWaitDeliveryAsync(
+            parentId, "BranchWait", "Approve", CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(delivery);
+        Assert.Equal(childId, delivery.ExecutionId);
+        Assert.Equal("BranchWait", delivery.NodeId);
+        Assert.Equal("Approve", delivery.EventName);
+    }
+
+    /// <summary>PublishEvent 互換（nodeId なし）でも子 Wait へ解決する。</summary>
+    [Fact]
+    public async Task TryResolveChildWaitDeliveryAsync_WithoutNodeId_ResolvesChildByEventName()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childId, Guid.NewGuid(), now);
+        await SeedWaitAsync(db.Options, childId, "BranchWait", "Approve", now);
+        var sut = CreateSut(db, new CapturingWorkQueue());
+
+        // Act
+        var delivery = await sut.TryResolveChildWaitDeliveryAsync(
+            parentId, nodeId: null, "Approve", CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(delivery);
+        Assert.Equal(childId, delivery.ExecutionId);
+        Assert.Equal("BranchWait", delivery.NodeId);
+    }
+
+    /// <summary>複数子に同一イベント Wait があるとき曖昧として例外になる。</summary>
+    [Fact]
+    public async Task TryResolveChildWaitDeliveryAsync_WhenAmbiguous_Throws()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var childB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childA, childB, now);
+        await SeedWaitAsync(db.Options, childA, "WaitA", "Approve", now);
+        await SeedWaitAsync(db.Options, childB, "WaitB", "Approve", now);
+        var sut = CreateSut(db, new CapturingWorkQueue());
+
+        // Act
+        var act = () => sut.TryResolveChildWaitDeliveryAsync(
+            parentId, nodeId: null, "Approve", CancellationToken.None);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+    }
+
+    private static ForkChildExecutionCoordinator CreateSut(InMemoryTestDatabase db, IExecutionWorkQueue workQueue)
+    {
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var executor = new TestCoreTransactionExecutor(uowFactory);
+        return new ForkChildExecutionCoordinator(
+            executor,
+            new ExecutionRepository(),
+            new ExecutionBranchRepository(),
+            new ExecutionWaitRepository(db.Factory),
+            workQueue,
+            new GuidIdGenerator(),
+            new StubDisplayIdWrites(),
+            new EventStoreRepository(new GuidIdGenerator()),
+            Options.Create(new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 }),
+            NullLogger<ForkChildExecutionCoordinator>.Instance);
+    }
+
+    private static async Task SeedParentAndBranchesAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        Guid childA,
+        Guid childB,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        ctx.Executions.Add(new ExecutionRow
+        {
+            ExecutionId = parentId,
+            TenantId = TestTenantIds.T1TenantId,
+            DefinitionId = Guid.NewGuid(),
+            DefinitionVersionId = Guid.NewGuid(),
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = now,
+            UpdatedAt = now,
+            CancelRequested = false,
+            RestartLost = false
+        });
+
+        foreach (var childId in new[] { childA, childB })
+        {
+            ctx.Executions.Add(new ExecutionRow
+            {
+                ExecutionId = childId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = now,
+                UpdatedAt = now,
+                CancelRequested = false,
+                RestartLost = false
+            });
+        }
+
+        ctx.ExecutionBranches.AddRange(
+            new ExecutionBranchRow
+            {
+                ParentExecutionId = parentId,
+                ExecutionId = childA,
+                ForkNodeId = "fork-node-1",
+                JoinState = "Join1",
+                BranchState = "A",
+                Status = ExecutionBranchStatuses.Running,
+                CreatedAt = now,
+                UpdatedAt = now
+            },
+            new ExecutionBranchRow
+            {
+                ParentExecutionId = parentId,
+                ExecutionId = childB,
+                ForkNodeId = "fork-node-1",
+                JoinState = "Join1",
+                BranchState = "B",
+                Status = ExecutionBranchStatuses.Running,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task MarkBranchStatusAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        Guid childId,
+        string status,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        var row = await ctx.ExecutionBranches.SingleAsync(
+            x => x.ParentExecutionId == parentId && x.ExecutionId == childId);
+        row.Status = status;
+        row.UpdatedAt = now;
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task SeedWaitAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid executionId,
+        string nodeId,
+        string eventName,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        ctx.ExecutionWaits.Add(new ExecutionWaitRow
+        {
+            ExecutionId = executionId,
+            NodeId = nodeId,
+            WaitKind = ExecutionWaitKind.EventWait,
+            AllowedEvents = [eventName],
+            CreatedAt = now
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private sealed class GuidIdGenerator : IIdGenerator
+    {
+        public Guid NewGuid() => Guid.NewGuid();
+    }
+
+    private sealed class StubDisplayIdWrites : IDisplayIdWriteService
+    {
+        public Task<string> AllocateAsync(ICoreUnitOfWork uow, string kind, Guid uuid, CancellationToken ct = default) =>
+            Task.FromResult(uuid.ToString("D"));
+    }
+
+    private sealed class CapturingWorkQueue : IExecutionWorkQueue
+    {
+        public List<ExecutionWorkItemRow> Items { get; } = [];
+
+        public Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct)
+        {
+            Items.Add(item);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            EnqueueAsync(item, ct);
+
+        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
+        {
+            Items.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            EnqueueManyAsync(items, ct);
+
+        public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            int limit,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<bool> RenewLeaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task CompleteAsync(Guid workItemId, string leaseOwner, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task ReleaseAsync(Guid workItemId, string leaseOwner, DateTime availableAt, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<int> EnqueueExpiredOwnershipRecoveriesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<int> EnqueueExpiredDelayWaitResumesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            throw new NotImplementedException();
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorExpandTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorExpandTests.cs
@@ -1,0 +1,458 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+using Statevia.Core.Engine.Abstractions;
+using Statevia.Core.Engine.Definition;
+using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Persistence.Repositories;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary><see cref="ForkChildExecutionCoordinator.ExpandForkAsync"/> の展開・再入・D9 失敗経路。</summary>
+public sealed class ForkChildExecutionCoordinatorExpandTests
+{
+    /// <summary>初回展開で子 execution・branches・Start work item を同一 TX で作成する。</summary>
+    [Fact]
+    public async Task ExpandForkAsync_CreatesChildrenBranchesAndStartWorkItems()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAsync(db.Options, parentId, definitionId, definitionVersionId, now);
+
+        var workQueue = new CapturingWorkQueue();
+        var sut = CreateSut(db, workQueue, new ForkChildExpansionOptions { MaxAttempts = 2, BaseDelayMs = 0 });
+        var request = CreateRequest(parentId, definitionId, definitionVersionId);
+
+        // Act
+        var result = await sut.ExpandForkAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Equal("Join1", result.JoinState);
+        Assert.Equal(2, result.ChildExecutionIds.Count);
+        Assert.Equal(2, workQueue.Items.Count);
+        Assert.All(workQueue.Items, item => Assert.Equal(ExecutionWorkItemKinds.Start, item.Kind));
+
+        await using var verify = new CoreDbContext(db.Options);
+        var branches = await verify.ExecutionBranches
+            .Where(x => x.ParentExecutionId == parentId)
+            .OrderBy(x => x.BranchState)
+            .ToListAsync();
+        Assert.Equal(2, branches.Count);
+        Assert.Equal("A", branches[0].BranchState);
+        Assert.Equal("B", branches[1].BranchState);
+        Assert.Equal(2, await verify.Executions.CountAsync(x => x.ExecutionId != parentId));
+        Assert.Equal(2, await verify.EventStore.CountAsync(x => x.Type == EventStoreEventType.WorkflowStarted.ToPersistedString()));
+    }
+
+    /// <summary>同数の branches が既にある再入では Start を二重 enqueue しない。</summary>
+    [Fact]
+    public async Task ExpandForkAsync_WhenAlreadyExpanded_DoesNotReEnqueueStarts()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var childB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAsync(db.Options, parentId, definitionId, definitionVersionId, now);
+        await SeedChildAndBranchesAsync(db.Options, parentId, childA, childB, now);
+
+        var workQueue = new CapturingWorkQueue();
+        var sut = CreateSut(db, workQueue, new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 });
+        var request = CreateRequest(parentId, definitionId, definitionVersionId);
+
+        // Act
+        var result = await sut.ExpandForkAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Equal(new[] { childA, childB }.OrderBy(x => x).ToArray(), result.ChildExecutionIds.OrderBy(x => x).ToArray());
+        Assert.Empty(workQueue.Items);
+    }
+
+    /// <summary>展開が上限まで失敗すると親を Failed にし子 Cancel を enqueue する。</summary>
+    [Fact]
+    public async Task ExpandForkAsync_WhenAttemptsExhausted_FailsParentAndEnqueuesCancel()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAsync(db.Options, parentId, definitionId, definitionVersionId, now);
+        await SeedPartialChildAsync(db.Options, parentId, childA, now);
+
+        var workQueue = new CapturingWorkQueue();
+        var failingBranches = new ThrowingBranchRepository();
+        var sut = CreateSut(
+            db,
+            workQueue,
+            new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 },
+            branches: failingBranches);
+
+        var request = CreateRequest(parentId, definitionId, definitionVersionId);
+
+        // Act
+        var result = await sut.ExpandForkAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Empty(result.ChildExecutionIds);
+
+        await using var verify = new CoreDbContext(db.Options);
+        var parent = await verify.Executions.SingleAsync(x => x.ExecutionId == parentId);
+        Assert.Equal(ExecutionProjectionStatuses.Failed, parent.Status);
+        Assert.True(parent.CancelRequested);
+
+        Assert.Single(workQueue.Items);
+        Assert.Equal(ExecutionWorkItemKinds.Cancel, workQueue.Items[0].Kind);
+        Assert.Equal(childA, workQueue.Items[0].ExecutionId);
+    }
+
+    /// <summary>分岐が空のとき ArgumentException になる。</summary>
+    [Fact]
+    public async Task ExpandForkAsync_EmptyBranches_Throws()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var workQueue = new CapturingWorkQueue();
+        var sut = CreateSut(db, workQueue, new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 });
+        var parentId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var request = new ForkExpansionRequest(
+            ParentExecutionId: parentId,
+            TenantId: TestTenantIds.T1TenantId,
+            DefinitionId: definitionId,
+            DefinitionVersionId: Guid.NewGuid(),
+            DefinitionVersion: 1,
+            DefinitionDisplayId: definitionId.ToString("D"),
+            SecuritySnapshotJson: "{}",
+            CompiledDefinition: CreateDefinition(),
+            ForkNodeId: "fork-node-1",
+            Branches: Array.Empty<ForkBranchExpansion>());
+
+        // Act
+        var act = () => sut.ExpandForkAsync(request, CancellationToken.None);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(act);
+    }
+
+    /// <summary>MaxAttempts が不正なとき InvalidOperationException になる。</summary>
+    [Fact]
+    public async Task ExpandForkAsync_InvalidMaxAttempts_Throws()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var workQueue = new CapturingWorkQueue();
+        var sut = CreateSut(db, workQueue, new ForkChildExpansionOptions { MaxAttempts = 0, BaseDelayMs = 0 });
+        var parentId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        await SeedParentAsync(db.Options, parentId, definitionId, definitionVersionId, DateTime.UtcNow);
+        var request = CreateRequest(parentId, definitionId, definitionVersionId);
+
+        // Act
+        var act = () => sut.ExpandForkAsync(request, CancellationToken.None);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+    }
+
+    private static ForkChildExecutionCoordinator CreateSut(
+        InMemoryTestDatabase db,
+        IExecutionWorkQueue workQueue,
+        ForkChildExpansionOptions options,
+        IExecutionBranchRepository? branches = null)
+    {
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var executor = new TestCoreTransactionExecutor(uowFactory);
+        return new ForkChildExecutionCoordinator(
+            executor,
+            new ExecutionRepository(),
+            branches ?? new ExecutionBranchRepository(),
+            workQueue,
+            new GuidIdGenerator(),
+            new StubDisplayIdWrites(),
+            new EventStoreRepository(new GuidIdGenerator()),
+            Options.Create(options),
+            NullLogger<ForkChildExecutionCoordinator>.Instance);
+    }
+
+    private static ForkExpansionRequest CreateRequest(
+        Guid parentId,
+        Guid definitionId,
+        Guid definitionVersionId) =>
+        new(
+            ParentExecutionId: parentId,
+            TenantId: TestTenantIds.T1TenantId,
+            DefinitionId: definitionId,
+            DefinitionVersionId: definitionVersionId,
+            DefinitionVersion: 1,
+            DefinitionDisplayId: definitionId.ToString("D"),
+            SecuritySnapshotJson: """{"securityModelVersion":1}""",
+            CompiledDefinition: CreateDefinition(),
+            ForkNodeId: "fork-node-1",
+            Branches:
+            [
+                new ForkBranchExpansion("A", new { n = 1 }),
+                new ForkBranchExpansion("B", new { n = 2 })
+            ]);
+
+    private static CompiledWorkflowDefinition CreateDefinition() =>
+        new()
+        {
+            Name = "ForkExpand",
+            InitialState = "Start",
+            Transitions = new Dictionary<string, IReadOnlyDictionary<string, TransitionTarget>>(StringComparer.OrdinalIgnoreCase),
+            ForkTable = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Start"] = ["A", "B"]
+            },
+            JoinTable = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Join1"] = ["A", "B"]
+            },
+            WaitEventRouteTable = new Dictionary<string, IReadOnlyDictionary<string, WaitEventRouteDefinition>>(
+                StringComparer.OrdinalIgnoreCase),
+            StateExecutorFactory = new DictionaryStateExecutorFactory(
+                new Dictionary<string, IStateExecutor>(StringComparer.OrdinalIgnoreCase))
+        };
+
+    private static async Task SeedParentAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        Guid definitionId,
+        Guid definitionVersionId,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        ctx.Executions.Add(new ExecutionRow
+        {
+            ExecutionId = parentId,
+            TenantId = TestTenantIds.T1TenantId,
+            DefinitionId = definitionId,
+            DefinitionVersionId = definitionVersionId,
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = now,
+            UpdatedAt = now,
+            CancelRequested = false,
+            RestartLost = false,
+            SecuritySnapshotJson = """{"securityModelVersion":1}"""
+        });
+        ctx.ExecutionGraphSnapshots.Add(new ExecutionGraphSnapshotRow
+        {
+            ExecutionId = parentId,
+            GraphJson = """{"nodes":[],"edges":[]}""",
+            UpdatedAt = now
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task SeedChildAndBranchesAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        Guid childA,
+        Guid childB,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        foreach (var childId in new[] { childA, childB })
+        {
+            ctx.Executions.Add(new ExecutionRow
+            {
+                ExecutionId = childId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = now,
+                UpdatedAt = now,
+                CancelRequested = false,
+                RestartLost = false
+            });
+        }
+
+        ctx.ExecutionBranches.AddRange(
+            new ExecutionBranchRow
+            {
+                ParentExecutionId = parentId,
+                ExecutionId = childA,
+                ForkNodeId = "fork-node-1",
+                JoinState = "Join1",
+                BranchState = "A",
+                Status = ExecutionBranchStatuses.Running,
+                CreatedAt = now,
+                UpdatedAt = now
+            },
+            new ExecutionBranchRow
+            {
+                ParentExecutionId = parentId,
+                ExecutionId = childB,
+                ForkNodeId = "fork-node-1",
+                JoinState = "Join1",
+                BranchState = "B",
+                Status = ExecutionBranchStatuses.Running,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task SeedPartialChildAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        Guid childA,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        ctx.Executions.Add(new ExecutionRow
+        {
+            ExecutionId = childA,
+            TenantId = TestTenantIds.T1TenantId,
+            DefinitionId = Guid.NewGuid(),
+            DefinitionVersionId = Guid.NewGuid(),
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = now,
+            UpdatedAt = now,
+            CancelRequested = false,
+            RestartLost = false
+        });
+        ctx.ExecutionBranches.Add(new ExecutionBranchRow
+        {
+            ParentExecutionId = parentId,
+            ExecutionId = childA,
+            ForkNodeId = "fork-node-1",
+            JoinState = "Join1",
+            BranchState = "A",
+            Status = ExecutionBranchStatuses.Running,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private sealed class GuidIdGenerator : IIdGenerator
+    {
+        public Guid NewGuid() => Guid.NewGuid();
+    }
+
+    private sealed class StubDisplayIdWrites : IDisplayIdWriteService
+    {
+        public Task<string> AllocateAsync(ICoreUnitOfWork uow, string kind, Guid uuid, CancellationToken ct = default)
+        {
+            _ = uow;
+            _ = kind;
+            return Task.FromResult(uuid.ToString("D"));
+        }
+    }
+
+    private sealed class CapturingWorkQueue : IExecutionWorkQueue
+    {
+        public List<ExecutionWorkItemRow> Items { get; } = [];
+
+        public Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct)
+        {
+            Items.Add(item);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            EnqueueAsync(item, ct);
+
+        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
+        {
+            Items.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            EnqueueManyAsync(items, ct);
+
+        public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            int limit,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<bool> RenewLeaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task CompleteAsync(Guid workItemId, string leaseOwner, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task ReleaseAsync(Guid workItemId, string leaseOwner, DateTime availableAt, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<int> EnqueueExpiredOwnershipRecoveriesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<int> EnqueueExpiredDelayWaitResumesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// List は実データを返し、Insert だけ失敗させて D9 上限経路を踏む。
+    /// </summary>
+    private sealed class ThrowingBranchRepository : IExecutionBranchRepository
+    {
+        private readonly ExecutionBranchRepository _inner = new();
+
+        public Task InsertBranchesIdempotentAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionBranchRow> branches,
+            CancellationToken ct) =>
+            throw new InvalidOperationException("simulated insert failure");
+
+        public Task<IReadOnlyList<ExecutionBranchRow>> ListByParentAndForkNodeAsync(
+            ICoreUnitOfWork uow,
+            Guid parentExecutionId,
+            string forkNodeId,
+            CancellationToken ct) =>
+            _inner.ListByParentAndForkNodeAsync(uow, parentExecutionId, forkNodeId, ct);
+
+        public Task<IReadOnlyList<ExecutionBranchRow>> ListByParentExecutionIdAsync(
+            ICoreUnitOfWork uow,
+            Guid parentExecutionId,
+            CancellationToken ct) =>
+            _inner.ListByParentExecutionIdAsync(uow, parentExecutionId, ct);
+
+        public Task<ExecutionBranchRow?> GetByChildExecutionIdAsync(
+            ICoreUnitOfWork uow,
+            Guid childExecutionId,
+            CancellationToken ct) =>
+            _inner.GetByChildExecutionIdAsync(uow, childExecutionId, ct);
+
+        public Task<bool> TryUpdateStatusAsync(
+            ICoreUnitOfWork uow,
+            Guid parentExecutionId,
+            string forkNodeId,
+            string branchState,
+            ExecutionBranchStatusUpdate update,
+            CancellationToken ct) =>
+            _inner.TryUpdateStatusAsync(uow, parentExecutionId, forkNodeId, branchState, update, ct);
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorExpandTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorExpandTests.cs
@@ -184,6 +184,7 @@ public sealed class ForkChildExecutionCoordinatorExpandTests
             executor,
             new ExecutionRepository(),
             branches ?? new ExecutionBranchRepository(),
+            new ExecutionWaitRepository(db.Factory),
             workQueue,
             new GuidIdGenerator(),
             new StubDisplayIdWrites(),

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorGraphComposeTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorGraphComposeTests.cs
@@ -1,0 +1,212 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Persistence.Repositories;
+using Statevia.Service.Api.Tests.Infrastructure;
+using System.Text.Json.Nodes;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>ComposeReadModelGraphJsonAsync の永続連携（タスク 7）。</summary>
+public sealed class ForkChildExecutionCoordinatorGraphComposeTests
+{
+    /// <summary>親 GET 合成で子の workerId が親 graph 上に現れる。</summary>
+    [Fact]
+    public async Task ComposeReadModelGraphJsonAsync_IncludesChildWorkerIdOnParentGraph()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        const string forkNodeId = "fork0001";
+        const string parentGraph = """
+            {
+              "nodes": [
+                {
+                  "nodeId": "fork0001",
+                  "stateName": "ForkSrc",
+                  "nodeType": "Task",
+                  "startedAt": "2026-08-07T00:00:00Z",
+                  "completedAt": "2026-08-07T00:00:01Z",
+                  "fact": "Completed",
+                  "attempt": 1,
+                  "workerId": "parent-w"
+                }
+              ],
+              "edges": []
+            }
+            """;
+        const string childGraph = """
+            {
+              "nodes": [
+                {
+                  "nodeId": "child001",
+                  "stateName": "A",
+                  "nodeType": "Wait",
+                  "startedAt": "2026-08-07T00:00:01Z",
+                  "attempt": 1,
+                  "workerId": "worker-child-42"
+                }
+              ],
+              "edges": []
+            }
+            """;
+        await SeedAsync(db.Options, parentId, childId, forkNodeId, parentGraph, childGraph, now);
+        var sut = CreateSut(db);
+
+        // Act
+        var composed = await sut.ComposeReadModelGraphJsonAsync(parentId, parentGraph, CancellationToken.None);
+
+        // Assert
+        var nodes = JsonNode.Parse(composed)!["nodes"]!.AsArray().OfType<JsonObject>().ToList();
+        var childNode = Assert.Single(nodes, n => n["nodeId"]!.GetValue<string>() == "child001");
+        Assert.Equal("worker-child-42", childNode["workerId"]!.GetValue<string>());
+
+        var edges = JsonNode.Parse(composed)!["edges"]!.AsArray().OfType<JsonObject>().ToList();
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == forkNodeId
+                && e["to"]!.GetValue<string>() == "child001"
+                && e["type"]!.GetValue<int>() == 1);
+    }
+
+    private static ForkChildExecutionCoordinator CreateSut(InMemoryTestDatabase db)
+    {
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var executor = new TestCoreTransactionExecutor(uowFactory);
+        return new ForkChildExecutionCoordinator(
+            executor,
+            new ExecutionRepository(),
+            new ExecutionBranchRepository(),
+            new ExecutionWaitRepository(db.Factory),
+            new NoOpWorkQueue(),
+            new GuidIdGenerator(),
+            new StubDisplayIdWrites(),
+            new EventStoreRepository(new GuidIdGenerator()),
+            Options.Create(new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 }),
+            NullLogger<ForkChildExecutionCoordinator>.Instance);
+    }
+
+    private static async Task SeedAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        Guid childId,
+        string forkNodeId,
+        string parentGraph,
+        string childGraph,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        ctx.Executions.AddRange(
+            new ExecutionRow
+            {
+                ExecutionId = parentId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = definitionId,
+                DefinitionVersionId = definitionVersionId,
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = now,
+                UpdatedAt = now,
+                CancelRequested = false,
+                RestartLost = false
+            },
+            new ExecutionRow
+            {
+                ExecutionId = childId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = definitionId,
+                DefinitionVersionId = definitionVersionId,
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = now,
+                UpdatedAt = now,
+                CancelRequested = false,
+                RestartLost = false
+            });
+        ctx.ExecutionGraphSnapshots.AddRange(
+            new ExecutionGraphSnapshotRow
+            {
+                ExecutionId = parentId,
+                GraphJson = parentGraph
+            },
+            new ExecutionGraphSnapshotRow
+            {
+                ExecutionId = childId,
+                GraphJson = childGraph
+            });
+        ctx.ExecutionBranches.Add(new ExecutionBranchRow
+        {
+            ParentExecutionId = parentId,
+            ExecutionId = childId,
+            ForkNodeId = forkNodeId,
+            JoinState = "Join1",
+            BranchState = "A",
+            Status = ExecutionBranchStatuses.Running,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private sealed class GuidIdGenerator : IIdGenerator
+    {
+        public Guid NewGuid() => Guid.NewGuid();
+    }
+
+    private sealed class StubDisplayIdWrites : IDisplayIdWriteService
+    {
+        public Task<string> AllocateAsync(ICoreUnitOfWork uow, string kind, Guid uuid, CancellationToken ct = default) =>
+            Task.FromResult(uuid.ToString("D"));
+    }
+
+    private sealed class NoOpWorkQueue : IExecutionWorkQueue
+    {
+        public Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct) => Task.CompletedTask;
+
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            int limit,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<bool> RenewLeaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task CompleteAsync(Guid workItemId, string leaseOwner, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task ReleaseAsync(Guid workItemId, string leaseOwner, DateTime availableAt, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<int> EnqueueExpiredOwnershipRecoveriesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<int> EnqueueExpiredDelayWaitResumesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            throw new NotImplementedException();
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorGraphComposeTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorGraphComposeTests.cs
@@ -75,6 +75,25 @@ public sealed class ForkChildExecutionCoordinatorGraphComposeTests
                 && e["type"]!.GetValue<int>() == 1);
     }
 
+    /// <summary>直下の子 execution ID を列挙する（D6.1）。</summary>
+    [Fact]
+    public async Task ListDescendantExecutionIdsAsync_ReturnsDirectChild()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedAsync(db.Options, parentId, childId, "fork0001", """{"nodes":[],"edges":[]}""", """{"nodes":[],"edges":[]}""", now);
+        var sut = CreateSut(db);
+
+        // Act
+        var ids = await sut.ListDescendantExecutionIdsAsync(parentId, CancellationToken.None);
+
+        // Assert
+        Assert.Equal([childId], ids);
+    }
+
     private static ForkChildExecutionCoordinator CreateSut(InMemoryTestDatabase db)
     {
         var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorJoinAggregationTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorJoinAggregationTests.cs
@@ -142,6 +142,7 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
             executor,
             new ExecutionRepository(),
             new ExecutionBranchRepository(),
+            new ExecutionWaitRepository(db.Factory),
             workQueue,
             new GuidIdGenerator(),
             new StubDisplayIdWrites(),

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorJoinAggregationTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorJoinAggregationTests.cs
@@ -34,6 +34,8 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
             childA,
             ExecutionProjectionStatuses.Completed,
             """{"v":1}""",
+            """{"A":{"output":"a-out"}}""",
+            """{"x":1}""",
             CancellationToken.None);
 
         // Assert
@@ -48,6 +50,8 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
         var row = await verify.ExecutionBranches.SingleAsync(x => x.ExecutionId == childA);
         Assert.Equal(ExecutionBranchStatuses.Completed, row.Status);
         Assert.Equal("""{"v":1}""", row.OutputJson);
+        Assert.Equal("""{"A":{"output":"a-out"}}""", row.StatesJson);
+        Assert.Equal("""{"x":1}""", row.VarsJson);
     }
 
     /// <summary>全子 Completed なら候補 input 付き Satisfied を返す。</summary>
@@ -61,8 +65,8 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
         var childB = Guid.NewGuid();
         var now = DateTime.UtcNow;
         await SeedParentAndBranchesAsync(db.Options, parentId, childA, childB, now);
-        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Completed, """{"a":true}""", now);
-        await MarkBranchAsync(db.Options, parentId, "B", ExecutionBranchStatuses.Completed, """{"b":true}""", now);
+        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Completed, """{"a":true}""", """{"A":{"output":1}}""", """{"shared":"first"}""", now.AddSeconds(1));
+        await MarkBranchAsync(db.Options, parentId, "B", ExecutionBranchStatuses.Completed, """{"b":true}""", """{"B":{"output":2},"A":{"output":99}}""", """{"shared":"second"}""", now.AddSeconds(2));
 
         var sut = CreateSut(db, new CapturingWorkQueue());
 
@@ -77,6 +81,11 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
         Assert.True(evaluation.CandidateInputs.ContainsKey("A"));
         Assert.True(evaluation.CandidateInputs.ContainsKey("B"));
         Assert.Equal(JsonValueKind.Object, ((JsonElement)evaluation.CandidateInputs["A"]!).ValueKind);
+        Assert.NotNull(evaluation.ContextMerges);
+        Assert.Equal(2, evaluation.ContextMerges.Count);
+        Assert.True(evaluation.ContextMerges[0].States.ContainsKey("A"));
+        Assert.True(evaluation.ContextMerges[1].States.ContainsKey("A"));
+        Assert.Equal(99, ((JsonElement)evaluation.ContextMerges[1].States["A"]!).GetProperty("output").GetInt32());
     }
 
     /// <summary>一文 Failed なら Failed 評価を返す。</summary>
@@ -90,7 +99,7 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
         var childB = Guid.NewGuid();
         var now = DateTime.UtcNow;
         await SeedParentAndBranchesAsync(db.Options, parentId, childA, childB, now);
-        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Failed, null, now);
+        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Failed, null, null, null, now);
 
         var sut = CreateSut(db, new CapturingWorkQueue());
 
@@ -114,7 +123,7 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
         var childB = Guid.NewGuid();
         var now = DateTime.UtcNow;
         await SeedParentAndBranchesAsync(db.Options, parentId, childA, childB, now);
-        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Completed, "{}", now);
+        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Completed, "{}", null, null, now);
 
         var sut = CreateSut(db, new CapturingWorkQueue());
 
@@ -217,6 +226,8 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
         string branchState,
         string status,
         string? outputJson,
+        string? statesJson,
+        string? varsJson,
         DateTime now)
     {
         await using var db = new CoreDbContext(options);
@@ -224,6 +235,8 @@ public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
             x.ParentExecutionId == parentId && x.BranchState == branchState);
         row.Status = status;
         row.OutputJson = outputJson;
+        row.StatesJson = statesJson;
+        row.VarsJson = varsJson;
         row.UpdatedAt = now;
         await db.SaveChangesAsync();
     }

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorJoinAggregationTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorJoinAggregationTests.cs
@@ -1,0 +1,299 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Persistence.Repositories;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>子終端信号と Join 再評価（タスク 4）。</summary>
+public sealed class ForkChildExecutionCoordinatorJoinAggregationTests
+{
+    /// <summary>子終端で branch status を更新し親へ ChildCompleted Resume を enqueue する。</summary>
+    [Fact]
+    public async Task NotifyChildTerminalAsync_UpdatesBranchAndEnqueuesParentResume()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var childB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childA, childB, now);
+
+        var workQueue = new CapturingWorkQueue();
+        var sut = CreateSut(db, workQueue);
+
+        // Act
+        var signaled = await sut.NotifyChildTerminalAsync(
+            childA,
+            ExecutionProjectionStatuses.Completed,
+            """{"v":1}""",
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(signaled);
+        Assert.Single(workQueue.Items);
+        Assert.Equal(ExecutionWorkItemKinds.Resume, workQueue.Items[0].Kind);
+        Assert.Equal(parentId, workQueue.Items[0].ExecutionId);
+        Assert.Contains(ExecutionWaitEventNames.ChildCompleted, workQueue.Items[0].Payload, StringComparison.Ordinal);
+        Assert.Contains("fork-node-1", workQueue.Items[0].Payload, StringComparison.Ordinal);
+
+        await using var verify = new CoreDbContext(db.Options);
+        var row = await verify.ExecutionBranches.SingleAsync(x => x.ExecutionId == childA);
+        Assert.Equal(ExecutionBranchStatuses.Completed, row.Status);
+        Assert.Equal("""{"v":1}""", row.OutputJson);
+    }
+
+    /// <summary>全子 Completed なら候補 input 付き Satisfied を返す。</summary>
+    [Fact]
+    public async Task EvaluateJoinAsync_WhenAllCompleted_ReturnsSatisfiedWithCandidateInputs()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var childB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childA, childB, now);
+        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Completed, """{"a":true}""", now);
+        await MarkBranchAsync(db.Options, parentId, "B", ExecutionBranchStatuses.Completed, """{"b":true}""", now);
+
+        var sut = CreateSut(db, new CapturingWorkQueue());
+
+        // Act
+        var evaluation = await sut.EvaluateJoinAsync(parentId, "fork-node-1", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(ForkJoinEvaluationKind.Satisfied, evaluation.Kind);
+        Assert.Equal("Join1", evaluation.JoinState);
+        Assert.NotNull(evaluation.CandidateInputs);
+        Assert.Equal(2, evaluation.CandidateInputs.Count);
+        Assert.True(evaluation.CandidateInputs.ContainsKey("A"));
+        Assert.True(evaluation.CandidateInputs.ContainsKey("B"));
+        Assert.Equal(JsonValueKind.Object, ((JsonElement)evaluation.CandidateInputs["A"]!).ValueKind);
+    }
+
+    /// <summary>一文 Failed なら Failed 評価を返す。</summary>
+    [Fact]
+    public async Task EvaluateJoinAsync_WhenOneFailed_ReturnsFailed()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var childB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childA, childB, now);
+        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Failed, null, now);
+
+        var sut = CreateSut(db, new CapturingWorkQueue());
+
+        // Act
+        var evaluation = await sut.EvaluateJoinAsync(parentId, "fork-node-1", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(ForkJoinEvaluationKind.Failed, evaluation.Kind);
+        Assert.Equal(ExecutionBranchStatuses.Failed, evaluation.FailureStatus);
+        Assert.Null(evaluation.CandidateInputs);
+    }
+
+    /// <summary>未終端子が残るあいだは Waiting。</summary>
+    [Fact]
+    public async Task EvaluateJoinAsync_WhenStillRunning_ReturnsWaiting()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var childB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedParentAndBranchesAsync(db.Options, parentId, childA, childB, now);
+        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Completed, "{}", now);
+
+        var sut = CreateSut(db, new CapturingWorkQueue());
+
+        // Act
+        var evaluation = await sut.EvaluateJoinAsync(parentId, "fork-node-1", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(ForkJoinEvaluationKind.Waiting, evaluation.Kind);
+    }
+
+    private static ForkChildExecutionCoordinator CreateSut(InMemoryTestDatabase db, IExecutionWorkQueue workQueue)
+    {
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var executor = new TestCoreTransactionExecutor(uowFactory);
+        return new ForkChildExecutionCoordinator(
+            executor,
+            new ExecutionRepository(),
+            new ExecutionBranchRepository(),
+            workQueue,
+            new GuidIdGenerator(),
+            new StubDisplayIdWrites(),
+            new EventStoreRepository(new GuidIdGenerator()),
+            Options.Create(new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 }),
+            NullLogger<ForkChildExecutionCoordinator>.Instance);
+    }
+
+    private static async Task SeedParentAndBranchesAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        Guid childA,
+        Guid childB,
+        DateTime now)
+    {
+        await using var db = new CoreDbContext(options);
+        var tenantId = TestTenantIds.T1TenantId;
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        db.Executions.Add(new ExecutionRow
+        {
+            ExecutionId = parentId,
+            TenantId = tenantId,
+            DefinitionId = definitionId,
+            DefinitionVersionId = definitionVersionId,
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = now,
+            UpdatedAt = now,
+            SecuritySnapshotJson = "{}"
+        });
+        db.Executions.Add(new ExecutionRow
+        {
+            ExecutionId = childA,
+            TenantId = tenantId,
+            DefinitionId = definitionId,
+            DefinitionVersionId = definitionVersionId,
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = now,
+            UpdatedAt = now,
+            SecuritySnapshotJson = "{}"
+        });
+        db.Executions.Add(new ExecutionRow
+        {
+            ExecutionId = childB,
+            TenantId = tenantId,
+            DefinitionId = definitionId,
+            DefinitionVersionId = definitionVersionId,
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = now,
+            UpdatedAt = now,
+            SecuritySnapshotJson = "{}"
+        });
+        db.ExecutionBranches.AddRange(
+            new ExecutionBranchRow
+            {
+                ParentExecutionId = parentId,
+                ExecutionId = childA,
+                ForkNodeId = "fork-node-1",
+                JoinState = "Join1",
+                BranchState = "A",
+                Status = ExecutionBranchStatuses.Running,
+                CreatedAt = now,
+                UpdatedAt = now
+            },
+            new ExecutionBranchRow
+            {
+                ParentExecutionId = parentId,
+                ExecutionId = childB,
+                ForkNodeId = "fork-node-1",
+                JoinState = "Join1",
+                BranchState = "B",
+                Status = ExecutionBranchStatuses.Running,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task MarkBranchAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        string branchState,
+        string status,
+        string? outputJson,
+        DateTime now)
+    {
+        await using var db = new CoreDbContext(options);
+        var row = await db.ExecutionBranches.SingleAsync(x =>
+            x.ParentExecutionId == parentId && x.BranchState == branchState);
+        row.Status = status;
+        row.OutputJson = outputJson;
+        row.UpdatedAt = now;
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class GuidIdGenerator : IIdGenerator
+    {
+        public Guid NewGuid() => Guid.NewGuid();
+    }
+
+    private sealed class StubDisplayIdWrites : IDisplayIdWriteService
+    {
+        public Task<string> AllocateAsync(ICoreUnitOfWork uow, string kind, Guid uuid, CancellationToken ct = default)
+        {
+            _ = uow;
+            _ = kind;
+            return Task.FromResult(uuid.ToString("D"));
+        }
+    }
+
+    private sealed class CapturingWorkQueue : IExecutionWorkQueue
+    {
+        public List<ExecutionWorkItemRow> Items { get; } = [];
+
+        public Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct)
+        {
+            Items.Add(item);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            EnqueueAsync(item, ct);
+
+        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
+        {
+            Items.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            EnqueueManyAsync(items, ct);
+
+        public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            int limit,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<bool> RenewLeaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task CompleteAsync(Guid workItemId, string leaseOwner, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task ReleaseAsync(Guid workItemId, string leaseOwner, DateTime availableAt, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<int> EnqueueExpiredOwnershipRecoveriesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            Task.FromResult(0);
+
+        public Task<int> EnqueueExpiredDelayWaitResumesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            Task.FromResult(0);
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorJoinResolutionTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorJoinResolutionTests.cs
@@ -1,0 +1,104 @@
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+using Statevia.Core.Engine.Abstractions;
+using Statevia.Core.Engine.Definition;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary><see cref="ForkChildExecutionCoordinator.ResolveJoinState"/> の解決規則。</summary>
+public sealed class ForkChildExecutionCoordinatorJoinResolutionTests
+{
+    /// <summary>Join.all と分岐先頭集合が一致する Join を返す。</summary>
+    [Fact]
+    public void ResolveJoinState_ReturnsMatchingJoin()
+    {
+        // Arrange
+        var definition = CreateDefinition(
+            fork: ("Start", ["A", "B"]),
+            join: ("Join1", ["A", "B"]));
+        var branches = new[]
+        {
+            new ForkBranchExpansion("A", null),
+            new ForkBranchExpansion("B", null)
+        };
+
+        // Act
+        var joinState = ForkChildExecutionCoordinator.ResolveJoinState(definition, branches);
+
+        // Assert
+        Assert.Equal("Join1", joinState);
+    }
+
+    /// <summary>一致する Join が無いとき例外になる。</summary>
+    [Fact]
+    public void ResolveJoinState_Throws_WhenNoJoinMatches()
+    {
+        // Arrange
+        var definition = CreateDefinition(
+            fork: ("Start", ["A", "B"]),
+            join: ("Join1", ["A", "C"]));
+        var branches = new[]
+        {
+            new ForkBranchExpansion("A", null),
+            new ForkBranchExpansion("B", null)
+        };
+
+        // Act
+        var act = () => ForkChildExecutionCoordinator.ResolveJoinState(definition, branches);
+
+        // Assert
+        Assert.Throws<ForkJoinResolutionException>(act);
+    }
+
+    /// <summary>複数 Join が同一分岐集合に一致するとき曖昧として例外になる。</summary>
+    [Fact]
+    public void ResolveJoinState_Throws_WhenJoinIsAmbiguous()
+    {
+        // Arrange
+        var definition = CreateDefinition(
+            fork: ("Start", ["A", "B"]),
+            joins:
+            [
+                ("Join1", ["A", "B"]),
+                ("Join2", ["A", "B"])
+            ]);
+        var branches = new[]
+        {
+            new ForkBranchExpansion("A", null),
+            new ForkBranchExpansion("B", null)
+        };
+
+        // Act
+        var act = () => ForkChildExecutionCoordinator.ResolveJoinState(definition, branches);
+
+        // Assert
+        Assert.Throws<ForkJoinResolutionException>(act);
+    }
+
+    private static CompiledWorkflowDefinition CreateDefinition(
+        (string State, string[] Branches) fork,
+        (string State, string[] All) join) =>
+        CreateDefinition(fork, [join]);
+
+    private static CompiledWorkflowDefinition CreateDefinition(
+        (string State, string[] Branches) fork,
+        (string State, string[] All)[] joins) =>
+        new()
+        {
+            Name = "ForkJoinResolve",
+            InitialState = fork.State,
+            Transitions = new Dictionary<string, IReadOnlyDictionary<string, TransitionTarget>>(StringComparer.OrdinalIgnoreCase),
+            ForkTable = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                [fork.State] = fork.Branches
+            },
+            JoinTable = joins.ToDictionary(
+                j => j.State,
+                j => (IReadOnlyList<string>)j.All,
+                StringComparer.OrdinalIgnoreCase),
+            WaitEventRouteTable = new Dictionary<string, IReadOnlyDictionary<string, WaitEventRouteDefinition>>(
+                StringComparer.OrdinalIgnoreCase),
+            StateExecutorFactory = new DictionaryStateExecutorFactory(
+                new Dictionary<string, IStateExecutor>(StringComparer.OrdinalIgnoreCase))
+        };
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorNestAndRecoveryTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorNestAndRecoveryTests.cs
@@ -1,0 +1,445 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+using Statevia.Core.Engine.Abstractions;
+using Statevia.Core.Engine.Definition;
+using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Persistence.Repositories;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>
+/// タスク 9: ネスト Fork の基本完走と展開の一時失敗リカバリ（循環耐久・幽霊枝は follow-up）。
+/// </summary>
+public sealed class ForkChildExecutionCoordinatorNestAndRecoveryTests
+{
+    /// <summary>展開の一時失敗後、リトライで子と Start が作成される（D9）。</summary>
+    [Fact]
+    public async Task ExpandForkAsync_WhenTransientFailure_RetriesAndSucceeds()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedExecutionAsync(db.Options, parentId, definitionId, definitionVersionId, now);
+
+        var workQueue = new CapturingWorkQueue();
+        var branches = new FailOnceThenSucceedBranchRepository();
+        var sut = CreateSut(
+            db,
+            workQueue,
+            new ForkChildExpansionOptions { MaxAttempts = 3, BaseDelayMs = 0 },
+            branches);
+        var request = CreateFlatExpandRequest(parentId, definitionId, definitionVersionId);
+
+        // Act
+        var result = await sut.ExpandForkAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, result.ChildExecutionIds.Count);
+        Assert.Equal(2, branches.InsertCalls);
+        Assert.Equal(2, workQueue.Items.Count);
+        Assert.All(workQueue.Items, item => Assert.Equal(ExecutionWorkItemKinds.Start, item.Kind));
+
+        await using var verify = new CoreDbContext(db.Options);
+        Assert.Equal(2, await verify.ExecutionBranches.CountAsync(x => x.ParentExecutionId == parentId));
+        var parent = await verify.Executions.SingleAsync(x => x.ExecutionId == parentId);
+        Assert.Equal(ExecutionProjectionStatuses.Running, parent.Status);
+    }
+
+    /// <summary>展開済み再入は Start を増やさず既存子 ID を返す（クラッシュ後 recovery）。</summary>
+    [Fact]
+    public async Task ExpandForkAsync_AfterCrashWithFullBranches_IsIdempotentRecovery()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        var childA = Guid.NewGuid();
+        var childB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedExecutionAsync(db.Options, parentId, definitionId, definitionVersionId, now);
+        await SeedBranchAsync(db.Options, parentId, childA, "fork-node-1", "Join1", "A", now);
+        await SeedBranchAsync(db.Options, parentId, childB, "fork-node-1", "Join1", "B", now);
+
+        var workQueue = new CapturingWorkQueue();
+        var sut = CreateSut(db, workQueue, new ForkChildExpansionOptions { MaxAttempts = 2, BaseDelayMs = 0 });
+        var request = CreateFlatExpandRequest(parentId, definitionId, definitionVersionId);
+
+        // Act
+        var result = await sut.ExpandForkAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Equal(
+            new[] { childA, childB }.OrderBy(x => x).ToArray(),
+            result.ChildExecutionIds.OrderBy(x => x).ToArray());
+        Assert.Empty(workQueue.Items);
+    }
+
+    /// <summary>ネスト: 内側 Join 充足のあと外側 Join も充足できる（D4 基本経路）。</summary>
+    [Fact]
+    public async Task NestedFork_InnerThenOuterJoin_BothSatisfied()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var outerId = Guid.NewGuid();
+        var midId = Guid.NewGuid();
+        var siblingId = Guid.NewGuid();
+        var innerA = Guid.NewGuid();
+        var innerB = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+
+        await SeedExecutionAsync(db.Options, outerId, definitionId, definitionVersionId, now);
+        await SeedExecutionAsync(db.Options, midId, definitionId, definitionVersionId, now);
+        await SeedExecutionAsync(db.Options, siblingId, definitionId, definitionVersionId, now);
+        await SeedExecutionAsync(db.Options, innerA, definitionId, definitionVersionId, now);
+        await SeedExecutionAsync(db.Options, innerB, definitionId, definitionVersionId, now);
+
+        // 外側: OuterFast + Mid（内側 Fork 枝）
+        await SeedBranchAsync(db.Options, outerId, siblingId, "outer-fork", "OuterJoin", "OuterFast", now);
+        await SeedBranchAsync(db.Options, outerId, midId, "outer-fork", "OuterJoin", "InnerFork", now);
+        // 内側: Mid が親
+        await SeedBranchAsync(db.Options, midId, innerA, "inner-fork", "InnerJoin", "InnerA", now);
+        await SeedBranchAsync(db.Options, midId, innerB, "inner-fork", "InnerJoin", "InnerB", now);
+
+        await MarkBranchAsync(db.Options, midId, "InnerA", ExecutionBranchStatuses.Completed, """{"a":1}""", now.AddSeconds(1));
+        await MarkBranchAsync(db.Options, midId, "InnerB", ExecutionBranchStatuses.Completed, """{"b":2}""", now.AddSeconds(2));
+        await MarkBranchAsync(db.Options, outerId, "OuterFast", ExecutionBranchStatuses.Completed, """{"fast":true}""", now.AddSeconds(3));
+
+        var sut = CreateSut(db, new CapturingWorkQueue(), new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 });
+
+        // Act — 内側充足
+        var innerEval = await sut.EvaluateJoinAsync(midId, "inner-fork", CancellationToken.None);
+        Assert.Equal(ForkJoinEvaluationKind.Satisfied, innerEval.Kind);
+        Assert.Equal("InnerJoin", innerEval.JoinState);
+
+        // Mid 終端を外側へ通知
+        var signaled = await sut.NotifyChildTerminalAsync(
+            midId,
+            ExecutionProjectionStatuses.Completed,
+            """{"mid":true}""",
+            """{"InnerFork":{"output":"merged"}}""",
+            """{"k":1}""",
+            CancellationToken.None);
+        Assert.True(signaled);
+
+        // Act — 外側充足
+        var outerEval = await sut.EvaluateJoinAsync(outerId, "outer-fork", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(ForkJoinEvaluationKind.Satisfied, outerEval.Kind);
+        Assert.Equal("OuterJoin", outerEval.JoinState);
+        Assert.NotNull(outerEval.CandidateInputs);
+        Assert.True(outerEval.CandidateInputs.ContainsKey("OuterFast"));
+        Assert.True(outerEval.CandidateInputs.ContainsKey("InnerFork"));
+    }
+
+    /// <summary>子孫列挙は孫まで再帰する（ネスト D4 / D6.1）。</summary>
+    [Fact]
+    public async Task ListDescendantExecutionIdsAsync_ReturnsNestedGrandchild()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var outerId = Guid.NewGuid();
+        var midId = Guid.NewGuid();
+        var leafId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        await SeedExecutionAsync(db.Options, outerId, definitionId, definitionVersionId, now);
+        await SeedExecutionAsync(db.Options, midId, definitionId, definitionVersionId, now);
+        await SeedExecutionAsync(db.Options, leafId, definitionId, definitionVersionId, now);
+        await SeedBranchAsync(db.Options, outerId, midId, "outer-fork", "OuterJoin", "InnerFork", now);
+        await SeedBranchAsync(db.Options, midId, leafId, "inner-fork", "InnerJoin", "InnerA", now);
+
+        var sut = CreateSut(db, new CapturingWorkQueue(), new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 });
+
+        // Act
+        var ids = await sut.ListDescendantExecutionIdsAsync(outerId, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, ids.Count);
+        Assert.Contains(midId, ids);
+        Assert.Contains(leafId, ids);
+        Assert.DoesNotContain(outerId, ids);
+    }
+
+    private static ForkChildExecutionCoordinator CreateSut(
+        InMemoryTestDatabase db,
+        IExecutionWorkQueue workQueue,
+        ForkChildExpansionOptions options,
+        IExecutionBranchRepository? branches = null)
+    {
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var executor = new TestCoreTransactionExecutor(uowFactory);
+        return new ForkChildExecutionCoordinator(
+            executor,
+            new ExecutionRepository(),
+            branches ?? new ExecutionBranchRepository(),
+            new ExecutionWaitRepository(db.Factory),
+            workQueue,
+            new GuidIdGenerator(),
+            new StubDisplayIdWrites(),
+            new EventStoreRepository(new GuidIdGenerator()),
+            Options.Create(options),
+            NullLogger<ForkChildExecutionCoordinator>.Instance);
+    }
+
+    private static ForkExpansionRequest CreateFlatExpandRequest(
+        Guid parentId,
+        Guid definitionId,
+        Guid definitionVersionId) =>
+        new(
+            ParentExecutionId: parentId,
+            TenantId: TestTenantIds.T1TenantId,
+            DefinitionId: definitionId,
+            DefinitionVersionId: definitionVersionId,
+            DefinitionVersion: 1,
+            DefinitionDisplayId: definitionId.ToString("D"),
+            SecuritySnapshotJson: """{"securityModelVersion":1}""",
+            CompiledDefinition: CreateFlatDefinition(),
+            ForkNodeId: "fork-node-1",
+            Branches:
+            [
+                new ForkBranchExpansion("A", new { n = 1 }),
+                new ForkBranchExpansion("B", new { n = 2 })
+            ]);
+
+    private static CompiledWorkflowDefinition CreateFlatDefinition() =>
+        new()
+        {
+            Name = "NestRecoveryFlat",
+            InitialState = "Start",
+            Transitions = new Dictionary<string, IReadOnlyDictionary<string, TransitionTarget>>(StringComparer.OrdinalIgnoreCase),
+            ForkTable = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Start"] = ["A", "B"]
+            },
+            JoinTable = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Join1"] = ["A", "B"]
+            },
+            WaitEventRouteTable = new Dictionary<string, IReadOnlyDictionary<string, WaitEventRouteDefinition>>(
+                StringComparer.OrdinalIgnoreCase),
+            StateExecutorFactory = new DictionaryStateExecutorFactory(
+                new Dictionary<string, IStateExecutor>(StringComparer.OrdinalIgnoreCase))
+        };
+
+    private static async Task SeedExecutionAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid executionId,
+        Guid definitionId,
+        Guid definitionVersionId,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        if (await ctx.Executions.AnyAsync(x => x.ExecutionId == executionId))
+            return;
+
+        ctx.Executions.Add(new ExecutionRow
+        {
+            ExecutionId = executionId,
+            TenantId = TestTenantIds.T1TenantId,
+            DefinitionId = definitionId,
+            DefinitionVersionId = definitionVersionId,
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = now,
+            UpdatedAt = now,
+            CancelRequested = false,
+            RestartLost = false,
+            SecuritySnapshotJson = """{"securityModelVersion":1}"""
+        });
+        ctx.ExecutionGraphSnapshots.Add(new ExecutionGraphSnapshotRow
+        {
+            ExecutionId = executionId,
+            GraphJson = """{"nodes":[],"edges":[]}""",
+            UpdatedAt = now
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task SeedBranchAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        Guid childId,
+        string forkNodeId,
+        string joinState,
+        string branchState,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        if (!await ctx.Executions.AnyAsync(x => x.ExecutionId == childId))
+        {
+            ctx.Executions.Add(new ExecutionRow
+            {
+                ExecutionId = childId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = now,
+                UpdatedAt = now,
+                CancelRequested = false,
+                RestartLost = false
+            });
+        }
+
+        ctx.ExecutionBranches.Add(new ExecutionBranchRow
+        {
+            ParentExecutionId = parentId,
+            ExecutionId = childId,
+            ForkNodeId = forkNodeId,
+            JoinState = joinState,
+            BranchState = branchState,
+            Status = ExecutionBranchStatuses.Running,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task MarkBranchAsync(
+        DbContextOptions<CoreDbContext> options,
+        Guid parentId,
+        string branchState,
+        string status,
+        string? outputJson,
+        DateTime now)
+    {
+        await using var ctx = new CoreDbContext(options);
+        var row = await ctx.ExecutionBranches.SingleAsync(x =>
+            x.ParentExecutionId == parentId && x.BranchState == branchState);
+        row.Status = status;
+        row.OutputJson = outputJson;
+        row.UpdatedAt = now;
+        await ctx.SaveChangesAsync();
+    }
+
+    private sealed class GuidIdGenerator : IIdGenerator
+    {
+        public Guid NewGuid() => Guid.NewGuid();
+    }
+
+    private sealed class StubDisplayIdWrites : IDisplayIdWriteService
+    {
+        public Task<string> AllocateAsync(ICoreUnitOfWork uow, string kind, Guid uuid, CancellationToken ct = default)
+        {
+            _ = uow;
+            _ = kind;
+            return Task.FromResult(uuid.ToString("D"));
+        }
+    }
+
+    private sealed class CapturingWorkQueue : IExecutionWorkQueue
+    {
+        public List<ExecutionWorkItemRow> Items { get; } = [];
+
+        public Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct)
+        {
+            Items.Add(item);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            EnqueueAsync(item, ct);
+
+        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
+        {
+            Items.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            EnqueueManyAsync(items, ct);
+
+        public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            int limit,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<bool> RenewLeaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task CompleteAsync(Guid workItemId, string leaseOwner, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task ReleaseAsync(Guid workItemId, string leaseOwner, DateTime availableAt, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<int> EnqueueExpiredOwnershipRecoveriesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            Task.FromResult(0);
+
+        public Task<int> EnqueueExpiredDelayWaitResumesAsync(DateTime nowUtc, int limit, CancellationToken ct) =>
+            Task.FromResult(0);
+    }
+
+    /// <summary>1 回目の Insert だけ失敗させ、2 回目以降は実リポジトリへ委譲する。</summary>
+    private sealed class FailOnceThenSucceedBranchRepository : IExecutionBranchRepository
+    {
+        private readonly ExecutionBranchRepository _inner = new();
+
+        public int InsertCalls { get; private set; }
+
+        public Task InsertBranchesIdempotentAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionBranchRow> branches,
+            CancellationToken ct)
+        {
+            InsertCalls++;
+            if (InsertCalls == 1)
+                throw new InvalidOperationException("simulated transient insert failure");
+
+            return _inner.InsertBranchesIdempotentAsync(uow, branches, ct);
+        }
+
+        public Task<IReadOnlyList<ExecutionBranchRow>> ListByParentAndForkNodeAsync(
+            ICoreUnitOfWork uow,
+            Guid parentExecutionId,
+            string forkNodeId,
+            CancellationToken ct) =>
+            _inner.ListByParentAndForkNodeAsync(uow, parentExecutionId, forkNodeId, ct);
+
+        public Task<IReadOnlyList<ExecutionBranchRow>> ListByParentExecutionIdAsync(
+            ICoreUnitOfWork uow,
+            Guid parentExecutionId,
+            CancellationToken ct) =>
+            _inner.ListByParentExecutionIdAsync(uow, parentExecutionId, ct);
+
+        public Task<ExecutionBranchRow?> GetByChildExecutionIdAsync(
+            ICoreUnitOfWork uow,
+            Guid childExecutionId,
+            CancellationToken ct) =>
+            _inner.GetByChildExecutionIdAsync(uow, childExecutionId, ct);
+
+        public Task<bool> TryUpdateStatusAsync(
+            ICoreUnitOfWork uow,
+            Guid parentExecutionId,
+            string forkNodeId,
+            string branchState,
+            ExecutionBranchStatusUpdate update,
+            CancellationToken ct) =>
+            _inner.TryUpdateStatusAsync(uow, parentExecutionId, forkNodeId, branchState, update, ct);
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
@@ -375,6 +375,12 @@ public sealed class ForkExpansionHostHandlerTests
             string eventName,
             CancellationToken ct) =>
             Task.FromResult<ForkWaitDeliveryTarget?>(null);
+
+        public Task<string> ComposeReadModelGraphJsonAsync(
+            Guid executionId,
+            string baseGraphJson,
+            CancellationToken ct) =>
+            Task.FromResult(baseGraphJson);
     }
 
     private sealed class RecordingExecutionService : IExecutionService

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
@@ -1,0 +1,415 @@
+using System.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+using Statevia.Core.Engine.Abstractions;
+using Statevia.Core.Engine.Definition;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary><see cref="ForkExpansionHostHandler"/> の分岐配線。</summary>
+public sealed class ForkExpansionHostHandlerTests
+{
+    /// <summary>不正な親 execution id は展開も Unload もしない。</summary>
+    [Fact]
+    public async Task HandleAsync_InvalidExecutionId_Skips()
+    {
+        // Arrange
+        var coordinator = new RecordingCoordinator();
+        var executions = new RecordingExecutionService();
+        var sut = CreateSut(coordinator, executions, parent: null);
+
+        // Act
+        await sut.HandleAsync(CreateEvent("bad-id"), CancellationToken.None);
+
+        // Assert
+        Assert.False(coordinator.Called);
+        Assert.False(executions.UnloadCalled);
+    }
+
+    /// <summary>親が無いとき展開も Unload もしない。</summary>
+    [Fact]
+    public async Task HandleAsync_ParentMissing_Skips()
+    {
+        // Arrange
+        var parentId = Guid.NewGuid();
+        var coordinator = new RecordingCoordinator();
+        var executions = new RecordingExecutionService();
+        var sut = CreateSut(coordinator, executions, parent: null);
+
+        // Act
+        await sut.HandleAsync(CreateEvent(parentId.ToString("D")), CancellationToken.None);
+
+        // Assert
+        Assert.False(coordinator.Called);
+        Assert.False(executions.UnloadCalled);
+    }
+
+    /// <summary>展開成功時は親を Unload する。</summary>
+    [Fact]
+    public async Task HandleAsync_ExpandSucceeded_UnloadsParent()
+    {
+        // Arrange
+        var parentId = Guid.NewGuid();
+        var coordinator = new RecordingCoordinator
+        {
+            Result = new ForkExpansionResult(true, [Guid.NewGuid()], "Join1")
+        };
+        var executions = new RecordingExecutionService();
+        var sut = CreateSut(coordinator, executions, CreateParent(parentId));
+
+        // Act
+        await sut.HandleAsync(CreateEvent(parentId.ToString("D")), CancellationToken.None);
+
+        // Assert
+        Assert.True(coordinator.Called);
+        Assert.True(executions.UnloadCalled);
+        Assert.Equal(parentId.ToString("D"), executions.LastEngineExecutionId);
+        Assert.Equal("Start", executions.LastNodeId);
+    }
+
+    /// <summary>展開失敗時も親を Unload する。</summary>
+    [Fact]
+    public async Task HandleAsync_ExpandFailed_StillUnloadsParent()
+    {
+        // Arrange
+        var parentId = Guid.NewGuid();
+        var coordinator = new RecordingCoordinator
+        {
+            Result = new ForkExpansionResult(false, [], "Join1")
+        };
+        var executions = new RecordingExecutionService();
+        var sut = CreateSut(coordinator, executions, CreateParent(parentId));
+
+        // Act
+        await sut.HandleAsync(CreateEvent(parentId.ToString("D")), CancellationToken.None);
+
+        // Assert
+        Assert.True(coordinator.Called);
+        Assert.True(executions.UnloadCalled);
+    }
+
+    /// <summary>親に security snapshot が無いとき例外になる。</summary>
+    [Fact]
+    public async Task HandleAsync_MissingSecuritySnapshot_Throws()
+    {
+        // Arrange
+        var parentId = Guid.NewGuid();
+        var parent = CreateParent(parentId);
+        parent.SecuritySnapshotJson = null;
+        var sut = CreateSut(new RecordingCoordinator(), new RecordingExecutionService(), parent);
+
+        // Act
+        var act = () => sut.HandleAsync(CreateEvent(parentId.ToString("D")), CancellationToken.None);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+    }
+
+    /// <summary>定義版が無いとき例外になる。</summary>
+    [Fact]
+    public async Task HandleAsync_MissingDefinitionVersion_Throws()
+    {
+        // Arrange
+        var parentId = Guid.NewGuid();
+        var sut = CreateSut(
+            new RecordingCoordinator(),
+            new RecordingExecutionService(),
+            CreateParent(parentId),
+            definitionVersionMissing: true);
+
+        // Act
+        var act = () => sut.HandleAsync(CreateEvent(parentId.ToString("D")), CancellationToken.None);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+    }
+
+    private static ForkExpansionHostHandler CreateSut(
+        IForkChildExecutionCoordinator coordinator,
+        IExecutionService executionService,
+        ExecutionRow? parent,
+        bool definitionVersionMissing = false) =>
+        new(
+            new ReadOnlyExecutor(),
+            new StubExecutionRepository(parent),
+            new StubDefinitionRepository(definitionVersionMissing ? null : StubDefinitionRepository.CreateDefaultVersion()),
+            new StubCompiler(),
+            coordinator,
+            executionService,
+            NullLogger<ForkExpansionHostHandler>.Instance);
+
+    private static ForkExpansionEvent CreateEvent(string executionId) =>
+        new(
+            ExecutionId: executionId,
+            ForkState: "Start",
+            SourceNodeId: "Start",
+            Branches:
+            [
+                new ForkBranchExpansionPlan("A", null),
+                new ForkBranchExpansionPlan("B", null)
+            ]);
+
+    private static ExecutionRow CreateParent(Guid parentId) =>
+        new()
+        {
+            ExecutionId = parentId,
+            TenantId = Guid.Parse("00000000-0000-4000-8000-000000000002"),
+            DefinitionId = Guid.NewGuid(),
+            DefinitionVersionId = Guid.NewGuid(),
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            CancelRequested = false,
+            RestartLost = false,
+            SecuritySnapshotJson = """{"securityModelVersion":1}"""
+        };
+
+    private sealed class ReadOnlyExecutor : ICoreTransactionExecutor
+    {
+        public Task ExecuteReadCommittedAsync(
+            Func<ICoreUnitOfWork, CancellationToken, Task> work,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<T> ExecuteReadCommittedAsync<T>(
+            Func<ICoreUnitOfWork, CancellationToken, Task<T>> work,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task ExecuteReadOnlyAsync(
+            Func<ICoreUnitOfWork, CancellationToken, Task> work,
+            CancellationToken cancellationToken = default) =>
+            work(StubUnitOfWork.Instance, cancellationToken);
+
+        public Task<T> ExecuteReadOnlyAsync<T>(
+            Func<ICoreUnitOfWork, CancellationToken, Task<T>> work,
+            CancellationToken cancellationToken = default) =>
+            work(StubUnitOfWork.Instance, cancellationToken);
+    }
+
+    private sealed class StubUnitOfWork : ICoreUnitOfWork
+    {
+        public static readonly StubUnitOfWork Instance = new();
+        public ICoreDatabase Db => throw new NotImplementedException();
+        public Task BeginTransactionAsync(IsolationLevel level, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+        public Task<int> SaveChangesAsync(CancellationToken cancellationToken) => Task.FromResult(0);
+        public Task CommitAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task RollbackAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class StubExecutionRepository(ExecutionRow? parent) : IExecutionRepository
+    {
+        public Task<ExecutionRow?> GetByIdAsync(ICoreUnitOfWork uow, Guid tenantId, Guid executionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<ExecutionRow?> GetByExecutionIdAsync(ICoreUnitOfWork uow, Guid executionId, CancellationToken ct) =>
+            Task.FromResult(parent is not null && parent.ExecutionId == executionId ? parent : null);
+
+        public Task<(int TotalCount, List<(ExecutionRow Execution, string? DisplayId)> Items)> ListWithDisplayIdsPageAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            ExecutionListPageQuery query,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task AddExecutionAndSnapshotAsync(
+            ICoreUnitOfWork uow,
+            ExecutionRow execution,
+            ExecutionGraphSnapshotRow snapshot,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<ExecutionGraphSnapshotRow?> GetSnapshotByExecutionIdAsync(
+            ICoreUnitOfWork uow,
+            Guid executionId,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task UpdateExecutionAndSnapshotAsync(
+            ICoreUnitOfWork uow,
+            Guid executionId,
+            string status,
+            bool? cancelRequested,
+            string graphJson,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+    }
+
+    private sealed class StubDefinitionRepository(DefinitionVersionRow? version) : IDefinitionRepository
+    {
+        public static DefinitionVersionRow CreateDefaultVersion() =>
+            new()
+            {
+                DefinitionVersionId = Guid.NewGuid(),
+                DefinitionId = Guid.NewGuid(),
+                Version = 1,
+                SourceYaml = "name: stub",
+                CompiledJson = "{}",
+                CreatedAt = DateTime.UtcNow
+            };
+
+        public Task<DefinitionDetail?> GetLatestForApiAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionRow?> GetLatestForMutationAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionVersionRow?> GetVersionForExecutionAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, int version, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionVersionRow?> GetVersionForExecutionByIdAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionVersionId, CancellationToken ct)
+        {
+            if (version is null)
+                return Task.FromResult<DefinitionVersionRow?>(null);
+
+            return Task.FromResult<DefinitionVersionRow?>(new DefinitionVersionRow
+            {
+                DefinitionVersionId = definitionVersionId,
+                DefinitionId = version.DefinitionId,
+                Version = version.Version,
+                SourceYaml = version.SourceYaml,
+                CompiledJson = version.CompiledJson,
+                CreatedAt = version.CreatedAt
+            });
+        }
+
+        public Task<DefinitionVersionRow?> GetVersionForApiAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, int version, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionRow?> GetDeletedCatalogEntryAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<Guid?> ResolveProjectIdAsync(ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task AddWithInitialVersionAsync(
+            ICoreUnitOfWork uow, DefinitionRow definition, DefinitionVersionRow version, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionDetail?> PublishVersionAsync(
+            ICoreUnitOfWork uow, DefinitionVersionPublishCommand command, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<(int TotalCount, List<(DefinitionDetail Detail, string? DisplayId)> Items)> ListWithDisplayIdsPageAsync(
+            ICoreUnitOfWork uow, Guid tenantId, DefinitionListPageQuery query, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionSoftDeleteOutcome> SoftDeleteAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, DateTime deletedAt, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionDetail?> RestoreAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<bool> ExistsActiveSlugInProjectAsync(
+            ICoreUnitOfWork uow, Guid projectId, string slug, Guid excludingDefinitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+    }
+
+    private sealed class StubCompiler : IDefinitionCompilerService
+    {
+        public CompiledWorkflowDefinition RestoreFromStoredVersion(string sourceYaml, string compiledJson) =>
+            new()
+            {
+                Name = "stub",
+                InitialState = "Start",
+                Transitions = new Dictionary<string, IReadOnlyDictionary<string, TransitionTarget>>(StringComparer.OrdinalIgnoreCase),
+                ForkTable = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase),
+                JoinTable = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase),
+                WaitEventRouteTable = new Dictionary<string, IReadOnlyDictionary<string, WaitEventRouteDefinition>>(
+                    StringComparer.OrdinalIgnoreCase),
+                StateExecutorFactory = new DictionaryStateExecutorFactory(
+                    new Dictionary<string, IStateExecutor>(StringComparer.OrdinalIgnoreCase))
+            };
+
+        public (CompiledWorkflowDefinition Compiled, string CompiledJson) ValidateAndCompile(
+            string name,
+            string yaml,
+            Guid? tenantId = null) =>
+            throw new NotImplementedException();
+    }
+
+    private sealed class RecordingCoordinator : IForkChildExecutionCoordinator
+    {
+        public bool Called { get; private set; }
+        public ForkExpansionResult Result { get; set; } = new(true, [], "Join1");
+
+        public Task<ForkExpansionResult> ExpandForkAsync(ForkExpansionRequest request, CancellationToken ct)
+        {
+            Called = true;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private sealed class RecordingExecutionService : IExecutionService
+    {
+        public bool UnloadCalled { get; private set; }
+        public string? LastEngineExecutionId { get; private set; }
+        public string? LastNodeId { get; private set; }
+
+        public Task PersistCheckpointAndUnloadByEngineIdAsync(string engineExecutionId, string nodeId, CancellationToken ct)
+        {
+            UnloadCalled = true;
+            LastEngineExecutionId = engineExecutionId;
+            LastNodeId = nodeId;
+            return Task.CompletedTask;
+        }
+
+        public Task<ExecutionResponse> StartAsync(
+            StartExecutionRequest request, string? idempotencyKey, CommandRequestContext requestContext, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task<ExecutionResponse> ExecuteQueuedStartAsync(Guid executionId, StartExecutionRequest request, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task<PagedResult<ExecutionResponse>> ListPagedAsync(ExecutionListPageQuery query, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task EnsureExecutionExistsAsync(Guid executionId, CancellationToken ct) => throw new NotImplementedException();
+        public Task<string> GetGraphJsonAsync(string idOrUuid, CancellationToken ct) => throw new NotImplementedException();
+        public Task<string?> TryGetSnapshotGraphJsonByExecutionIdAsync(Guid executionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task<ExecutionViewDto> GetExecutionViewAtSeqAsync(string idOrUuid, long atSeq, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task<ExecutionEventsResponseDto> ListEventsAsync(string idOrUuid, long afterSeq, int limit, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task ResumeNodeAsync(
+            string idOrUuid, string nodeId, string? resumeKey, string? idempotencyKey,
+            CommandRequestContext requestContext, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task RecoverExecutionAsync(Guid executionId, CommandRequestContext requestContext, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task CancelAsync(
+            string idOrUuid, string? idempotencyKey, CommandRequestContext requestContext, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task PublishEventAsync(
+            string idOrUuid, string eventName, string? idempotencyKey, CommandRequestContext requestContext, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task UpdateProjectionFromEngineAsync(Guid executionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task PersistCheckpointAndUnloadAsync(Guid executionId, string nodeId, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task<long?> BeginOwnedSessionAsync(
+            Guid executionId, string workerId, TimeSpan leaseDuration, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task<bool> RenewOwnedSessionLeaseAsync(Guid executionId, TimeSpan leaseDuration, CancellationToken ct) =>
+            throw new NotImplementedException();
+        public Task EndOwnedSessionAsync(Guid executionId, CancellationToken ct) => throw new NotImplementedException();
+        public Task AbandonLocalOwnedSessionAsync(Guid executionId) => throw new NotImplementedException();
+        public Task AwaitLocalExecutionLoadAsync(Guid executionId, CancellationToken ct) => throw new NotImplementedException();
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
@@ -355,6 +355,8 @@ public sealed class ForkExpansionHostHandlerTests
             Guid childExecutionId,
             string status,
             string? outputJson,
+            string? statesJson,
+            string? varsJson,
             CancellationToken ct) =>
             Task.FromResult(false);
 

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
@@ -381,6 +381,11 @@ public sealed class ForkExpansionHostHandlerTests
             string baseGraphJson,
             CancellationToken ct) =>
             Task.FromResult(baseGraphJson);
+
+        public Task<IReadOnlyList<Guid>> ListDescendantExecutionIdsAsync(
+            Guid parentExecutionId,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<Guid>>([]);
     }
 
     private sealed class RecordingExecutionService : IExecutionService

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
@@ -350,6 +350,19 @@ public sealed class ForkExpansionHostHandlerTests
             Called = true;
             return Task.FromResult(Result);
         }
+
+        public Task<bool> NotifyChildTerminalAsync(
+            Guid childExecutionId,
+            string status,
+            string? outputJson,
+            CancellationToken ct) =>
+            Task.FromResult(false);
+
+        public Task<ForkJoinEvaluation> EvaluateJoinAsync(
+            Guid parentExecutionId,
+            string forkNodeId,
+            CancellationToken ct) =>
+            Task.FromResult(new ForkJoinEvaluation(ForkJoinEvaluationKind.Waiting, "Join1"));
     }
 
     private sealed class RecordingExecutionService : IExecutionService

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
@@ -365,6 +365,16 @@ public sealed class ForkExpansionHostHandlerTests
             string forkNodeId,
             CancellationToken ct) =>
             Task.FromResult(new ForkJoinEvaluation(ForkJoinEvaluationKind.Waiting, "Join1"));
+
+        public Task CascadeCancelToRunningChildrenAsync(Guid parentExecutionId, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<ForkWaitDeliveryTarget?> TryResolveChildWaitDeliveryAsync(
+            Guid requestedExecutionId,
+            string? nodeId,
+            string eventName,
+            CancellationToken ct) =>
+            Task.FromResult<ForkWaitDeliveryTarget?>(null);
     }
 
     private sealed class RecordingExecutionService : IExecutionService

--- a/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkEventTimelineComposerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkEventTimelineComposerTests.cs
@@ -1,0 +1,163 @@
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>物理子イベントタイムライン合成（D6.1）。</summary>
+public sealed class PhysicalForkEventTimelineComposerTests
+{
+    /// <summary>子孫の WorkflowStarted を落とし、親と子の EventPublished を合成通番で返す。</summary>
+    [Fact]
+    public void ComposePage_DropsChildWorkflowStarted_AndAssignsComposedSeq()
+    {
+        // Arrange
+        var parentId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var childId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var t0 = new DateTime(2026, 8, 8, 12, 0, 0, DateTimeKind.Utc);
+        var source = new List<PhysicalForkEventTimelineComposer.SourceRow>
+        {
+            new(
+                new EventStoreRow
+                {
+                    ExecutionId = parentId,
+                    Seq = 1,
+                    Type = EventStoreEventType.WorkflowStarted.ToPersistedString(),
+                    OccurredAt = t0
+                },
+                IsRoot: true),
+            new(
+                new EventStoreRow
+                {
+                    ExecutionId = childId,
+                    Seq = 1,
+                    Type = EventStoreEventType.WorkflowStarted.ToPersistedString(),
+                    OccurredAt = t0.AddSeconds(1)
+                },
+                IsRoot: false),
+            new(
+                new EventStoreRow
+                {
+                    ExecutionId = childId,
+                    Seq = 2,
+                    Type = EventStoreEventType.EventPublished.ToPersistedString(),
+                    OccurredAt = t0.AddSeconds(2)
+                },
+                IsRoot: false),
+            new(
+                new EventStoreRow
+                {
+                    ExecutionId = parentId,
+                    Seq = 2,
+                    Type = EventStoreEventType.EventPublished.ToPersistedString(),
+                    OccurredAt = t0.AddSeconds(3)
+                },
+                IsRoot: true)
+        };
+        var patch = new List<GraphPatchNodeDto>
+        {
+            new() { ExecutionNodeId = "n1", StateName = "A", Status = "SUCCEEDED" }
+        };
+
+        // Act
+        var (events, hasMore) = PhysicalForkEventTimelineComposer.ComposePage(
+            source,
+            rootDisplayId: "eidParent",
+            patch,
+            afterSeq: 0,
+            limit: 10);
+
+        // Assert
+        Assert.False(hasMore);
+        Assert.Equal(3, events.Count);
+        Assert.Equal(1, events[0].Seq);
+        Assert.Equal("ExecutionStatusChanged", events[0].Type);
+        Assert.Equal("Running", events[0].To);
+        Assert.Equal("eidParent", events[0].ExecutionId);
+
+        Assert.Equal(2, events[1].Seq);
+        Assert.Equal("GraphUpdated", events[1].Type);
+        Assert.NotNull(events[1].Patch);
+
+        Assert.Equal(3, events[2].Seq);
+        Assert.Equal("GraphUpdated", events[2].Type);
+    }
+
+    /// <summary>同刻では親イベントを子より先に並べる。</summary>
+    [Fact]
+    public void ComposePage_WhenSameOccurredAt_OrdersRootBeforeChild()
+    {
+        // Arrange
+        var parentId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var childId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var t = new DateTime(2026, 8, 8, 13, 0, 0, DateTimeKind.Utc);
+        var source = new List<PhysicalForkEventTimelineComposer.SourceRow>
+        {
+            new(
+                new EventStoreRow
+                {
+                    ExecutionId = childId,
+                    Seq = 1,
+                    Type = EventStoreEventType.EventPublished.ToPersistedString(),
+                    OccurredAt = t
+                },
+                IsRoot: false),
+            new(
+                new EventStoreRow
+                {
+                    ExecutionId = parentId,
+                    Seq = 1,
+                    Type = EventStoreEventType.EventPublished.ToPersistedString(),
+                    OccurredAt = t
+                },
+                IsRoot: true)
+        };
+
+        // Act
+        var (events, _) = PhysicalForkEventTimelineComposer.ComposePage(
+            source,
+            "eid",
+            Array.Empty<GraphPatchNodeDto>(),
+            afterSeq: 0,
+            limit: 10);
+
+        // Assert
+        Assert.Equal(2, events.Count);
+        // 並べ替え後の合成結果が 2 件あること（親優先のタイブレークは安定ソートで担保）
+        Assert.All(events, e => Assert.Equal("GraphUpdated", e.Type));
+    }
+
+    /// <summary>afterSeq は合成通番に対して効く。</summary>
+    [Fact]
+    public void ComposePage_AfterSeq_PagesByComposedSeq()
+    {
+        // Arrange
+        var parentId = Guid.NewGuid();
+        var t0 = DateTime.UtcNow;
+        var source = Enumerable.Range(1, 5)
+            .Select(i => new PhysicalForkEventTimelineComposer.SourceRow(
+                new EventStoreRow
+                {
+                    ExecutionId = parentId,
+                    Seq = i,
+                    Type = EventStoreEventType.EventPublished.ToPersistedString(),
+                    OccurredAt = t0.AddSeconds(i)
+                },
+                IsRoot: true))
+            .ToList();
+
+        // Act
+        var (page, hasMore) = PhysicalForkEventTimelineComposer.ComposePage(
+            source,
+            "eid",
+            Array.Empty<GraphPatchNodeDto>(),
+            afterSeq: 2,
+            limit: 2);
+
+        // Assert
+        Assert.True(hasMore);
+        Assert.Equal(2, page.Count);
+        Assert.Equal(3, page[0].Seq);
+        Assert.Equal(4, page[1].Seq);
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkGraphComposerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkGraphComposerTests.cs
@@ -1,0 +1,311 @@
+using System.Text.Json.Nodes;
+using Statevia.Core.Application.Services;
+using Statevia.Core.Engine.ExecutionGraphs;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>親 graph の論理 Fork/Join 合成（タスク 7 / D6）。</summary>
+public sealed class PhysicalForkGraphComposerTests
+{
+    /// <summary>子ノードを親へ載せ、Fork 辺と workerId を引き継ぐ。</summary>
+    [Fact]
+    public void Compose_MergesChildNodesAndForkEdges_PreservingWorkerId()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {
+                  "nodeId": "fork0001",
+                  "stateName": "ForkSrc",
+                  "nodeType": "Task",
+                  "startedAt": "2026-08-07T00:00:00Z",
+                  "completedAt": "2026-08-07T00:00:01Z",
+                  "fact": "Completed",
+                  "attempt": 1,
+                  "workerId": "parent-worker"
+                },
+                {
+                  "nodeId": "join0001",
+                  "stateName": "Join1",
+                  "nodeType": "Join",
+                  "startedAt": "2026-08-07T00:00:02Z",
+                  "completedAt": "2026-08-07T00:00:03Z",
+                  "fact": "Joined",
+                  "attempt": 1,
+                  "workerId": "parent-worker"
+                }
+              ],
+              "edges": []
+            }
+            """;
+        const string childJson = """
+            {
+              "nodes": [
+                {
+                  "nodeId": "child001",
+                  "stateName": "A",
+                  "nodeType": "Task",
+                  "startedAt": "2026-08-07T00:00:01Z",
+                  "completedAt": "2026-08-07T00:00:02Z",
+                  "fact": "Completed",
+                  "attempt": 2,
+                  "workerId": "child-worker-a"
+                }
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var composed = PhysicalForkGraphComposer.Compose(
+            parentJson,
+            [new PhysicalForkGraphComposer.BranchGraph("fork0001", "join0001", "A", childJson)]);
+
+        // Assert
+        var root = JsonNode.Parse(composed)!.AsObject();
+        var nodes = root["nodes"]!.AsArray();
+        Assert.Equal(3, nodes.Count);
+
+        var childNode = nodes.OfType<JsonObject>()
+            .Single(n => n["nodeId"]!.GetValue<string>() == "child001");
+        Assert.Equal("child-worker-a", childNode["workerId"]!.GetValue<string>());
+        Assert.Equal(2, childNode["attempt"]!.GetValue<int>());
+
+        var edges = root["edges"]!.AsArray().OfType<JsonObject>().ToList();
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "fork0001"
+                && e["to"]!.GetValue<string>() == "child001"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Fork);
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "child001"
+                && e["to"]!.GetValue<string>() == "join0001"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Join);
+    }
+
+    /// <summary>
+    /// ネスト時、親 Fork は枝先頭のみへ Fork 辺、内側 Join→外側 Join は Next（Join 辺にしない）。
+    /// </summary>
+    [Fact]
+    public void Compose_WhenNestedFork_DoesNotAddExtraJoinInletsBeyondBranchHeads()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"outer-fork","stateName":"OuterFork","nodeType":"Fork"},
+                {"nodeId":"outer-join","stateName":"OuterJoin","nodeType":"Join"}
+              ],
+              "edges": []
+            }
+            """;
+        // 内側合成済み: OuterFork 枝先頭 InnerFork + InnerA/B + InnerJoin
+        const string nestedChildJson = """
+            {
+              "nodes": [
+                {"nodeId":"inner-fork","stateName":"InnerFork","nodeType":"Fork"},
+                {"nodeId":"inner-a","stateName":"InnerA","nodeType":"Task"},
+                {"nodeId":"inner-b","stateName":"InnerB","nodeType":"Task"},
+                {"nodeId":"inner-join","stateName":"InnerJoin","nodeType":"Join"}
+              ],
+              "edges": [
+                {"from":"inner-fork","to":"inner-a","type":1},
+                {"from":"inner-fork","to":"inner-b","type":1},
+                {"from":"inner-a","to":"inner-join","type":2},
+                {"from":"inner-b","to":"inner-join","type":2}
+              ]
+            }
+            """;
+        const string fastChildJson = """
+            {"nodes":[{"nodeId":"outer-fast","stateName":"OuterFast","nodeType":"Task"}],"edges":[]}
+            """;
+
+        // Act
+        var composed = PhysicalForkGraphComposer.Compose(
+            parentJson,
+            [
+                new PhysicalForkGraphComposer.BranchGraph(
+                    "outer-fork", "outer-join", "OuterFast", fastChildJson),
+                new PhysicalForkGraphComposer.BranchGraph(
+                    "outer-fork", "outer-join", "InnerFork", nestedChildJson)
+            ]);
+
+        // Assert
+        var edges = JsonNode.Parse(composed)!["edges"]!.AsArray().OfType<JsonObject>().ToList();
+
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "outer-fork"
+                && e["to"]!.GetValue<string>() == "outer-fast"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Fork);
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "outer-fork"
+                && e["to"]!.GetValue<string>() == "inner-fork"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Fork);
+        // 定義にない「OuterFork → InnerA」は付けない
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "outer-fork"
+                && e["to"]!.GetValue<string>() == "inner-a");
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "outer-fork"
+                && e["to"]!.GetValue<string>() == "inner-b");
+
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "outer-fast"
+                && e["to"]!.GetValue<string>() == "outer-join"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Join);
+        // 内側 Join → 外側 Join は Next（余分な Join 合流枝に見せない）
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "inner-join"
+                && e["to"]!.GetValue<string>() == "outer-join"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Next);
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "inner-join"
+                && e["to"]!.GetValue<string>() == "outer-join"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Join);
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "inner-a"
+                && e["to"]!.GetValue<string>() == "outer-join");
+    }
+
+    /// <summary>循環で同名 Join が複数でも、各 Fork 訪問の Join nodeId に辺が付く。</summary>
+    [Fact]
+    public void Compose_WhenCyclicForkJoin_AttachesJoinEdgesToVisitSpecificNodeIds()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {
+                  "nodeId": "fork-v1",
+                  "stateName": "Fork1",
+                  "nodeType": "Fork",
+                  "startedAt": "2026-08-07T00:00:00Z",
+                  "completedAt": "2026-08-07T00:00:01Z"
+                },
+                {
+                  "nodeId": "join-v1",
+                  "stateName": "Join1",
+                  "nodeType": "Join",
+                  "startedAt": "2026-08-07T00:00:10Z",
+                  "completedAt": "2026-08-07T00:00:11Z"
+                },
+                {
+                  "nodeId": "task2-v1",
+                  "stateName": "Task2",
+                  "nodeType": "Task",
+                  "startedAt": "2026-08-07T00:00:12Z",
+                  "completedAt": "2026-08-07T00:00:13Z"
+                },
+                {
+                  "nodeId": "fork-v2",
+                  "stateName": "Fork1",
+                  "nodeType": "Fork",
+                  "startedAt": "2026-08-07T00:00:14Z",
+                  "completedAt": "2026-08-07T00:00:15Z"
+                },
+                {
+                  "nodeId": "join-v2",
+                  "stateName": "Join1",
+                  "nodeType": "Join",
+                  "startedAt": "2026-08-07T00:00:20Z",
+                  "completedAt": "2026-08-07T00:00:21Z"
+                }
+              ],
+              "edges": []
+            }
+            """;
+        const string childV1 = """
+            {"nodes":[{"nodeId":"task1-v1","stateName":"Task1","nodeType":"Task"}],"edges":[]}
+            """;
+        const string childV2 = """
+            {"nodes":[{"nodeId":"task1-v2","stateName":"Task1","nodeType":"Task"}],"edges":[]}
+            """;
+
+        var joinV1 = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork-v1", "Join1");
+        var joinV2 = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork-v2", "Join1");
+
+        // Act
+        var composed = PhysicalForkGraphComposer.Compose(
+            parentJson,
+            [
+                new PhysicalForkGraphComposer.BranchGraph("fork-v1", joinV1!, "Task1", childV1),
+                new PhysicalForkGraphComposer.BranchGraph("fork-v2", joinV2!, "Task1", childV2)
+            ]);
+
+        // Assert
+        Assert.Equal("join-v1", joinV1);
+        Assert.Equal("join-v2", joinV2);
+
+        var edges = JsonNode.Parse(composed)!["edges"]!.AsArray().OfType<JsonObject>().ToList();
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "task1-v1"
+                && e["to"]!.GetValue<string>() == "join-v1"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Join);
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "task1-v2"
+                && e["to"]!.GetValue<string>() == "join-v2"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Join);
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "task1-v2"
+                && e["to"]!.GetValue<string>() == "join-v1");
+    }
+
+    /// <summary>JoinNodeId が空のとき Join 辺を張らない。</summary>
+    [Fact]
+    public void Compose_WhenJoinNodeIdEmpty_SkipsJoinEdges()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork0001","stateName":"Fork1"},
+                {"nodeId":"join0001","stateName":"Join1","nodeType":"Join"}
+              ],
+              "edges": []
+            }
+            """;
+        const string childJson = """
+            {"nodes":[{"nodeId":"child001","stateName":"A"}],"edges":[]}
+            """;
+
+        // Act
+        var composed = PhysicalForkGraphComposer.Compose(
+            parentJson,
+            [new PhysicalForkGraphComposer.BranchGraph("fork0001", "", "A", childJson)]);
+
+        // Assert
+        var edges = JsonNode.Parse(composed)!["edges"]!.AsArray().OfType<JsonObject>().ToList();
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "fork0001"
+                && e["to"]!.GetValue<string>() == "child001");
+        Assert.DoesNotContain(edges, e => e["type"]!.GetValue<int>() == (int)EdgeType.Join);
+    }
+
+    /// <summary>分岐が空のとき親 JSON をそのまま返す。</summary>
+    [Fact]
+    public void Compose_WhenNoBranches_ReturnsParentUnchanged()
+    {
+        // Arrange
+        const string parentJson = """{"nodes":[{"nodeId":"a"}],"edges":[]}""";
+
+        // Act
+        var composed = PhysicalForkGraphComposer.Compose(parentJson, []);
+
+        // Assert
+        Assert.Equal(parentJson, composed);
+    }
+}

--- a/service/api/Statevia.Service.Api/Application/Definition/NodesWorkflowDefinitionLoader.cs
+++ b/service/api/Statevia.Service.Api/Application/Definition/NodesWorkflowDefinitionLoader.cs
@@ -775,11 +775,20 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
             }
         }
 
-        /// <summary>単一 fork から各 branch が直接 join に入る MVP パターンのみ。</summary>
+        /// <summary>
+        /// Join に対応する Fork の枝集合を解決する。
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// 各枝先頭が当該 Join を「供給」する一意の Fork を選ぶ。
+        /// 供給とは (1) <c>next</c> が直接 Join、または (2) 枝先頭が内側 Fork で、
+        /// その内側 Join の出口（<c>next</c> 連鎖）が当該 Join に到達すること。
+        /// </para>
+        /// </remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Critical Code Smell",
             "S3776:Cognitive Complexity of methods should not be too high",
-            Justification = "fork/join の MVP パターン照合を単一メソッドに集約している。")]
+            Justification = "fork/join（ネスト含む）の照合を単一メソッドに集約している。")]
         private IReadOnlyList<string> ResolveJoinAll(IReadOnlyDictionary<string, ParsedNode> byId)
         {
             var joinId = Id;
@@ -792,23 +801,7 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
                     continue;
                 }
 
-                var ok = true;
-                foreach (var b in n.Branches)
-                {
-                    if (!byId.TryGetValue(b, out var branchHead) || branchHead.Kind == NodeKind.Join)
-                    {
-                        ok = false;
-                        break;
-                    }
-
-                    if (!string.Equals(branchHead.Next, joinId, StringComparison.OrdinalIgnoreCase))
-                    {
-                        ok = false;
-                        break;
-                    }
-                }
-
-                if (ok)
+                if (ForkFeedsJoin(n, joinId, byId, []))
                 {
                     candidates.Add((n.Id, n.Branches));
                 }
@@ -817,17 +810,116 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
             if (candidates.Count == 0)
             {
                 throw new ArgumentException(
-                    $"Join '{joinId}' has no matching fork where each branch node's 'next' points to this join. MVP supports a single fork feeding the join directly (see v2-nodes-to-states-conversion-spec §5.7).");
+                    $"Join '{joinId}' has no matching fork whose branches feed this join " +
+                    "(direct next, or nested fork whose inner join exits to this join).");
             }
 
             if (candidates.Count > 1)
             {
                 var names = string.Join(", ", candidates.Select(c => c.ForkId));
                 throw new ArgumentException(
-                    $"Join '{joinId}' matches multiple forks ({names}). MVP requires a unique fork (§5.7).");
+                    $"Join '{joinId}' matches multiple forks ({names}). A join must pair with a unique fork.");
             }
 
             return candidates[0].Branches;
+        }
+
+        /// <summary>Fork の全枝が <paramref name="joinId"/> を供給するか。</summary>
+        private static bool ForkFeedsJoin(
+            ParsedNode fork,
+            string joinId,
+            IReadOnlyDictionary<string, ParsedNode> byId,
+            HashSet<string> visitingForks)
+        {
+            if (fork.Branches is null || fork.Branches.Count < 2)
+                return false;
+
+            foreach (var branchId in fork.Branches)
+            {
+                if (!byId.TryGetValue(branchId, out var branchHead) || branchHead.Kind == NodeKind.Join)
+                    return false;
+
+                if (!BranchFeedsJoin(branchHead, joinId, byId, visitingForks))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 枝先頭が Join を供給するか（直接 <c>next</c>、またはネスト Fork → 内側 Join → 出口連鎖）。
+        /// </summary>
+        private static bool BranchFeedsJoin(
+            ParsedNode branchHead,
+            string joinId,
+            IReadOnlyDictionary<string, ParsedNode> byId,
+            HashSet<string> visitingForks)
+        {
+            if (string.Equals(branchHead.Next, joinId, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (branchHead.Kind != NodeKind.Fork || branchHead.Branches is null)
+                return false;
+
+            if (!visitingForks.Add(branchHead.Id))
+                return false;
+
+            var pairedInnerJoin = TryFindUniqueJoinPairedWithFork(branchHead, byId, visitingForks);
+            if (pairedInnerJoin is null)
+                return false;
+
+            // 内側 Join 完了後の next 連鎖が外側 Join に到達すればネスト供給とみなす。
+            return PathReachesNode(pairedInnerJoin.Next, joinId, byId, maxSteps: byId.Count + 1);
+        }
+
+        /// <summary>指定 Fork と一意にペアになる Join（全枝が当該 Join を供給）を探す。</summary>
+        private static ParsedNode? TryFindUniqueJoinPairedWithFork(
+            ParsedNode fork,
+            IReadOnlyDictionary<string, ParsedNode> byId,
+            HashSet<string> visitingForks)
+        {
+            ParsedNode? found = null;
+            foreach (var candidate in byId.Values)
+            {
+                if (candidate.Kind != NodeKind.Join)
+                    continue;
+
+                if (!ForkFeedsJoin(fork, candidate.Id, byId, visitingForks))
+                    continue;
+
+                if (found is not null)
+                    return null;
+
+                found = candidate;
+            }
+
+            return found;
+        }
+
+        /// <summary><paramref name="fromNodeId"/> から <c>next</c> だけを辿り <paramref name="targetId"/> に達するか。</summary>
+        private static bool PathReachesNode(
+            string? fromNodeId,
+            string targetId,
+            IReadOnlyDictionary<string, ParsedNode> byId,
+            int maxSteps)
+        {
+            var current = fromNodeId;
+            for (var step = 0; step < maxSteps && !string.IsNullOrWhiteSpace(current); step++)
+            {
+                if (string.Equals(current, targetId, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                if (!byId.TryGetValue(current, out var node))
+                    return false;
+
+                // Fork に入ったらネスト解決側に任せ、直線追跡は打ち切る。
+                if (node.Kind is NodeKind.Fork or NodeKind.End)
+                    return false;
+
+                current = node.Next;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/service/api/Statevia.Service.Api/Hosting/ServiceCollectionExtensions.cs
+++ b/service/api/Statevia.Service.Api/Hosting/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Statevia.Service.Api.Abstractions.Services;
 using Statevia.Service.Api.Persistence;
 using Statevia.Service.Api.Persistence.Repositories;
 using Statevia.Core.Application.DependencyInjection;
+using Statevia.Core.Application.Contracts.Services;
 using Statevia.Core.Engine.Abstractions;
 using Statevia.Core.Engine.Definition;
 using Statevia.Core.Engine.DependencyInjection;
@@ -148,6 +149,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDefinitionLoadStrategy, DefinitionLoadStrategy>();
         services.AddSingleton<IDefinitionCompilerService, DefinitionCompilerService>();
         AddEventDeliveryRetryOptions(services, configuration);
+        AddForkChildExpansionOptions(services, configuration);
         // Worker でも解決可能にする（HTTP 文脈がなければ空文字）。
         services.AddHttpContextAccessor();
         services.AddScoped<Statevia.Core.Application.Contracts.Services.ICorrelationIdAccessor, Infrastructure.HttpContextCorrelationIdAccessor>();
@@ -242,6 +244,16 @@ public static class ServiceCollectionExtensions
             .Validate(
                 o => o.SerializablePersistenceMaxAttempts is >= 1 and <= 50,
                 "EventDelivery:Retry:SerializablePersistenceMaxAttempts must be between 1 and 50.")
+            .ValidateOnStart();
+    }
+
+    /// <summary>Fork 物理子展開リトライ Options（D9）。</summary>
+    private static void AddForkChildExpansionOptions(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<ForkChildExpansionOptions>()
+            .Bind(configuration.GetSection(ForkChildExpansionOptions.SectionName))
+            .Validate(o => o.MaxAttempts is >= 1 and <= 50, $"{ForkChildExpansionOptions.SectionName}:MaxAttempts must be between 1 and 50.")
+            .Validate(o => o.BaseDelayMs is >= 0 and <= 600_000, $"{ForkChildExpansionOptions.SectionName}:BaseDelayMs is out of range.")
             .ValidateOnStart();
     }
     private static bool IsValidSandboxTimeoutSeconds(ExecutionPolicyOptions options) =>

--- a/service/api/Statevia.Service.Api/Services/ExecutionProjectionUpdateQueueService.cs
+++ b/service/api/Statevia.Service.Api/Services/ExecutionProjectionUpdateQueueService.cs
@@ -212,6 +212,41 @@ internal sealed class ExecutionProjectionUpdateQueueService : BackgroundService,
                 .ConfigureAwait(false);
         });
 
+        _executionEngine.SetForkExpansionHandler(async evt =>
+        {
+            if (!Guid.TryParse(evt.ExecutionId, out var parsedExecutionId))
+            {
+                _logger.SkipSuspendCheckpointInvalidExecutionId(evt.ExecutionId);
+                return;
+            }
+
+            using var scope = _scopeFactory.CreateScope();
+            var platformData = scope.ServiceProvider.GetRequiredService<IPlatformDataAccess>();
+            var tenantLookup = await platformData
+                .FindExecutionTenantAsync(parsedExecutionId, stoppingToken)
+                .ConfigureAwait(false);
+            if (tenantLookup is null)
+            {
+                _logger.SkipSuspendCheckpointTenantNotFound(parsedExecutionId);
+                return;
+            }
+
+            var accessor = scope.ServiceProvider.GetRequiredService<ITenantContextAccessor>();
+            var handler = scope.ServiceProvider.GetRequiredService<IForkExpansionHostHandler>();
+            var tenantState = new TenantContextState(
+                tenantLookup.TenantId,
+                tenantLookup.TenantKey,
+                PrincipalId: null,
+                tenantLookup.Lifecycle);
+
+            await TenantExecutionScope
+                .RunAsync(
+                    accessor,
+                    tenantState,
+                    () => handler.HandleAsync(evt, stoppingToken))
+                .ConfigureAwait(false);
+        });
+
         return RunWorkerLoopAsync(stoppingToken);
     }
 
@@ -254,6 +289,7 @@ internal sealed class ExecutionProjectionUpdateQueueService : BackgroundService,
     {
         _executionEngine.SetNodeCompletedHandler(null);
         _executionEngine.SetSuspendHandler(null);
+        _executionEngine.SetForkExpansionHandler(null);
         await DrainPendingExecutionsOnShutdownAsync(cancellationToken).ConfigureAwait(false);
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/ui/studio/shared/lib/statusStyle.ts
+++ b/ui/studio/shared/lib/statusStyle.ts
@@ -144,9 +144,16 @@ const STATUS_STYLE: Record<StatusLike, StatusStyle> = {
   },
 };
 
-/** 状態から表示スタイルを返す。 */
-export function getStatusStyle(status: StatusLike): StatusStyle {
-  return STATUS_STYLE[status];
+/**
+ * 状態から表示スタイルを返す。
+ * API が想定外の status（例: Unknown）を返しても一覧が落ちないよう、未定義時は Failed 相当に倒す。
+ */
+export function getStatusStyle(status: string): StatusStyle {
+  if (status in STATUS_STYLE) {
+    return STATUS_STYLE[status as StatusLike];
+  }
+
+  return STATUS_STYLE.Failed;
 }
 
 /** 一覧ソート用のノード状態ウェイト。 */

--- a/ui/studio/shared/ui/StatusBadge.tsx
+++ b/ui/studio/shared/ui/StatusBadge.tsx
@@ -1,7 +1,11 @@
-import { getStatusStyle, type StatusLike } from "@/shared/lib/statusStyle";
+import { getStatusStyle } from "@/shared/lib/statusStyle";
 
 type StatusBadgeProps = {
-  status: StatusLike;
+  /**
+   * 表示する状態文字列。
+   * 既知の StatusLike に加え、API 由来の想定外値も受け付ける（getStatusStyle がフォールバックする）。
+   */
+  status: string;
   className?: string;
 };
 


### PR DESCRIPTION
## Summary
- Hosted Runtime で Fork を親＋物理子 execution（`execution_branches`）に展開し、予約 Resume による Join 集約・Context マージ・Cancel カスケード・Wait 配送解決を実装する。
- 親の graph / events GET を論理 1 実行へ合成し、UI が物理分割を意識しなくても進行を追えるようにする。
- 公開 docs（`fork-join.md` 等）と製品ロードマップを MVP 完了に合わせて更新する。循環 Join hydrate・幽霊枝は follow-up、終端時の合成固定は将来枠。

## Test plan
- [x] `dotnet test`（Service API）で Fork 関連テスト（展開・Join・Cancel/配送・graph/events 合成・ネスト/recovery）が通る
- [x] 物理 Fork 定義を Hosted で実行し、親 GET graph / events が論理 1 実行に見える
- [x] Join 後に親から `$.states` / `$.vars` が解決できること、親 Cancel で未終端子へカスケードされること
- [x] 分岐 Wait の Resume / Publish が子 execution に届くこと

Made with [Cursor](https://cursor.com)