### PR TITLE
実行ノード ID の新規採番を Hex 12 に拡張する

### DIFF
--- a/core/engine/Statevia.Core.Engine.Tests/ExecutionGraph/ExecutionGraphTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/ExecutionGraph/ExecutionGraphTests.cs
@@ -1,14 +1,17 @@
-using System.Linq;
+using Statevia.Core.Engine.Abstractions;
 using Statevia.Core.Engine.ExecutionGraphs;
 using Xunit;
 
 namespace Statevia.Core.Engine.Tests.ExecutionGraphs;
 
+/// <summary><see cref="ExecutionGraph"/> の採番・辺・スナップショットを検証する。</summary>
 public class ExecutionGraphTests
 {
-    /// <summary>AddNode が空でないノード ID を返すことを検証する。</summary>
+    private const string LowercaseHex12Pattern = "^[0-9a-f]{12}$";
+
+    /// <summary>AddNode が小文字 Hex ちょうど 12 桁のノード ID を返すことを検証する。</summary>
     [Fact]
-    public void AddNode_ReturnsNodeId()
+    public void AddNode_ReturnsLowercaseHex12NodeId()
     {
         // Arrange
         var graph = new ExecutionGraph();
@@ -17,8 +20,86 @@ public class ExecutionGraphTests
         var id = graph.AddNode("Start");
 
         // Assert
-        Assert.NotNull(id);
-        Assert.NotEmpty(id);
+        Assert.Matches(LowercaseHex12Pattern, id);
+    }
+
+    /// <summary>候補が既存 NodeId と衝突したら再採番して一意な ID を返すことを検証する。</summary>
+    [Fact]
+    public void AddNode_WhenCandidateCollides_RetriesUntilUnique()
+    {
+        // Arrange
+        var graph = new ExecutionGraph();
+        const string colliding = "aaaaaaaaaaaa";
+        const string unique = "bbbbbbbbbbbb";
+        var callCount = 0;
+        graph.SetNodeIdCandidateFactoryForTests(() =>
+        {
+            callCount++;
+            return callCount == 1 ? colliding : unique;
+        });
+        Assert.Equal(colliding, graph.AddNode("Seed"));
+        callCount = 0;
+        graph.SetNodeIdCandidateFactoryForTests(() =>
+        {
+            callCount++;
+            return callCount == 1 ? colliding : unique;
+        });
+
+        // Act
+        var id = graph.AddNode("Next");
+
+        // Assert
+        Assert.Equal(unique, id);
+        Assert.Equal(2, callCount);
+        Assert.Equal(2, graph.GetNodesSnapshot().Count);
+    }
+
+    /// <summary>再採番が上限を超えたとき InvalidOperationException になることを検証する。</summary>
+    [Fact]
+    public void AddNode_WhenAllocationExhausted_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var graph = new ExecutionGraph();
+        const string colliding = "cccccccccccc";
+        graph.SetNodeIdCandidateFactoryForTests(() => colliding);
+        Assert.Equal(colliding, graph.AddNode("Seed"));
+
+        // Act
+        var ex = Assert.Throws<InvalidOperationException>(() => graph.AddNode("Next"));
+
+        // Assert
+        Assert.Contains("unique execution node ID", ex.Message, StringComparison.Ordinal);
+        Assert.Single(graph.GetNodesSnapshot());
+    }
+
+    /// <summary>既存 8 桁 NodeId があるグラフでも新規は Hex 12 で追加できることを検証する。</summary>
+    [Fact]
+    public void AddNode_WhenGraphHasLegacyHex8Node_AllocatesHex12()
+    {
+        // Arrange
+        var graph = new ExecutionGraph();
+        graph.ImportFromCheckpoint(new CheckpointGraphData
+        {
+            Nodes =
+            [
+                new CheckpointGraphNode
+                {
+                    NodeId = "deadbeef",
+                    StateName = "Legacy",
+                    NodeType = "Task",
+                    StartedAt = DateTime.UtcNow,
+                    Attempt = 1
+                }
+            ],
+            Edges = []
+        });
+
+        // Act
+        var id = graph.AddNode("Fresh");
+
+        // Assert
+        Assert.Matches(LowercaseHex12Pattern, id);
+        Assert.Equal(2, graph.GetNodesSnapshot().Count);
     }
 
     /// <summary>AddEdge がノード間の辺を記録し、Edges から取得できることを検証する。</summary>

--- a/core/engine/Statevia.Core.Engine/ExecutionGraph/ExecutionGraph.cs
+++ b/core/engine/Statevia.Core.Engine/ExecutionGraph/ExecutionGraph.cs
@@ -15,9 +15,26 @@ public sealed class ExecutionGraph
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
+    /// <summary>
+    /// 新規実行ノード ID の Hex 桁数（約 48 bit）。
+    /// </summary>
+    /// <remarks>
+    /// 誕生日近似で n=10^4 でも衝突前確率は ~10^-7 程度。既存実行の 8 桁 ID は変換しない。
+    /// </remarks>
+    private const int ExecutionNodeIdHexLength = 12;
+
+    /// <summary>
+    /// 同一グラフ内で衝突したときの再採番上限。
+    /// </summary>
+    /// <remarks>
+    /// 異常乱数源やテスト注入時に無限ループしないための安全弁。Hex 12 の正規運用では到達しない。
+    /// </remarks>
+    private const int ExecutionNodeIdMaxAllocationAttempts = 32;
+
     private readonly List<ExecutionNode> _nodes = [];
     private readonly List<ExecutionEdge> _edges = [];
     private readonly object _lock = new();
+    private Func<string>? _nodeIdCandidateFactory;
 
     /// <summary>ノード一覧のスナップショットを返します。</summary>
     public IReadOnlyList<ExecutionNode> GetNodesSnapshot()
@@ -38,6 +55,10 @@ public sealed class ExecutionGraph
     }
 
     /// <summary>ノードを追加し、ノード ID を返します。</summary>
+    /// <remarks>
+    /// <para>新規採番は <c>Guid("N")</c> 先頭 12 Hex。同一グラフ内で衝突したら再採番し、上限超過で失敗する。</para>
+    /// <para>既存 checkpoint の 8 桁 ID はそのまま読み取り互換とする。</para>
+    /// </remarks>
     /// <param name="stateName">状態名。</param>
     /// <param name="nodeType">ノード種別。</param>
     /// <param name="input">状態入力。</param>
@@ -45,6 +66,7 @@ public sealed class ExecutionGraph
     /// <param name="workerId">ワーカー識別子。</param>
     /// <param name="wait">Wait ノード用の観測メタデータ（任意）。</param>
     /// <returns>採番されたノード ID。</returns>
+    /// <exception cref="InvalidOperationException">再採番上限内に一意な ID を割り当てられなかったとき。</exception>
     public string AddNode(
         string stateName,
         string nodeType = "Task",
@@ -53,9 +75,9 @@ public sealed class ExecutionGraph
         string? workerId = null,
         WaitNodeGraphMetadata? wait = null)
     {
-        var nodeId = Guid.NewGuid().ToString("N")[..8];
         lock (_lock)
         {
+            var nodeId = AllocateUniqueNodeIdUnlocked();
             _nodes.Add(new ExecutionNode
             {
                 NodeId = nodeId,
@@ -69,8 +91,40 @@ public sealed class ExecutionGraph
                 AllowedEvents = wait?.AllowedEvents,
                 Subscriptions = wait?.Subscriptions
             });
+            return nodeId;
         }
-        return nodeId;
+    }
+
+    /// <summary>単体テスト用に nodeId 候補生成を差し替える。本番コードは呼び出さない。</summary>
+    /// <param name="factory">候補生成デリゲート。null で既定（Guid 先頭 12）に戻す。</param>
+    internal void SetNodeIdCandidateFactoryForTests(Func<string>? factory) =>
+        _nodeIdCandidateFactory = factory;
+
+    /// <summary>同一グラフ内で一意な実行ノード ID を割り当てる（呼び出し元が <c>_lock</c> を保持していること）。</summary>
+    private string AllocateUniqueNodeIdUnlocked()
+    {
+        for (var attempt = 0; attempt < ExecutionNodeIdMaxAllocationAttempts; attempt++)
+        {
+            var candidate = CreateNodeIdCandidate();
+            if (!_nodes.Exists(n => string.Equals(n.NodeId, candidate, StringComparison.OrdinalIgnoreCase)))
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Failed to allocate a unique execution node ID within {ExecutionNodeIdMaxAllocationAttempts} attempts.");
+    }
+
+    /// <summary>実行ノード ID の候補を 1 件生成する。</summary>
+    private string CreateNodeIdCandidate()
+    {
+        if (_nodeIdCandidateFactory is not null)
+        {
+            return _nodeIdCandidateFactory();
+        }
+
+        return Guid.NewGuid().ToString("N")[..ExecutionNodeIdHexLength];
     }
 
     /// <summary>ノードを完了としてマークし、事実と出力を記録します。</summary>

--- a/docs/specifications/api-http.md
+++ b/docs/specifications/api-http.md
@@ -288,7 +288,7 @@ Response: 200 OK、Content-Type: application/json。`execution_graph_snapshots` 
 
 - JSON キー命名は **camelCase**。
 - トップレベルは **`nodes`**, **`edges`**（ExecutionGraph のシリアライズ形）。**HTTP** では `execution_graph_snapshots` の行が無い場合は **404**（`ExecutionService.GetGraphJsonAsync`）。エンジン API `ExportExecutionGraph` がメモリにインスタンスを持たないときは **`{}`** 文字列を返し得るが、それは in-process 観測用であり、Read API の正本ではない（`AGENTS.md` Read-model authority）。
-- **`nodes[*].nodeId`**: ランタイム実行ノード ID（短いランダム ID）。**定義**の `GET /v1/graphs/{graphId}` における **`nodes[*].nodeId`（状態名ベースのキャンバス ID）とは別**。
+- **`nodes[*].nodeId`**: ランタイム実行ノード ID（opaque。新規は小文字 Hex 12、既存実行は 8 桁のまま混在しうる）。**定義**の `GET /v1/graphs/{graphId}` における **`nodes[*].nodeId`（状態名ベースのキャンバス ID）とは別**。詳細は `docs/specifications/execution/execution-graph.md` §4。
 - **`nodes[*].stateName`**: 定義上の状態名。UI はマージ時に `stateName` および実行エッジで対応付ける（`docs/specifications/execution/execution-graph.md` §7）。
 - **`edges[*].from` / `edges[*].to`**: いずれも **`nodes[*].nodeId`** を指す。旧キー `fromNodeId` / `toNodeId` は用いない。
 - **`edges[*].type`**: `EdgeType` の数値（`Next` 0 など）。`Join`（2）では合流元から Join 合成ノードへ **複数辺** が立ち得る。

--- a/docs/specifications/execution/execution-graph.md
+++ b/docs/specifications/execution/execution-graph.md
@@ -96,7 +96,7 @@
 
 | キー | 型 | 必須 | 説明 |
 | --- | --- | --- | --- |
-| `nodeId` | `string` | 必須 | **ランタイム実行ノード ID**。`Guid("N")` の先頭 8 文字。定義キャンバスの `nodeId`（状態名ベース）とは別物 |
+| `nodeId` | `string` | 必須 | **ランタイム実行ノード ID**（opaque）。新規採番は `Guid("N")` の先頭 **12** 文字（小文字 Hex）で、同一実行グラフ内の衝突時は再採番する。既存実行・checkpoint に残る **8** 桁 ID はそのまま有効（変換しない）。定義キャンバスの `nodeId`（状態名ベース）とは別物 |
 | `stateName` | `string` | 必須 | ワークフロー定義上の状態名 |
 | `nodeType` | `string` | 必須 | ノード種別（例: `Start` / `Task` / `Fork` / `Join` / `Wait` / `End`。既定は `Task`） |
 | `startedAt` | `string(date-time)` | 必須 | ノード開始 UTC 時刻 |
@@ -124,8 +124,8 @@ JSON プロパティ名は **camelCase** のため、C# の `From` / `To` は **
 
 ```json
 {
-  "from": "a1b2c3d4",
-  "to": "f0e1d2c3",
+  "from": "a1b2c3d4e5f6",
+  "to": "f0e1d2c3b4a5",
   "type": 0
 }
 ```


### PR DESCRIPTION
## Summary
- `ExecutionGraph.AddNode` の新規 `nodeId` を小文字 Hex 12 桁に拡張し、同一グラフ内の衝突検知と再採番（上限 32）を追加する。
- 既存 checkpoint / 実行に残る 8 桁 ID は読み取り互換のまま（変換しない）。
- `execution-graph.md` / `api-http.md` と Engine 単体テストを実装に合わせて更新する。

## Test plan
- [x] `cd core/engine && dotnet test --filter FullyQualifiedName~ExecutionGraphTests`
- [x] 新規採番の `nodeId` が `[0-9a-f]{12}` であること
- [x] 旧 8 桁 ID を含む checkpoint 復元後も Resume / 辺参照が回帰しないこと

Made with [Cursor](https://cursor.com)