### PR TITLE
ExecutionGraph の NodeId 解決を大文字小文字無視に揃える

### DIFF
--- a/core/engine/Statevia.Core.Engine.Tests/ExecutionGraph/ExecutionGraphTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/ExecutionGraph/ExecutionGraphTests.cs
@@ -102,6 +102,46 @@ public class ExecutionGraphTests
         Assert.Equal(2, graph.GetNodesSnapshot().Count);
     }
 
+    /// <summary>CompleteNode / SetNodeConditionRouting が NodeId を大文字小文字無視で解決することを検証する。</summary>
+    [Fact]
+    public void CompleteNode_AndSetConditionRouting_ResolveNodeIdIgnoreCase()
+    {
+        // Arrange
+        var graph = new ExecutionGraph();
+        graph.ImportFromCheckpoint(new CheckpointGraphData
+        {
+            Nodes =
+            [
+                new CheckpointGraphNode
+                {
+                    NodeId = "AaBbCcDdEeFf",
+                    StateName = "Mixed",
+                    NodeType = "Task",
+                    StartedAt = DateTime.UtcNow,
+                    Attempt = 1
+                }
+            ],
+            Edges = []
+        });
+        var diagnostics = new ConditionRoutingDiagnostics
+        {
+            Fact = "Completed",
+            Resolution = ConditionRoutingResolutions.Linear
+        };
+
+        // Act
+        graph.SetNodeConditionRouting("aabbccddeeff", diagnostics);
+        graph.CompleteNode("AABBCCDDEEFF", "Completed", new { ok = true });
+        var node = Assert.Single(graph.GetNodesSnapshot());
+
+        // Assert
+        Assert.Equal("AaBbCcDdEeFf", node.NodeId);
+        Assert.NotNull(node.CompletedAt);
+        Assert.Equal("Completed", node.Fact);
+        Assert.NotNull(node.ConditionRouting);
+        Assert.Equal(ConditionRoutingResolutions.Linear, node.ConditionRouting.Resolution);
+    }
+
     /// <summary>AddEdge がノード間の辺を記録し、Edges から取得できることを検証する。</summary>
     [Fact]
     public void AddEdge_RecordsRelationship()

--- a/core/engine/Statevia.Core.Engine/ExecutionGraph/ExecutionGraph.cs
+++ b/core/engine/Statevia.Core.Engine/ExecutionGraph/ExecutionGraph.cs
@@ -106,7 +106,7 @@ public sealed class ExecutionGraph
         for (var attempt = 0; attempt < ExecutionNodeIdMaxAllocationAttempts; attempt++)
         {
             var candidate = CreateNodeIdCandidate();
-            if (!_nodes.Exists(n => string.Equals(n.NodeId, candidate, StringComparison.OrdinalIgnoreCase)))
+            if (FindNodeUnlocked(candidate) is null)
             {
                 return candidate;
             }
@@ -127,12 +127,18 @@ public sealed class ExecutionGraph
         return Guid.NewGuid().ToString("N")[..ExecutionNodeIdHexLength];
     }
 
+    /// <summary>
+    /// 同一グラフ内のノードを NodeId で探す（大文字小文字無視。呼び出し元が <c>_lock</c> を保持していること）。
+    /// </summary>
+    private ExecutionNode? FindNodeUnlocked(string nodeId) =>
+        _nodes.Find(n => string.Equals(n.NodeId, nodeId, StringComparison.OrdinalIgnoreCase));
+
     /// <summary>ノードを完了としてマークし、事実と出力を記録します。</summary>
     public void CompleteNode(string nodeId, string fact, object? output)
     {
         lock (_lock)
         {
-            var node = _nodes.FirstOrDefault(n => n.NodeId == nodeId);
+            var node = FindNodeUnlocked(nodeId);
             if (node != null)
             {
                 node.CompletedAt = DateTime.UtcNow;
@@ -150,7 +156,7 @@ public sealed class ExecutionGraph
     {
         lock (_lock)
         {
-            var node = _nodes.FirstOrDefault(n => n.NodeId == nodeId);
+            var node = FindNodeUnlocked(nodeId);
             if (node is not null)
             {
                 node.ConditionRouting = diagnostics;


### PR DESCRIPTION
## Summary
- `CompleteNode` / `SetNodeConditionRouting` の NodeId 照合を、採番時と同じ `OrdinalIgnoreCase` に揃える。
- `FindNodeUnlocked` に共通化し、大小文字だけが異なる ID でも完了・条件ルーティングが解決できるようにする。
- 回帰防止の単体テストを追加する。

## Test plan
- [x] `cd core/engine && dotnet test --filter FullyQualifiedName~ExecutionGraphTests`
- [x] 混在ケースの NodeId で `CompleteNode` / `SetNodeConditionRouting` が成功すること

Made with [Cursor](https://cursor.com)