### PR TITLE
JsonSerializerOptions を共有プロファイルに集約する

### DIFF
--- a/core/application/Statevia.Core.Application/Infrastructure/JsonDeserialize.cs
+++ b/core/application/Statevia.Core.Application/Infrastructure/JsonDeserialize.cs
@@ -10,14 +10,6 @@ namespace Statevia.Core.Application.Infrastructure;
 internal static class JsonDeserialize
 {
     /// <summary>
-    /// 実行グラフスナップショット等、歴史的に PascalCase も混在する JSON をゆるやかに解釈するとき。
-    /// </summary>
-    internal static readonly JsonSerializerOptions CaseInsensitiveDeserializeOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
-
-    /// <summary>
     /// <see cref="JsonSerializer.Deserialize{T}(string, JsonSerializerOptions?)"/> を試し、復元処理で想定する例外のみ失敗として扱う。
     /// </summary>
     /// <returns><c>true</c> のとき復帰値を解釈可能（入力が JSON の <c>null</c> であれば <paramref name="value"/> は既定の参照型どおりになりうる）。</returns>

--- a/core/application/Statevia.Core.Application/Infrastructure/JsonSerializerProfiles.cs
+++ b/core/application/Statevia.Core.Application/Infrastructure/JsonSerializerProfiles.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+
+namespace Statevia.Core.Application.Infrastructure;
+
+/// <summary>
+/// Application 層の標準 <see cref="JsonSerializerOptions"/> プロファイル。
+/// </summary>
+/// <remarks>
+/// <para>
+/// camelCase シリアライズと、プロパティ名の大文字小文字非区別デシリアライズを
+/// 別インスタンスとして提供する。設定を混ぜない（複合が必要な契約は専用 Options を使う）。
+/// </para>
+/// <para>
+/// HTTP / DB 契約の正本ではなく、内部の参照共有とホットパス上の都度生成回避が目的。
+/// </para>
+/// </remarks>
+internal static class JsonSerializerProfiles
+{
+    /// <summary>
+    /// イベント本文・冪等キャッシュ応答・Fork 関連 JSON・SSE ペイロードなど、camelCase 出力向け。
+    /// </summary>
+    internal static readonly JsonSerializerOptions CamelCase = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// 歴史的に PascalCase が混在しうる投影／dedup 復元など、名前非区別デシリアライズ向け。
+    /// </summary>
+    internal static readonly JsonSerializerOptions CaseInsensitive = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionOperationalProjectionSync.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionOperationalProjectionSync.cs
@@ -14,11 +14,6 @@ namespace Statevia.Core.Application.Services;
 /// </summary>
 internal static class ExecutionOperationalProjectionSync
 {
-    private static readonly JsonSerializerOptions CaseInsensitiveJsonSerializerOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
-
     /// <summary>
     /// 投影フラッシュと同一トランザクション内で cursor / durable wait を同期する。
     /// Publish / Resume 時は <see cref="ExecutionOperationalProjectionSyncRequest.NodeIdToClear"/> で該当 wait を先行削除する。
@@ -233,7 +228,7 @@ internal static class ExecutionOperationalProjectionSync
 
         if (!JsonDeserialize.TryDeserialize(
                 graphJson,
-                CaseInsensitiveJsonSerializerOptions,
+                JsonSerializerProfiles.CaseInsensitive,
                 out ExecutionGraphSnapshotDto? dto)
             || dto?.Nodes is null)
             return false;

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -15,24 +15,8 @@ namespace Statevia.Core.Application.Services;
 
 internal sealed class ExecutionService : IExecutionService
 {
-    /// <summary>
-    /// イベント本文・冪等キャッシュ応答・リクエストハッシュ入力など、camelCase でシリアル化する際の共有オプション（都度 new しない）。
-    /// </summary>
-    private static readonly JsonSerializerOptions CamelCaseJsonSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     /// <summary>Worker が 1 Load を待つときのポーリング間隔。</summary>
     private static readonly TimeSpan LocalExecutionLoadPollInterval = TimeSpan.FromMilliseconds(250);
-
-    /// <summary>
-    /// <see cref="CommandDedupRow.ResponseBody"/> からの逆シリアル用（プロパティ名の大文字小文字を許容）。
-    /// </summary>
-    private static readonly JsonSerializerOptions CaseInsensitiveJsonSerializerOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
 
     /// <summary><c>event_delivery_decision</c> 構造化ログの <c>decision</c> プロパティ値。</summary>
     private static class EventDeliveryLogDecisions
@@ -281,14 +265,14 @@ internal sealed class ExecutionService : IExecutionService
                         securityModelVersion = securitySnapshot.SecurityModelVersion,
                         evaluationMode = securitySnapshot.EvaluationMode.ToString()
                     },
-                    CamelCaseJsonSerializerOptions);
+                    JsonSerializerProfiles.CamelCase);
                 await _eventStore
                     .AppendAsync(uow, executionId, EventStoreEventType.WorkflowStarted, startedPayload, innerCt)
                     .ConfigureAwait(false);
 
                 if (dedupKey is { } saveKey)
                 {
-                    var responseJson = JsonSerializer.Serialize(accepted, CamelCaseJsonSerializerOptions);
+                    var responseJson = JsonSerializer.Serialize(accepted, JsonSerializerProfiles.CamelCase);
                     await _dedup.SaveAsync(
                         uow,
                         new CommandDedupRow
@@ -374,7 +358,7 @@ internal sealed class ExecutionService : IExecutionService
                                 securityModelVersion = securitySnapshot.SecurityModelVersion,
                                 evaluationMode = securitySnapshot.EvaluationMode.ToString()
                             },
-                            CamelCaseJsonSerializerOptions);
+                            JsonSerializerProfiles.CamelCase);
 
                         var displayId = await _displayIdWrites
                             .AllocateAsync(uow, DisplayIdResourceTypes.Execution, resolvedExecutionId, innerCt)
@@ -415,7 +399,7 @@ internal sealed class ExecutionService : IExecutionService
 
                         if (args.DedupKey is { } saveKey)
                         {
-                            var responseJson = JsonSerializer.Serialize(response, CamelCaseJsonSerializerOptions);
+                            var responseJson = JsonSerializer.Serialize(response, JsonSerializerProfiles.CamelCase);
                             await _dedup.SaveAsync(
                                 uow,
                                 new CommandDedupRow
@@ -556,7 +540,7 @@ internal sealed class ExecutionService : IExecutionService
             return false;
         }
 
-        var json = JsonSerializer.Serialize(checkpoint, CamelCaseJsonSerializerOptions);
+        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
         var updatedAt = DateTime.UtcNow;
         if (_ownership.TryGet(executionId, out _, out var generation))
         {
@@ -763,7 +747,7 @@ internal sealed class ExecutionService : IExecutionService
         var (projStatus, projCancel, projGraphJson) = BuildProjectionFromEngine(uuid.Value);
         var cancelPayload = JsonSerializer.Serialize(
             new { tenantId },
-            CamelCaseJsonSerializerOptions);
+            JsonSerializerProfiles.CamelCase);
 
         await _mutationPersistence.ExecuteSerializableWithRetryAsync(
             tenantId,
@@ -894,7 +878,7 @@ internal sealed class ExecutionService : IExecutionService
         if (checkpoint is null)
             return;
 
-        var json = JsonSerializer.Serialize(checkpoint, CamelCaseJsonSerializerOptions);
+        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
         var updatedAt = DateTime.UtcNow;
 
         await _executor.ExecuteReadCommittedAsync(
@@ -1188,7 +1172,7 @@ internal sealed class ExecutionService : IExecutionService
         var (pubStatus, pubCancel, pubGraphJson) = BuildProjectionFromEngine(uuid.Value);
         var publishedPayload = JsonSerializer.Serialize(
             new { tenantId, name = eventName },
-            CamelCaseJsonSerializerOptions);
+            JsonSerializerProfiles.CamelCase);
 
         await _mutationPersistence.ExecuteSerializableWithRetryAsync(
             tenantId,
@@ -1522,7 +1506,7 @@ internal sealed class ExecutionService : IExecutionService
         var (pubStatus, pubCancel, pubGraphJson) = BuildProjectionFromEngine(uuid.Value);
         var publishedPayload = JsonSerializer.Serialize(
             new { tenantId, name = eventName, nodeId },
-            CamelCaseJsonSerializerOptions);
+            JsonSerializerProfiles.CamelCase);
 
         await _mutationPersistence.ExecuteSerializableWithRetryAsync(
             tenantId,
@@ -2050,7 +2034,7 @@ internal sealed class ExecutionService : IExecutionService
     {
         if (string.IsNullOrEmpty(existing.ResponseBody))
             return null;
-        return JsonDeserialize.TryDeserialize<ExecutionResponse>(existing.ResponseBody, CaseInsensitiveJsonSerializerOptions, out var deserialized)
+        return JsonDeserialize.TryDeserialize<ExecutionResponse>(existing.ResponseBody, JsonSerializerProfiles.CaseInsensitive, out var deserialized)
             ? deserialized
             : null;
     }
@@ -2217,7 +2201,7 @@ internal sealed class ExecutionService : IExecutionService
                 definitionVersionId = request.DefinitionVersionId,
                 input = request.Input
             },
-            CamelCaseJsonSerializerOptions);
+            JsonSerializerProfiles.CamelCase);
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
     }
 
@@ -2330,7 +2314,7 @@ internal sealed class ExecutionService : IExecutionService
         var compiled = RestoreCompiledDefinitionFromVersion(versionRow);
         var checkpoint = JsonSerializer.Deserialize<ExecutionRuntimeCheckpoint>(
             checkpointDocument.CheckpointJson,
-            CamelCaseJsonSerializerOptions)
+            JsonSerializerProfiles.CamelCase)
             ?? throw new InvalidOperationException("Stored runtime checkpoint JSON is invalid.");
 
         try
@@ -2402,7 +2386,7 @@ internal sealed class ExecutionService : IExecutionService
             graphJson = _engine.ExportExecutionGraph(engineExecutionId);
         }
 
-        var json = JsonSerializer.Serialize(checkpoint, CamelCaseJsonSerializerOptions);
+        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
         var updatedAt = DateTime.UtcNow;
         var fenceLost = await _executor.ExecuteReadCommittedAsync(
             async (uow, innerCt) =>
@@ -2589,7 +2573,7 @@ internal sealed class ExecutionService : IExecutionService
                     kv => kv.Key,
                     kv => kv.Value,
                     StringComparer.OrdinalIgnoreCase),
-                CamelCaseJsonSerializerOptions);
+                JsonSerializerProfiles.CamelCase);
         }
 
         string? varsJson = null;

--- a/core/application/Statevia.Core.Application/Services/ExecutionViewMapper.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionViewMapper.cs
@@ -35,7 +35,7 @@ internal static class ExecutionViewMapper
         if (string.IsNullOrWhiteSpace(graphJson))
             return Array.Empty<ExecutionViewNodeDto>();
 
-        if (!JsonDeserialize.TryDeserialize(graphJson, JsonDeserialize.CaseInsensitiveDeserializeOptions, out ExecutionGraphSnapshotDto? dto))
+        if (!JsonDeserialize.TryDeserialize(graphJson, JsonSerializerProfiles.CaseInsensitive, out ExecutionGraphSnapshotDto? dto))
             return Array.Empty<ExecutionViewNodeDto>();
 
         if (dto?.Nodes is null || dto.Nodes.Count == 0)

--- a/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Infrastructure;
 using Statevia.Core.Engine.Abstractions;
 
 namespace Statevia.Core.Application.Services;
@@ -41,11 +42,6 @@ public sealed class ForkChildExecutionCoordinator(
     IOptions<ForkChildExpansionOptions> options,
     ILogger<ForkChildExecutionCoordinator> logger) : IForkChildExecutionCoordinator
 {
-    private static readonly JsonSerializerOptions CamelCaseJson = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     private readonly ForkChildExpansionOptions _options = options.Value;
 
     /// <inheritdoc />
@@ -478,7 +474,7 @@ public sealed class ForkChildExecutionCoordinator(
                                 definitionVersion = request.DefinitionVersion,
                                 tenantId = request.TenantId
                             },
-                            CamelCaseJson);
+                            JsonSerializerProfiles.CamelCase);
                         await eventStore
                             .AppendAsync(uow, childId, EventStoreEventType.WorkflowStarted, startedPayload, innerCt)
                             .ConfigureAwait(false);
@@ -642,7 +638,7 @@ public sealed class ForkChildExecutionCoordinator(
         if (value is JsonElement element)
             return element.Clone();
 
-        var json = JsonSerializer.Serialize(value, CamelCaseJson);
+        var json = JsonSerializer.Serialize(value, JsonSerializerProfiles.CamelCase);
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
     }

--- a/core/application/Statevia.Core.Application/Services/PhysicalForkGraphComposer.cs
+++ b/core/application/Statevia.Core.Application/Services/PhysicalForkGraphComposer.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Statevia.Core.Application.Infrastructure;
 using Statevia.Core.Engine.ExecutionGraphs;
 
 namespace Statevia.Core.Application.Services;
@@ -28,11 +29,6 @@ internal static class PhysicalForkGraphComposer
     private const string StateNameProperty = "stateName";
     private const string NodeTypeProperty = "nodeType";
     private const string JoinNodeType = "Join";
-
-    private static readonly JsonSerializerOptions CompactJson = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
 
     /// <summary>1 分岐分の子グラフ（再帰合成済み可）。</summary>
     /// <param name="ForkNodeId">親上の Fork 到達ノード ID。</param>
@@ -75,7 +71,7 @@ internal static class PhysicalForkGraphComposer
             ["nodes"] = new JsonArray(nodeById.Values.Select(n => n.DeepClone()).ToArray()),
             ["edges"] = new JsonArray(edges.Select(e => (JsonNode?)e.DeepClone()).ToArray())
         };
-        return root.ToJsonString(CompactJson);
+        return root.ToJsonString(JsonSerializerProfiles.CamelCase);
     }
 
     /// <summary>

--- a/service/api/Statevia.Service.Api.Tests/Infrastructure/JsonDeserializeTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Infrastructure/JsonDeserializeTests.cs
@@ -14,7 +14,7 @@ public sealed class JsonDeserializeTests
         const string json = """{"name":"x"}""";
 
         // Act
-        var ok = JsonDeserialize.TryDeserialize(json, JsonDeserialize.CaseInsensitiveDeserializeOptions, out JsonElement? value);
+        var ok = JsonDeserialize.TryDeserialize(json, JsonSerializerProfiles.CaseInsensitive, out JsonElement? value);
 
         // Assert
         Assert.True(ok);

--- a/service/api/Statevia.Service.Api/Services/ExecutionReadModelService.cs
+++ b/service/api/Statevia.Service.Api/Services/ExecutionReadModelService.cs
@@ -95,7 +95,7 @@ internal sealed class ExecutionReadModelService : IExecutionReadModelService
             return Array.Empty<ExecutionNodeReadModel>();
         }
 
-        if (!JsonDeserialize.TryDeserialize(graphJson, JsonDeserialize.CaseInsensitiveDeserializeOptions, out ExecutionGraphSnapshotDto? dto))
+        if (!JsonDeserialize.TryDeserialize(graphJson, JsonSerializerProfiles.CaseInsensitive, out ExecutionGraphSnapshotDto? dto))
         {
             return Array.Empty<ExecutionNodeReadModel>();
         }

--- a/service/api/Statevia.Service.Api/Services/ExecutionStreamService.cs
+++ b/service/api/Statevia.Service.Api/Services/ExecutionStreamService.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Infrastructure;
 using Statevia.Core.Application.Services;
 
 namespace Statevia.Service.Api.Services;
@@ -70,7 +71,7 @@ public sealed class ExecutionStreamService
         response.Headers.Connection = "keep-alive";
         response.Headers["X-Accel-Buffering"] = "no";
 
-        var jsonOpts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        var jsonOpts = JsonSerializerProfiles.CamelCase;
         string? lastHash = null;
 
         while (!ct.IsCancellationRequested)


### PR DESCRIPTION
## Summary
- Application に `JsonSerializerProfiles`（CamelCase / CaseInsensitive）を追加し、Execution / Fork / Projection 周辺の自前 Options を共有参照へ寄せる。
- `ExecutionStreamService` の SSE ループ内 `new JsonSerializerOptions` を廃止し、ホットパスの都度生成を解消する。
- HTTP / DB 契約は変更しない（内部参照の整理のみ）。

## Test plan
- [x] `cd service/api && dotnet test --filter FullyQualifiedName~JsonDeserializeTests`
- [x] Execution / Fork / Stream 関連テストが回帰しないこと
- [x] SSE graph stream が従来どおり camelCase JSON を送出すること

Made with [Cursor](https://cursor.com)