### PR TITLE
循環物理 Fork の Join 停滞修正と checkpoint 寿命・UI 代表ノード選択

### DIFF
--- a/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionBranchRow.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/ExecutionBranchRow.cs
@@ -27,9 +27,15 @@ public static class ExecutionBranchStatuses
 /// <remarks>
 /// <para>
 /// 一意: <c>(parent_execution_id, fork_node_id, branch_state)</c> および <c>execution_id</c>。
-/// <c>fork_node_id</c> は親実行グラフ上の Fork 到達インスタンス（実行ノード ID）。
-/// <c>join_state</c> / <c>branch_state</c> は定義の状態名空間。
 /// </para>
+/// <para>
+/// <c>fork_node_id</c>（<see cref="ForkNodeId"/>）は Hosted 物理 Fork の
+/// <b>1 回の Fork 到達（並列エピソード）の相関キー</b>である。
+/// 値は親実行グラフ上の当該 Fork 訪問の実行 <c>nodeId</c> と同一。
+/// 定義の状態名でも Join の <c>nodeId</c> でもない（Join は未到達時点で未作成になりうる）。
+/// 契約の正本は <c>docs/specifications/execution/fork-join.md</c>。
+/// </para>
+/// <para><c>join_state</c> / <c>branch_state</c> は定義の状態名空間。</para>
 /// </remarks>
 public sealed class ExecutionBranchRow
 {
@@ -39,7 +45,9 @@ public sealed class ExecutionBranchRow
     /// <summary>分岐を走らせる子 execution。</summary>
     public Guid ExecutionId { get; set; }
 
-    /// <summary>親実行グラフ上の Fork ノード ID（到達インスタンス）。</summary>
+    /// <summary>
+    /// 当該並列エピソードの相関キー（親グラフ上の Fork 到達 <c>nodeId</c>）。
+    /// </summary>
     public required string ForkNodeId { get; set; }
 
     /// <summary>Join 状態名。</summary>

--- a/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Services/IForkChildExecutionCoordinator.cs
@@ -18,7 +18,10 @@ public sealed record ForkBranchExpansion(
 /// <param name="DefinitionDisplayId">Start の definitionId に渡す表示／UUID 文字列。</param>
 /// <param name="SecuritySnapshotJson">親から継承する security snapshot JSON。</param>
 /// <param name="CompiledDefinition">親と同じコンパイル済み定義（Join 解決用）。</param>
-/// <param name="ForkNodeId">親実行グラフ上の Fork ノード ID（到達インスタンス）。</param>
+/// <param name="ForkNodeId">
+/// 当該並列エピソードの相関キー。親実行グラフ上の Fork 到達 <c>nodeId</c>（循環再到達ごとに別値）。
+/// Join の <c>nodeId</c> や定義の状態名ではない。
+/// </param>
 /// <param name="Branches">分岐先頭と写像済み input。</param>
 public sealed record ForkExpansionRequest(
     Guid ParentExecutionId,
@@ -137,13 +140,26 @@ public interface IForkChildExecutionCoordinator
     /// 親の指定 Fork 到達について <c>execution_branches</c> から Join を再評価する。
     /// </summary>
     /// <param name="parentExecutionId">親 execution。</param>
-    /// <param name="forkNodeId">親実行グラフ上の Fork ノード ID。</param>
+    /// <param name="forkNodeId">
+    /// 当該並列エピソードの相関キー（親グラフ上の Fork 到達 <c>nodeId</c>）。
+    /// </param>
     /// <param name="ct">キャンセル トークン。</param>
     /// <returns>評価結果（Waiting / Satisfied / Failed）。</returns>
     Task<ForkJoinEvaluation> EvaluateJoinAsync(
         Guid parentExecutionId,
         string forkNodeId,
         CancellationToken ct);
+
+    /// <summary>
+    /// 親に未終端（Running）の物理分岐が残っているかを返す。
+    /// </summary>
+    /// <remarks>
+    /// durable Wait が無くても物理 Join 待ち中は runtime checkpoint を破棄してはならない判定に使う。
+    /// </remarks>
+    /// <param name="parentExecutionId">親 execution。</param>
+    /// <param name="ct">キャンセル トークン。</param>
+    /// <returns>Running の <c>execution_branches</c> が 1 件以上あるとき true。</returns>
+    Task<bool> HasPendingPhysicalJoinBranchesAsync(Guid parentExecutionId, CancellationToken ct);
 
     /// <summary>
     /// 親 Cancel 時に、未終端（Running）の子へ Cancel work item を enqueue する。

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
@@ -18,6 +19,12 @@ internal sealed class ExecutionService : IExecutionService
     /// <summary>Worker が 1 Load を待つときのポーリング間隔。</summary>
     private static readonly TimeSpan LocalExecutionLoadPollInterval = TimeSpan.FromMilliseconds(250);
 
+    /// <summary>
+    /// 同一実行の <see cref="PersistCheckpointAndUnloadCoreAsync"/> を直列化し、
+    /// 古い Fork Unload が新しい Wait 断面を上書きしないようにする。
+    /// </summary>
+    private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> PersistUnloadGates = new();
+
     /// <summary><c>event_delivery_decision</c> 構造化ログの <c>decision</c> プロパティ値。</summary>
     private static class EventDeliveryLogDecisions
     {
@@ -27,6 +34,18 @@ internal sealed class ExecutionService : IExecutionService
         internal const string Retry = "retry";
         internal const string BackoffBudgetExhausted = "backoff_budget_exhausted";
         internal const string Failed = "failed";
+    }
+
+    /// <summary>実行グラフ JSON のプロパティ名（投影・Engine export 共通）。</summary>
+    private static class ExecutionGraphJsonProperties
+    {
+        internal const string Nodes = "nodes";
+        internal const string CompletedAt = "completedAt";
+        internal const string NodeId = "nodeId";
+        internal const string Fact = "fact";
+        internal const string Status = "status";
+        internal const string StartedAt = "startedAt";
+        internal const string NodeType = "nodeType";
     }
 
     /// <summary>
@@ -1062,7 +1081,7 @@ internal sealed class ExecutionService : IExecutionService
         try
         {
             using var document = JsonDocument.Parse(graphJson);
-            if (!document.RootElement.TryGetProperty("nodes", out var nodes)
+            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
                 || nodes.ValueKind != JsonValueKind.Array)
             {
                 return false;
@@ -1070,7 +1089,7 @@ internal sealed class ExecutionService : IExecutionService
 
             return nodes.EnumerateArray().Any(node =>
             {
-                var nodeType = node.TryGetProperty("nodeType", out var typeEl)
+                var nodeType = node.TryGetProperty(ExecutionGraphJsonProperties.NodeType, out var typeEl)
                     ? typeEl.GetString()
                     : null;
                 if (string.Equals(nodeType, "Wait", StringComparison.OrdinalIgnoreCase)
@@ -1079,14 +1098,14 @@ internal sealed class ExecutionService : IExecutionService
                     return false;
                 }
 
-                if (node.TryGetProperty("completedAt", out var completedAt)
+                if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
                     && completedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
                 {
                     return false;
                 }
 
                 // startedAt があり未完了なら実行中とみなす。
-                return node.TryGetProperty("startedAt", out var startedAt)
+                return node.TryGetProperty(ExecutionGraphJsonProperties.StartedAt, out var startedAt)
                     && startedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined;
             });
         }
@@ -1503,47 +1522,115 @@ internal sealed class ExecutionService : IExecutionService
         // 続けて後続 Task が落ち着くまで待つ（Wait 完了直後の RUNNING 中間像の永続化を避ける）。
         await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
 
-        var (pubStatus, pubCancel, pubGraphJson) = BuildProjectionFromEngine(uuid.Value);
+        // Again → Fork の Suspend Unload 後は in-process snapshot が欠ける。SuspendHandler 投影を正とする。
+        var (engineStillLoaded, pubStatus, pubCancel, pubGraphJson) =
+            await ResolveProjectionAfterWaitResumeAsync(uuid.Value, ct).ConfigureAwait(false);
+
         var publishedPayload = JsonSerializer.Serialize(
             new { tenantId, name = eventName, nodeId },
             JsonSerializerProfiles.CamelCase);
 
+        await PersistWaitResumeSideEffectsAsync(
+                new WaitResumePersistRequest(
+                    tenantId,
+                    uuid.Value,
+                    engineId,
+                    nodeId,
+                    clientEventId,
+                    dedupKey,
+                    engineStillLoaded,
+                    pubStatus,
+                    pubCancel,
+                    pubGraphJson,
+                    publishedPayload),
+                ct)
+            .ConfigureAwait(false);
+
+        // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
+        await _projectionUpdateQueue.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Wait Resume 後の投影・checkpoint・event_store・dedup 永続化入力。</summary>
+    private readonly record struct WaitResumePersistRequest(
+        Guid TenantId,
+        Guid ExecutionId,
+        string EngineId,
+        string NodeId,
+        Guid ClientEventId,
+        CommandDedupKey? DedupKey,
+        bool EngineStillLoaded,
+        string PubStatus,
+        bool? PubCancel,
+        string PubGraphJson,
+        string PublishedPayload);
+
+    /// <summary>Wait Resume 後の投影・checkpoint・event_store・dedup を同一 tx で永続化する。</summary>
+    private async Task PersistWaitResumeSideEffectsAsync(
+        WaitResumePersistRequest request,
+        CancellationToken ct)
+    {
         await _mutationPersistence.ExecuteSerializableWithRetryAsync(
-            tenantId,
-            uuid.Value,
-            clientEventId,
+            request.TenantId,
+            request.ExecutionId,
+            request.ClientEventId,
             async (uow, ctInner) =>
             {
                 await _executions
-                    .UpdateExecutionAndSnapshotAsync(uow, uuid.Value, pubStatus, pubCancel, pubGraphJson, ctInner)
+                    .UpdateExecutionAndSnapshotAsync(
+                        uow,
+                        request.ExecutionId,
+                        request.PubStatus,
+                        request.PubCancel,
+                        request.PubGraphJson,
+                        ctInner)
                     .ConfigureAwait(false);
                 await SyncOperationalProjectionAsync(
                         uow,
-                        uuid.Value,
-                        tenantId,
-                        pubStatus,
-                        pubGraphJson,
-                        nodeIdToClear: nodeId,
+                        request.ExecutionId,
+                        request.TenantId,
+                        request.PubStatus,
+                        request.PubGraphJson,
+                        nodeIdToClear: request.NodeId,
                         ctInner)
                     .ConfigureAwait(false);
 
-                // Resume 後に durable Wait が残っていなければ checkpoint を破棄する。
-                // 所有セッション中は lease 行を消さず runtime のみ更新する。
-                if (ShouldDiscardRuntimeCheckpoint(pubStatus, pubGraphJson))
+                if (request.EngineStillLoaded)
                 {
-                    await DiscardOrRefreshRuntimeCheckpointAsync(
-                            uow,
-                            engineId,
-                            uuid.Value,
+                    if (await ShouldDiscardRuntimeCheckpointAsync(
+                            request.ExecutionId,
+                            request.PubStatus,
+                            request.PubGraphJson,
                             ctInner)
-                        .ConfigureAwait(false);
+                        .ConfigureAwait(false))
+                    {
+                        await DiscardOrRefreshRuntimeCheckpointAsync(
+                                uow,
+                                request.EngineId,
+                                request.ExecutionId,
+                                ctInner)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await UpsertRuntimeCheckpointAsync(
+                                uow,
+                                request.EngineId,
+                                request.ExecutionId,
+                                ctInner)
+                            .ConfigureAwait(false);
+                    }
                 }
 
                 await _eventStore
-                    .AppendAsync(uow, uuid.Value, EventStoreEventType.EventPublished, publishedPayload, ctInner)
+                    .AppendAsync(
+                        uow,
+                        request.ExecutionId,
+                        EventStoreEventType.EventPublished,
+                        request.PublishedPayload,
+                        ctInner)
                     .ConfigureAwait(false);
 
-                if (dedupKey is { } saveKey)
+                if (request.DedupKey is { } saveKey)
                 {
                     var now = DateTime.UtcNow;
                     await _dedup.SaveAsync(
@@ -1565,9 +1652,9 @@ internal sealed class ExecutionService : IExecutionService
                 var nowUtc = DateTime.UtcNow;
                 await _eventDeliveryDedup.TryUpdateStatusAsync(
                     uow,
-                    tenantId,
-                    uuid.Value,
-                    clientEventId,
+                    request.TenantId,
+                    request.ExecutionId,
+                    request.ClientEventId,
                     new EventDeliveryDedupStatusUpdate(
                         EventDeliveryDedupStatuses.Applied,
                         nowUtc,
@@ -1576,9 +1663,40 @@ internal sealed class ExecutionService : IExecutionService
                     ctInner).ConfigureAwait(false);
             },
             ct).ConfigureAwait(false);
+    }
 
-        // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
-        await _projectionUpdateQueue.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
+    /// <summary>
+    /// Wait Resume 後の投影断面を Engine または DB（Unload 済み）から解決する。
+    /// </summary>
+    /// <returns>
+    /// Engine がメモリ上に残っているとき <c>engineStillLoaded</c> は true。
+    /// </returns>
+    private async Task<(bool EngineStillLoaded, string Status, bool? CancelRequested, string GraphJson)>
+        ResolveProjectionAfterWaitResumeAsync(Guid executionId, CancellationToken ct)
+    {
+        var (projectedStatus, projectedCancel, projectedGraphJson) = BuildProjectionFromEngineForQueue(executionId);
+        if (projectedStatus is not null && projectedGraphJson is not null)
+        {
+            return (true, projectedStatus, projectedCancel, projectedGraphJson);
+        }
+
+        var unloadedSnapshot = await _executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => _executions.GetSnapshotByExecutionIdAsync(uow, executionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        var unloadedRow = await _executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => _executions.GetByExecutionIdAsync(uow, executionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        if (unloadedSnapshot is null
+            || unloadedRow is null
+            || string.IsNullOrWhiteSpace(unloadedSnapshot.GraphJson))
+        {
+            throw new InvalidOperationException(
+                $"Cannot project execution '{executionId:D}': engine snapshot is missing after Resume unload.");
+        }
+
+        return (false, unloadedRow.Status, unloadedRow.CancelRequested, unloadedSnapshot.GraphJson);
     }
 
     /// <summary>
@@ -1682,6 +1800,24 @@ internal sealed class ExecutionService : IExecutionService
                 return;
 
             case ForkJoinEvaluationKind.Satisfied:
+                // 既に当該 Fork 訪問の Join が投影上 SUCCEEDED なら再実行しない（child.completed 再送の冪等）。
+                var snapshotRow = await _executor.ExecuteReadOnlyAsync(
+                        (uow, innerCt) => _executions.GetSnapshotByExecutionIdAsync(
+                            uow,
+                            parentExecutionId,
+                            innerCt),
+                        ct)
+                    .ConfigureAwait(false);
+                if (snapshotRow is not null
+                    && IsPhysicalJoinAlreadyCompleted(
+                        snapshotRow.GraphJson,
+                        forkNodeId,
+                        evaluation.JoinState))
+                {
+                    _logger.ForkJoinAlreadyCompleted(parentExecutionId, forkNodeId, evaluation.JoinState);
+                    return;
+                }
+
                 await CompleteParentPhysicalJoinAsync(
                         parentExecutionId,
                         execution,
@@ -1693,6 +1829,95 @@ internal sealed class ExecutionService : IExecutionService
 
             default:
                 throw new InvalidOperationException($"Unknown fork join evaluation kind '{evaluation.Kind}'.");
+        }
+    }
+
+    /// <summary>
+    /// Unload 後でも、Join が進んで Wait / 終端断面が checkpoint に残っているか。
+    /// </summary>
+    private async Task<bool> HasPhysicalJoinProgressAfterUnloadAsync(
+        Guid parentExecutionId,
+        CancellationToken ct)
+    {
+        var document = await _executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => _checkpointStore.GetByExecutionIdAsync(uow, parentExecutionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        if (document is null
+            || !TryParseRuntimeCheckpoint(document.CheckpointJson, out var checkpoint, out _))
+        {
+            return false;
+        }
+
+        if (checkpoint.IsCompleted || checkpoint.IsCancelled || checkpoint.IsFailed)
+            return true;
+
+        if (checkpoint.PendingWaits.Count > 0)
+            return true;
+
+        return checkpoint.ActiveStates.Count > 0;
+    }
+
+    /// <summary>
+    /// 親グラフ上で、当該 Fork 訪問に対応する Join が既に SUCCEEDED か。
+    /// </summary>
+    /// <remarks>単体テストから到達するため internal。</remarks>
+    internal static bool IsPhysicalJoinAlreadyCompleted(
+        string parentGraphJson,
+        string forkNodeId,
+        string joinState)
+    {
+        var joinNodeId = PhysicalForkGraphComposer.ResolveJoinNodeId(
+            parentGraphJson,
+            forkNodeId,
+            joinState);
+        if (string.IsNullOrWhiteSpace(joinNodeId))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(parentGraphJson);
+            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
+                || nodes.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            // joinNodeId は Fork 訪問ごとに一意。一致ノードが無ければ未完了扱い。
+            var node = nodes.EnumerateArray().FirstOrDefault(candidate =>
+                candidate.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var idEl)
+                && string.Equals(idEl.GetString(), joinNodeId, StringComparison.Ordinal));
+            if (node.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            // 投影 JSON は UI 用 status ではなく fact / completedAt を持つ。
+            // 当該 Fork 訪問に紐づく Join が既に Joined なら冪等スキップ（循環の別訪問は別 Join nodeId）。
+            var fact = node.TryGetProperty(ExecutionGraphJsonProperties.Fact, out var factEl)
+                ? factEl.GetString()
+                : null;
+            if (string.Equals(fact, "Joined", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(fact, "Completed", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAtEl)
+                && completedAtEl.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(completedAtEl.GetString()))
+            {
+                return true;
+            }
+
+            var status = node.TryGetProperty(ExecutionGraphJsonProperties.Status, out var statusEl)
+                ? statusEl.GetString()
+                : null;
+            return string.Equals(status, "SUCCEEDED", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (JsonException)
+        {
+            return false;
         }
     }
 
@@ -1768,32 +1993,70 @@ internal sealed class ExecutionService : IExecutionService
             evaluation.JoinState,
             evaluation.CandidateInputs,
             fragments);
-        await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
+        // Join は Schedule 非同期のため、ActiveStates==0 ですぐ戻ると decide Wait 前の断面を永続してしまう。
+        await WaitForPhysicalJoinSettlementAsync(
+            engineId,
+            forkNodeId,
+            evaluation.JoinState,
+            ct).ConfigureAwait(false);
 
-        var (status, cancelRequested, graphJson) = BuildProjectionFromEngine(parentExecutionId);
+        // Join 直後に Wait へ進むと SuspendHandler が PersistCheckpointAndUnload する。
+        // Unload 後は GetSnapshot が null になり得る。checkpoint に Wait / 終端が進んでいれば冪等完了。
+        // Join が startedJoins 等で無動作のまま Unload された場合は再試行する。
+        var (status, cancelRequested, graphJson) = BuildProjectionFromEngineForQueue(parentExecutionId);
+        if (status is null || graphJson is null)
+        {
+            if (!await HasPhysicalJoinProgressAfterUnloadAsync(parentExecutionId, ct).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException(
+                    $"Physical join for execution '{parentExecutionId:D}' unloaded before Join advanced; will retry.");
+            }
+
+            // SuspendHandler が checkpoint だけ進めて snapshot が遅れている場合の補正。
+            await TrySyncGraphSnapshotFromRuntimeCheckpointAsync(parentExecutionId, execution, ct)
+                .ConfigureAwait(false);
+
+            _logger.ForkJoinProjectionSkippedAfterUnload(
+                parentExecutionId,
+                forkNodeId,
+                evaluation.JoinState);
+            return;
+        }
+
         await _executor.ExecuteReadCommittedAsync(
                 async (uow, innerCt) =>
                 {
+                    // Settlement 待機後〜tx 開始前に Wait Persist が進んでいることがあるので直前に再取得。
+                    var (freshStatus, freshCancel, freshGraph) = BuildProjectionFromEngineForQueue(parentExecutionId);
+                    var writeStatus = freshStatus ?? status;
+                    var writeCancel = freshCancel ?? cancelRequested;
+                    var writeGraph = freshGraph ?? graphJson;
+
                     await _executions
                         .UpdateExecutionAndSnapshotAsync(
                             uow,
                             parentExecutionId,
-                            status,
-                            cancelRequested,
-                            graphJson,
+                            writeStatus,
+                            writeCancel,
+                            writeGraph,
                             innerCt)
                         .ConfigureAwait(false);
                     await SyncOperationalProjectionAsync(
                             uow,
                             parentExecutionId,
                             execution.TenantId,
-                            status,
-                            graphJson,
+                            writeStatus,
+                            writeGraph,
                             nodeIdToClear: null,
                             innerCt)
                         .ConfigureAwait(false);
 
-                    if (ShouldDiscardRuntimeCheckpoint(status, graphJson))
+                    if (await ShouldDiscardRuntimeCheckpointAsync(
+                                parentExecutionId,
+                                writeStatus,
+                                writeGraph,
+                                innerCt)
+                            .ConfigureAwait(false))
                     {
                         await DiscardOrRefreshRuntimeCheckpointAsync(
                                 uow,
@@ -1859,13 +2122,19 @@ internal sealed class ExecutionService : IExecutionService
                         innerCt)
                     .ConfigureAwait(false);
 
-                if (ShouldDiscardRuntimeCheckpoint(status, graphJson))
+                if (await ShouldDiscardRuntimeCheckpointAsync(executionId, status, graphJson, innerCt)
+                        .ConfigureAwait(false))
                 {
                     await DiscardOrRefreshRuntimeCheckpointAsync(
                             uow,
                             engineId,
                             executionId,
                             innerCt)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await UpsertRuntimeCheckpointAsync(uow, engineId, executionId, innerCt)
                         .ConfigureAwait(false);
                 }
             },
@@ -1956,6 +2225,170 @@ internal sealed class ExecutionService : IExecutionService
         _logger.WaitResumeQuiesceTimedOut(engineExecutionId);
     }
 
+    /// <summary>
+    /// 物理 Join 完了後、Join ノード完了・decide Wait 登録・Unload・終端のいずれかまで待つ。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IExecutionEngine.CompletePhysicalJoin"/> は Join を非同期 Schedule するだけなので、
+    /// 直後は <c>ActiveStates</c> が空のままである。ここで
+    /// <see cref="WaitForEngineQuiescedAfterWaitAsync"/> を使うと Join 前断面を投影してしまう。
+    /// </para>
+    /// <para>
+    /// Join 直後に長い Action が続く場合でも、Join ノード完了で抜けて投影する。
+    /// durable Wait 登録・Unload・終端も同様に出口とする。
+    /// </para>
+    /// </remarks>
+    /// <param name="engineExecutionId">Engine 辞書キー。</param>
+    /// <param name="forkNodeId">充足した物理 Fork の graph nodeId。</param>
+    /// <param name="joinState">対応する Join 状態名。</param>
+    /// <param name="ct">キャンセル。</param>
+    private async Task WaitForPhysicalJoinSettlementAsync(
+        string engineExecutionId,
+        string forkNodeId,
+        string joinState,
+        CancellationToken ct)
+    {
+        const int maxAttempts = 200;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var snapshot = _engine.GetSnapshot(engineExecutionId);
+            if (snapshot is null)
+                return;
+
+            if (snapshot.IsCompleted || snapshot.IsCancelled || snapshot.IsFailed)
+                return;
+
+            var graphJson = _engine.ExportExecutionGraph(engineExecutionId);
+            if (IsPhysicalJoinAlreadyCompleted(graphJson, forkNodeId, joinState))
+                return;
+
+            var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
+            if (checkpoint is { PendingWaits.Count: > 0 })
+                return;
+
+            await Task.Delay(10, ct).ConfigureAwait(false);
+        }
+
+        _logger.WaitResumeQuiesceTimedOut(engineExecutionId);
+    }
+
+    /// <summary>
+    /// Unload 後に runtime checkpoint が Wait 断面まで進んでいるとき、graph snapshot を追いつかせる。
+    /// </summary>
+    private async Task TrySyncGraphSnapshotFromRuntimeCheckpointAsync(
+        Guid executionId,
+        ExecutionRow execution,
+        CancellationToken ct)
+    {
+        await _executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    var runtime = await _checkpointStore
+                        .GetByExecutionIdAsync(uow, executionId, innerCt)
+                        .ConfigureAwait(false);
+                    if (runtime is null
+                        || !TryParseRuntimeCheckpoint(runtime.CheckpointJson, out var checkpoint, out _)
+                        || checkpoint.PendingWaits.Count == 0)
+                    {
+                        return;
+                    }
+
+                    var graphJson = _engine.ExportExecutionGraph(executionId.ToString());
+                    if (graphJson is "{}" || string.IsNullOrWhiteSpace(graphJson))
+                    {
+                        // Engine Unload 済みなら checkpoint 内グラフを投影 JSON へ写す。
+                        graphJson = JsonSerializer.Serialize(
+                            new
+                            {
+                                nodes = checkpoint.Graph.Nodes,
+                                edges = checkpoint.Graph.Edges
+                            },
+                            JsonSerializerProfiles.CamelCase);
+                    }
+
+                    var existingSnapshot = await _executions
+                        .GetSnapshotByExecutionIdAsync(uow, executionId, innerCt)
+                        .ConfigureAwait(false);
+                    if (existingSnapshot?.GraphJson is not null
+                        && !IsGraphSnapshotBehindCheckpoint(existingSnapshot.GraphJson, checkpoint))
+                    {
+                        return;
+                    }
+
+                    var status = execution.Status;
+                    if (string.IsNullOrWhiteSpace(status))
+                        status = "Running";
+
+                    await _executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            executionId,
+                            status,
+                            execution.CancelRequested,
+                            graphJson,
+                            innerCt)
+                        .ConfigureAwait(false);
+                    await SyncOperationalProjectionAsync(
+                            uow,
+                            executionId,
+                            execution.TenantId,
+                            status,
+                            graphJson,
+                            nodeIdToClear: null,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    _logger.SyncedGraphSnapshotFromRuntimeCheckpoint(
+                        executionId,
+                        checkpoint.PendingWaits.Count,
+                        checkpoint.Graph.Nodes.Count);
+                },
+                ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>永続 graph snapshot が runtime checkpoint より遅れているか。</summary>
+    private static bool IsGraphSnapshotBehindCheckpoint(
+        string snapshotGraphJson,
+        ExecutionRuntimeCheckpoint checkpoint)
+    {
+        if (!TryCountGraphNodes(snapshotGraphJson, out var snapshotNodeCount))
+            return true;
+
+        if (snapshotNodeCount < checkpoint.Graph.Nodes.Count)
+            return true;
+
+        return checkpoint.PendingWaits.Count > 0
+            && !ExecutionOperationalProjectionSync.HasDurableWaits(snapshotGraphJson);
+    }
+
+    /// <summary>グラフ JSON のノード数を数える。</summary>
+    private static bool TryCountGraphNodes(string graphJson, out int count)
+    {
+        count = 0;
+        if (string.IsNullOrWhiteSpace(graphJson))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(graphJson);
+            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
+                || nodes.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            count = nodes.GetArrayLength();
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
     /// <summary>グラフ JSON 上の指定 nodeId の完了有無を取得する。</summary>
     /// <returns>ノードが存在するとき <see langword="true"/>。</returns>
     private static bool TryGetGraphNodeCompletion(string graphJson, string nodeId, out bool completed)
@@ -1967,7 +2400,7 @@ internal sealed class ExecutionService : IExecutionService
         try
         {
             using var document = JsonDocument.Parse(graphJson);
-            if (!document.RootElement.TryGetProperty("nodes", out var nodes)
+            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
                 || nodes.ValueKind != JsonValueKind.Array)
             {
                 return false;
@@ -1975,14 +2408,14 @@ internal sealed class ExecutionService : IExecutionService
 
             foreach (var node in nodes.EnumerateArray())
             {
-                if (!node.TryGetProperty("nodeId", out var idProp)
+                if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var idProp)
                     || idProp.ValueKind != JsonValueKind.String
                     || !string.Equals(idProp.GetString(), nodeId, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
 
-                completed = node.TryGetProperty("completedAt", out var completedAt)
+                completed = node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
                     && completedAt.ValueKind is not JsonValueKind.Null
                     && completedAt.ValueKind is not JsonValueKind.Undefined;
                 return true;
@@ -2220,21 +2653,59 @@ internal sealed class ExecutionService : IExecutionService
     private static bool IsTerminalExecutionProjectionStatus(string status) =>
         ExecutionProjectionStatuses.IsTerminal(status);
 
-    /// <summary>Running かつ durable Wait が無い／終端なら checkpoint を破棄する。</summary>
     /// <summary>
-    /// durable Wait が不要（終端、または Running だが Wait 無し）のとき checkpoint 破棄候補。
+    /// 寿命表に従い checkpoint <b>内容</b>の破棄候補か。
     /// </summary>
     /// <remarks>
-    /// 所有セッション中は <see cref="DiscardOrRefreshRuntimeCheckpointAsync"/> が削除を抑止する。
-    /// BeginOwnedSession の seed 行は Wait 到達前から lease を保持するため。
+    /// 保持理由は <see cref="RuntimeCheckpointRetainReasons"/> のみ
+    ///（PendingWaits / PendingPhysicalJoin）。
+    /// Worker 所有 lease は同列にせず、破棄候補でも
+    /// <see cref="DiscardOrRefreshRuntimeCheckpointAsync"/> が Delete を抑止する。
     /// </remarks>
-    private static bool ShouldDiscardRuntimeCheckpoint(string status, string graphJson) =>
-        !string.Equals(status, ExecutionProjectionStatuses.Running, StringComparison.Ordinal)
-        || !ExecutionOperationalProjectionSync.HasDurableWaits(graphJson);
+    private async Task<bool> ShouldDiscardRuntimeCheckpointAsync(
+        Guid executionId,
+        string status,
+        string graphJson,
+        CancellationToken ct)
+    {
+        var retainReasons = await EvaluateRuntimeCheckpointRetainReasonsAsync(
+                executionId,
+                graphJson,
+                ct)
+            .ConfigureAwait(false);
+        return RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(status, retainReasons);
+    }
 
     /// <summary>
-    /// checkpoint を破棄するか、所有中なら runtime JSON のみ世代一致更新する。
+    /// 寿命表の内容保持理由を評価する（OwnedLease は含めない）。
     /// </summary>
+    private async Task<RuntimeCheckpointRetainReasons> EvaluateRuntimeCheckpointRetainReasonsAsync(
+        Guid executionId,
+        string graphJson,
+        CancellationToken ct)
+    {
+        var reasons = RuntimeCheckpointRetainReasons.None;
+
+        if (ExecutionOperationalProjectionSync.HasDurableWaits(graphJson))
+            reasons |= RuntimeCheckpointRetainReasons.PendingWaits;
+
+        if (_forkChildCoordinator is not null
+            && await _forkChildCoordinator
+                .HasPendingPhysicalJoinBranchesAsync(executionId, ct)
+                .ConfigureAwait(false))
+        {
+            reasons |= RuntimeCheckpointRetainReasons.PendingPhysicalJoin;
+        }
+
+        return reasons;
+    }
+
+    /// <summary>
+    /// 内容破棄候補の checkpoint を削除するか、Worker 所有中なら runtime JSON のみ更新する。
+    /// </summary>
+    /// <remarks>
+    /// 所有（OwnedLease）は寿命表の保持理由ではない。Worker 都合で行を残し refresh する別層。
+    /// </remarks>
     /// <returns>
     /// 投影同期後に Engine を Unload してよいとき <see langword="true"/>。
     /// 所有中の refresh や削除のみの場合は <see langword="false"/>。
@@ -2247,7 +2718,7 @@ internal sealed class ExecutionService : IExecutionService
     {
         if (_ownership.TryGet(executionId, out _, out _))
         {
-            // Worker が Load を保持中。lease 行は残し runtime だけ更新する（Unload しない）。
+            // Worker 所有中。寿命表上は破棄候補でも lease 行は残し runtime だけ更新する。
             _ = await UpsertRuntimeCheckpointAsync(uow, engineExecutionId, executionId, ct)
                 .ConfigureAwait(false);
             return false;
@@ -2312,10 +2783,17 @@ internal sealed class ExecutionService : IExecutionService
         }
 
         var compiled = RestoreCompiledDefinitionFromVersion(versionRow);
-        var checkpoint = JsonSerializer.Deserialize<ExecutionRuntimeCheckpoint>(
-            checkpointDocument.CheckpointJson,
-            JsonSerializerProfiles.CamelCase)
-            ?? throw new InvalidOperationException("Stored runtime checkpoint JSON is invalid.");
+        if (!TryParseRuntimeCheckpoint(checkpointDocument.CheckpointJson, out var checkpoint, out var parseError))
+        {
+            _logger.RuntimeCheckpointInvalidForHydrate(
+                executionId,
+                checkpointDocument.CheckpointJson?.Length ?? 0);
+            if (parseError is not null)
+                _logger.RuntimeCheckpointDeserializeFailed(parseError, executionId);
+
+            throw new InvalidOperationException(
+                $"Stored runtime checkpoint for execution '{executionId:D}' is empty or invalid and cannot be hydrated.");
+        }
 
         try
         {
@@ -2325,6 +2803,57 @@ internal sealed class ExecutionService : IExecutionService
         {
             // 二重 hydrate 等はクライアント向け 422（ArgumentException）へ写像する。
             throw new ArgumentException(ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// 永続 checkpoint JSON を hydrate 用に検証・デシリアライズする。
+    /// </summary>
+    /// <remarks>
+    /// <c>BeginOwnedSessionAsync</c> の seed <c>{}</c> や必須欠落は不正とし、Import しない。
+    /// </remarks>
+    private static bool TryParseRuntimeCheckpoint(
+        string? checkpointJson,
+        out ExecutionRuntimeCheckpoint checkpoint,
+        out Exception? parseError)
+    {
+        checkpoint = null!;
+        parseError = null;
+
+        if (string.IsNullOrWhiteSpace(checkpointJson))
+            return false;
+
+        var trimmed = checkpointJson.Trim();
+        if (trimmed is "{}" or "null")
+            return false;
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<ExecutionRuntimeCheckpoint>(
+                checkpointJson,
+                JsonSerializerProfiles.CamelCase);
+            if (parsed is null
+                || string.IsNullOrWhiteSpace(parsed.ExecutionId)
+                || string.IsNullOrWhiteSpace(parsed.DefinitionName)
+                || parsed.ActiveStates is null
+                || parsed.Graph is null
+                || parsed.Join is null
+                || parsed.Context is null
+                || parsed.PendingWaits is null)
+            {
+                return false;
+            }
+
+            // 物理 Join 待ち中は ActiveStates / PendingWaits が空の正規断面になり得る（Fork Unload 後）。
+            // 空配列だけでは破損とみなさない（seed "{}" は上で拒否済み）。
+
+            checkpoint = parsed;
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            parseError = ex;
+            return false;
         }
     }
 
@@ -2366,10 +2895,42 @@ internal sealed class ExecutionService : IExecutionService
         string nodeId,
         CancellationToken ct)
     {
+        var gate = PersistUnloadGates.GetOrAdd(executionId, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await PersistCheckpointAndUnloadUnderGateAsync(engineExecutionId, executionId, nodeId, ct)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>ゲート取得後の Persist + Unload 本体。</summary>
+    private async Task PersistCheckpointAndUnloadUnderGateAsync(
+        string engineExecutionId,
+        Guid executionId,
+        string nodeId,
+        CancellationToken ct)
+    {
         var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
         if (checkpoint is null)
         {
             _logger.ExportCheckpointNullSkipUnload(engineExecutionId, nodeId);
+            return;
+        }
+
+        // ForkExpansion は fire-and-forget のため ExpandFork 完了が Join→decide より遅れることがある。
+        // その遅延 Persist が空断面で Unload すると Wait 登録前／登録直後の decide を潰す（初回 Wait 到達不能）。
+        if (IsForkExpansionUnloadObsolete(checkpoint, nodeId))
+        {
+            _logger.SkipForkExpansionUnloadAlreadyProgressed(
+                executionId,
+                nodeId,
+                checkpoint.ActiveStates.Count,
+                checkpoint.PendingWaits.Count);
             return;
         }
 
@@ -2388,79 +2949,21 @@ internal sealed class ExecutionService : IExecutionService
 
         var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
         var updatedAt = DateTime.UtcNow;
-        var fenceLost = await _executor.ExecuteReadCommittedAsync(
-            async (uow, innerCt) =>
-            {
-                var execution = await _executions.GetByExecutionIdAsync(uow, executionId, innerCt)
-                    .ConfigureAwait(false);
-                if (execution is not null && status is not null && graphJson is not null)
-                {
-                    await _executions
-                        .UpdateExecutionAndSnapshotAsync(
-                            uow,
-                            executionId,
-                            status,
-                            cancelRequested,
-                            graphJson,
-                            innerCt)
-                        .ConfigureAwait(false);
-                    await SyncOperationalProjectionAsync(
-                            uow,
-                            executionId,
-                            execution.TenantId,
-                            status,
-                            graphJson,
-                            nodeIdToClear: null,
-                            innerCt)
-                        .ConfigureAwait(false);
-                }
+        var (fenceLost, skippedStalePersist) = await PersistCheckpointDocumentUnderTransactionAsync(
+                new CheckpointDocumentPersistRequest(
+                    executionId,
+                    nodeId,
+                    checkpoint,
+                    json,
+                    updatedAt,
+                    status,
+                    cancelRequested,
+                    graphJson),
+                ct)
+            .ConfigureAwait(false);
 
-                if (_ownership.TryGet(executionId, out _, out var generation))
-                {
-                    var upserted = await _checkpointStore.TryUpsertRuntimeWithGenerationAsync(
-                            uow,
-                            new ExecutionCheckpointRuntimeUpsert(
-                                executionId,
-                                generation,
-                                json,
-                                checkpoint.SchemaVersion,
-                                updatedAt),
-                            innerCt)
-                        .ConfigureAwait(false);
-                    if (!upserted)
-                        return true;
-
-                    await _checkpointStore.TryClearOwnershipAsync(uow, executionId, generation, innerCt)
-                        .ConfigureAwait(false);
-                    return false;
-                }
-
-                await _checkpointStore.UpsertAsync(
-                    uow,
-                    new ExecutionCheckpointDocument
-                    {
-                        ExecutionId = executionId,
-                        CheckpointJson = json,
-                        SchemaVersion = checkpoint.SchemaVersion,
-                        UpdatedAt = updatedAt
-                    },
-                    innerCt).ConfigureAwait(false);
-
-                var existing = await _checkpointStore.GetByExecutionIdAsync(uow, executionId, innerCt)
-                    .ConfigureAwait(false);
-                if (existing?.OwnerWorkerId is not null)
-                {
-                    await _checkpointStore.TryClearOwnershipAsync(
-                            uow,
-                            executionId,
-                            existing.OwnerGeneration,
-                            innerCt)
-                        .ConfigureAwait(false);
-                }
-
-                return false;
-            },
-            ct).ConfigureAwait(false);
+        if (skippedStalePersist)
+            return;
 
         _ownership.Clear(executionId);
         _engine.Unload(engineExecutionId);
@@ -2472,6 +2975,180 @@ internal sealed class ExecutionService : IExecutionService
         }
 
         _logger.CheckpointUnloadedAfterWait(executionId, nodeId);
+    }
+
+    /// <summary>Persist ゲート内の checkpoint 文書 Upsert 入力。</summary>
+    private readonly record struct CheckpointDocumentPersistRequest(
+        Guid ExecutionId,
+        string NodeId,
+        ExecutionRuntimeCheckpoint Checkpoint,
+        string CheckpointJson,
+        DateTime UpdatedAt,
+        string? Status,
+        bool? CancelRequested,
+        string? GraphJson);
+
+    /// <summary>
+    /// Persist ゲート内トランザクション: 投影更新・checkpoint Upsert・所有クリア。
+    /// </summary>
+    /// <returns>fencing 喪失と stale skip の有無。</returns>
+    private async Task<(bool FenceLost, bool SkippedStalePersist)> PersistCheckpointDocumentUnderTransactionAsync(
+        CheckpointDocumentPersistRequest request,
+        CancellationToken ct)
+    {
+        var skippedStalePersist = false;
+        var fenceLost = await _executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                var existingCheckpoint = await _checkpointStore
+                    .GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
+                    .ConfigureAwait(false);
+                if (existingCheckpoint is not null
+                    && TryParseRuntimeCheckpoint(existingCheckpoint.CheckpointJson, out var stored, out _)
+                    && IsRuntimeCheckpointLessAdvanced(request.Checkpoint, stored))
+                {
+                    skippedStalePersist = true;
+                    _logger.SkipStaleCheckpointPersist(
+                        request.ExecutionId,
+                        request.NodeId,
+                        stored.PendingWaits.Count,
+                        request.Checkpoint.PendingWaits.Count,
+                        stored.Graph.Nodes.Count,
+                        request.Checkpoint.Graph.Nodes.Count);
+                    return false;
+                }
+
+                var execution = await _executions.GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
+                    .ConfigureAwait(false);
+                if (execution is not null && request.Status is not null && request.GraphJson is not null)
+                {
+                    await _executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            request.ExecutionId,
+                            request.Status,
+                            request.CancelRequested,
+                            request.GraphJson,
+                            innerCt)
+                        .ConfigureAwait(false);
+                    await SyncOperationalProjectionAsync(
+                            uow,
+                            request.ExecutionId,
+                            execution.TenantId,
+                            request.Status,
+                            request.GraphJson,
+                            nodeIdToClear: null,
+                            innerCt)
+                        .ConfigureAwait(false);
+                }
+
+                if (_ownership.TryGet(request.ExecutionId, out _, out var generation))
+                {
+                    var upserted = await _checkpointStore.TryUpsertRuntimeWithGenerationAsync(
+                            uow,
+                            new ExecutionCheckpointRuntimeUpsert(
+                                request.ExecutionId,
+                                generation,
+                                request.CheckpointJson,
+                                request.Checkpoint.SchemaVersion,
+                                request.UpdatedAt),
+                            innerCt)
+                        .ConfigureAwait(false);
+                    if (!upserted)
+                        return true;
+
+                    await _checkpointStore.TryClearOwnershipAsync(uow, request.ExecutionId, generation, innerCt)
+                        .ConfigureAwait(false);
+                    return false;
+                }
+
+                await _checkpointStore.UpsertAsync(
+                    uow,
+                    new ExecutionCheckpointDocument
+                    {
+                        ExecutionId = request.ExecutionId,
+                        CheckpointJson = request.CheckpointJson,
+                        SchemaVersion = request.Checkpoint.SchemaVersion,
+                        UpdatedAt = request.UpdatedAt
+                    },
+                    innerCt).ConfigureAwait(false);
+
+                var existing = await _checkpointStore.GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
+                    .ConfigureAwait(false);
+                if (existing?.OwnerWorkerId is not null)
+                {
+                    await _checkpointStore.TryClearOwnershipAsync(
+                            uow,
+                            request.ExecutionId,
+                            existing.OwnerGeneration,
+                            innerCt)
+                        .ConfigureAwait(false);
+                }
+
+                return false;
+            },
+            ct).ConfigureAwait(false);
+
+        return (fenceLost, skippedStalePersist);
+    }
+
+    /// <summary>
+    /// 永続済み断面より incoming が遅れているか（古い Fork Unload の上書き防止）。
+    /// </summary>
+    /// <remarks>単体テストから到達するため internal。</remarks>
+    internal static bool IsRuntimeCheckpointLessAdvanced(
+        ExecutionRuntimeCheckpoint incoming,
+        ExecutionRuntimeCheckpoint stored)
+    {
+        if (incoming.IsCompleted || incoming.IsCancelled || incoming.IsFailed)
+            return false;
+
+        if (incoming.Graph.Nodes.Count < stored.Graph.Nodes.Count)
+            return true;
+
+        // stored に durable Wait があり、incoming が Fork 待ち相当（active/wait 空）なら古い。
+        return stored.PendingWaits.Count > 0
+            && incoming.PendingWaits.Count == 0
+            && incoming.ActiveStates.Count == 0;
+    }
+
+    /// <summary>
+    /// Fork 展開後の Persist が、当該 Fork より先の Join / Wait 進行後に遅延したか。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Hosted では <c>NotifyForkExpansion</c> が非同期のため、子完了→Join→decide が
+    /// <c>ExpandFork</c> 完了より先に進みうる。その場合の Unload は decide Wait を失わせる。
+    /// </para>
+    /// <para>
+    /// <paramref name="nodeId"/> が Fork ノードでない呼び出し（Wait Suspend）は常に false。
+    /// </para>
+    /// <para>単体テストから到達するため internal。</para>
+    /// </remarks>
+    /// <param name="checkpoint">Export 直後の断面。</param>
+    /// <param name="nodeId">Persist 要求元のノード ID（Fork 展開時は Fork ノード）。</param>
+    /// <returns>Unload をスキップすべきなら true。</returns>
+    internal static bool IsForkExpansionUnloadObsolete(
+        ExecutionRuntimeCheckpoint checkpoint,
+        string nodeId)
+    {
+        var forkNode = checkpoint.Graph.Nodes
+            .FirstOrDefault(n =>
+                string.Equals(n.NodeId, nodeId, StringComparison.Ordinal)
+                && string.Equals(n.NodeType, "Fork", StringComparison.OrdinalIgnoreCase));
+        if (forkNode is null)
+            return false;
+
+        // Join 後の decide 実行中、または durable Wait 登録済みなら SuspendHandler に委ねる。
+        if (checkpoint.ActiveStates.Count > 0 || checkpoint.PendingWaits.Count > 0)
+            return true;
+
+        // この Fork 到達以降に Join が完了していれば、子待ち Unload の窓は閉じている。
+        return checkpoint.Graph.Nodes.Any(n =>
+            string.Equals(n.NodeType, "Join", StringComparison.OrdinalIgnoreCase)
+            && n.StartedAt >= forkNode.StartedAt
+            && (string.Equals(n.Fact, "Joined", StringComparison.OrdinalIgnoreCase)
+                || n.CompletedAt is not null));
     }
 
     public async Task UpdateProjectionFromEngineAsync(Guid executionId, CancellationToken ct)
@@ -2501,9 +3178,10 @@ internal sealed class ExecutionService : IExecutionService
                         innerCt)
                     .ConfigureAwait(false);
 
-                // durable Wait が無い／終端なら checkpoint を削除（Resume 後の残留や再 hydrate を防ぐ）。
+                // durable Wait / 物理 Join 待ちが無い／終端なら checkpoint を削除する。
                 // ただし Worker 所有中は lease / fencing 行を消さない（Heartbeat が世代不一致で落ちる）。
-                if (ShouldDiscardRuntimeCheckpoint(status, graphJson))
+                if (await ShouldDiscardRuntimeCheckpointAsync(executionId, status, graphJson, innerCt)
+                        .ConfigureAwait(false))
                 {
                     return await DiscardOrRefreshRuntimeCheckpointAsync(
                             uow,
@@ -2707,7 +3385,7 @@ internal sealed class ExecutionService : IExecutionService
         try
         {
             using var doc = JsonDocument.Parse(graphJson);
-            if (!doc.RootElement.TryGetProperty("nodes", out var nodes)
+            if (!doc.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
                 || nodes.ValueKind != JsonValueKind.Array)
             {
                 return null;
@@ -2747,13 +3425,13 @@ internal sealed class ExecutionService : IExecutionService
     private static bool TryGetActiveWaitNodeId(JsonElement node, out string? nodeId)
     {
         nodeId = null;
-        if (!node.TryGetProperty("nodeType", out var nodeType)
+        if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeType, out var nodeType)
             || !string.Equals(nodeType.GetString(), "Wait", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
 
-        if (node.TryGetProperty("completedAt", out var completedAt)
+        if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
             && completedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
         {
             return false;
@@ -2762,7 +3440,7 @@ internal sealed class ExecutionService : IExecutionService
         if (!HasConfiguredWaitEvents(node))
             return false;
 
-        if (!node.TryGetProperty("nodeId", out var nodeIdElement))
+        if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var nodeIdElement))
             return false;
 
         var value = nodeIdElement.GetString();

--- a/core/application/Statevia.Core.Application/Services/ExecutionServiceLogMessages.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionServiceLogMessages.cs
@@ -217,6 +217,40 @@ internal static partial class ExecutionServiceLogMessages
     public static partial void ExportCheckpointNullSkipUnload(this ILogger logger, string executionId, string nodeId);
 
     [LoggerMessage(
+        EventId = 3018,
+        Level = LogLevel.Warning,
+        Message = "Skip stale checkpoint persist that would overwrite newer Wait state. ExecutionId={executionId} NodeId={nodeId} StoredPendingWaits={storedPendingWaits} IncomingPendingWaits={incomingPendingWaits} StoredNodes={storedNodes} IncomingNodes={incomingNodes}")]
+    public static partial void SkipStaleCheckpointPersist(
+        this ILogger logger,
+        Guid executionId,
+        string nodeId,
+        int storedPendingWaits,
+        int incomingPendingWaits,
+        int storedNodes,
+        int incomingNodes);
+
+    [LoggerMessage(
+        EventId = 3019,
+        Level = LogLevel.Information,
+        Message = "Skip delayed Fork expansion unload; execution already progressed past Fork wait. ExecutionId={executionId} ForkNodeId={forkNodeId} ActiveStates={activeStates} PendingWaits={pendingWaits}")]
+    public static partial void SkipForkExpansionUnloadAlreadyProgressed(
+        this ILogger logger,
+        Guid executionId,
+        string forkNodeId,
+        int activeStates,
+        int pendingWaits);
+
+    [LoggerMessage(
+        EventId = 3020,
+        Level = LogLevel.Information,
+        Message = "Synced graph snapshot from runtime checkpoint after Join unload. ExecutionId={executionId} PendingWaits={pendingWaits} CheckpointNodes={checkpointNodes}")]
+    public static partial void SyncedGraphSnapshotFromRuntimeCheckpoint(
+        this ILogger logger,
+        Guid executionId,
+        int pendingWaits,
+        int checkpointNodes);
+
+    [LoggerMessage(
         EventId = 3015,
         Level = LogLevel.Warning,
         Message = "Unload after Wait because ownership fencing was lost. NodeId={nodeId} ExecutionId={executionId}")]

--- a/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkChildExecutionCoordinator.cs
@@ -236,6 +236,20 @@ public sealed class ForkChildExecutionCoordinator(
     }
 
     /// <inheritdoc />
+    public async Task<bool> HasPendingPhysicalJoinBranchesAsync(
+        Guid parentExecutionId,
+        CancellationToken ct)
+    {
+        var rows = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => branches.ListByParentExecutionIdAsync(uow, parentExecutionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+
+        return rows.Any(r =>
+            string.Equals(r.Status, ExecutionBranchStatuses.Running, StringComparison.Ordinal));
+    }
+
+    /// <inheritdoc />
     public async Task CascadeCancelToRunningChildrenAsync(Guid parentExecutionId, CancellationToken ct)
     {
         await executor.ExecuteReadCommittedAsync(

--- a/core/application/Statevia.Core.Application/Services/ForkExpansionLogMessages.cs
+++ b/core/application/Statevia.Core.Application/Services/ForkExpansionLogMessages.cs
@@ -80,4 +80,42 @@ internal static partial class ForkExpansionLogMessages
         Guid parentExecutionId,
         string forkNodeId,
         string failureStatus);
+
+    [LoggerMessage(
+        EventId = 3109,
+        Level = LogLevel.Warning,
+        Message = "Runtime checkpoint is empty or invalid for Join hydrate. ParentExecutionId={parentExecutionId} CheckpointLength={checkpointLength}")]
+    public static partial void RuntimeCheckpointInvalidForHydrate(
+        this ILogger logger,
+        Guid parentExecutionId,
+        int checkpointLength);
+
+    [LoggerMessage(
+        EventId = 3110,
+        Level = LogLevel.Warning,
+        Message = "Runtime checkpoint deserialize failed for Join hydrate. ParentExecutionId={parentExecutionId}")]
+    public static partial void RuntimeCheckpointDeserializeFailed(
+        this ILogger logger,
+        Exception exception,
+        Guid parentExecutionId);
+
+    [LoggerMessage(
+        EventId = 3111,
+        Level = LogLevel.Information,
+        Message = "Fork join already completed; skipping re-entry. ParentExecutionId={parentExecutionId} ForkNodeId={forkNodeId} JoinState={joinState}")]
+    public static partial void ForkJoinAlreadyCompleted(
+        this ILogger logger,
+        Guid parentExecutionId,
+        string forkNodeId,
+        string joinState);
+
+    [LoggerMessage(
+        EventId = 3112,
+        Level = LogLevel.Information,
+        Message = "Fork join projection skipped after Wait unload. ParentExecutionId={parentExecutionId} ForkNodeId={forkNodeId} JoinState={joinState}")]
+    public static partial void ForkJoinProjectionSkippedAfterUnload(
+        this ILogger logger,
+        Guid parentExecutionId,
+        string forkNodeId,
+        string joinState);
 }

--- a/core/application/Statevia.Core.Application/Services/PhysicalForkGraphComposer.cs
+++ b/core/application/Statevia.Core.Application/Services/PhysicalForkGraphComposer.cs
@@ -13,14 +13,16 @@ namespace Statevia.Core.Application.Services;
 /// <para>永続スナップショットは変更しない。読み取り専用の合成 JSON を返す。</para>
 /// <para>子ノードの <c>workerId</c> / <c>attempt</c> はそのまま引き継ぐ。</para>
 /// <para>
-/// Join 辺は状態名ではなく <c>joinNodeId</c>（親上の Join 到達インスタンス）に固定する。
-/// 循環で同名 Join が複数あるとき、Fork 訪問との対応は
-/// <see cref="ResolveJoinNodeId"/> が親グラフ上で解決する。
+/// <c>forkNodeId</c> は Hosted 物理 Fork の並列エピソード相関キー（親グラフの Fork 到達
+/// <c>nodeId</c>）。定義状態名でも Join <c>nodeId</c> でもない。Join 辺は状態名ではなく
+/// <c>joinNodeId</c>（親上の Join 到達インスタンス）に固定し、循環で同名 Join が複数あるとき
+/// Fork 訪問との対応は <see cref="ResolveJoinNodeId"/> が親グラフ上で解決する。
 /// </para>
 /// <para>
 /// 定義上の枝以外の見た目の合流を避けるため、親 Fork からの Fork 辺は
 /// <c>branchState</c> ノードへだけ張り、親 Join への Join 辺も枝先頭状態の終端に限る。
 /// ネスト内側 Join など枝先頭以外から親 Join への接続は <see cref="EdgeType.Next"/> とする。
+/// 枝先頭が Fork 型の terminal になった場合も親 Join へは繋がない（幽霊枝防止）。
 /// </para>
 /// </remarks>
 internal static class PhysicalForkGraphComposer
@@ -79,13 +81,14 @@ internal static class PhysicalForkGraphComposer
     /// </summary>
     /// <remarks>
     /// <para>
+    /// <paramref name="forkNodeId"/> は並列エピソードの相関キー（親グラフの Fork 到達 <c>nodeId</c>）。
     /// 循環で同名 <paramref name="joinState"/> が複数あるとき、
     /// Fork の <c>completedAt</c>（なければ <c>startedAt</c>）以降で最も早い Join を選ぶ。
     /// 時刻が欠ける場合は、同名 Fork 訪問の出現順と Join 訪問の出現順をインデックス対応する。
     /// </para>
     /// </remarks>
     /// <param name="parentGraphJson">親の永続 graph JSON。</param>
-    /// <param name="forkNodeId">親上の Fork 到達ノード ID。</param>
+    /// <param name="forkNodeId">並列エピソードの相関キー（親上の Fork 到達 <c>nodeId</c>）。</param>
     /// <param name="joinState">定義上の Join 状態名。</param>
     /// <returns>対応する Join の <c>nodeId</c>。未解決なら <see langword="null"/>。</returns>
     public static string? ResolveJoinNodeId(
@@ -201,6 +204,15 @@ internal static class PhysicalForkGraphComposer
         {
             if (!nodeById.TryGetValue(terminalId, out var terminalNode))
                 continue;
+
+            // ネスト枝先頭の Fork 自体を親 Join へ繋がない（Join.all 依存の見た目の幽霊枝）。
+            if (string.Equals(
+                    ReadString(terminalNode, NodeTypeProperty),
+                    "Fork",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
 
             var terminalState = ReadString(terminalNode, NodeNameProperty);
             // 枝先頭状態の終端だけ Join 辺。ネスト内側 Join などは Next（定義の next に相当）。

--- a/core/application/Statevia.Core.Application/Services/RuntimeCheckpointLifetimePolicy.cs
+++ b/core/application/Statevia.Core.Application/Services/RuntimeCheckpointLifetimePolicy.cs
@@ -1,0 +1,45 @@
+using Statevia.Core.Application.Contracts.Persistence;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// runtime checkpoint 内容の寿命表（破棄候補判定）。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 保持理由は <see cref="RuntimeCheckpointRetainReasons"/> のみ
+///（<see cref="RuntimeCheckpointRetainReasons.PendingWaits"/> /
+/// <see cref="RuntimeCheckpointRetainReasons.PendingPhysicalJoin"/>）。
+/// </para>
+/// <para>
+/// Worker 所有 lease は同列にしない。所有中は内容破棄候補でも行 Delete せず
+/// runtime JSON の refresh に倒す（呼び出し側）。
+/// </para>
+/// <para>契約の文章正本は <c>docs/concepts/durability.md</c> および
+/// <c>docs/specifications/execution/fork-join.md</c>。</para>
+/// </remarks>
+internal static class RuntimeCheckpointLifetimePolicy
+{
+    /// <summary>
+    /// 寿命表に従い、checkpoint <b>内容</b>を破棄してよいか。
+    /// </summary>
+    /// <param name="projectionStatus">投影 status（<see cref="ExecutionProjectionStatuses"/>）。</param>
+    /// <param name="retainReasons">内容保持理由。終端では無視する。</param>
+    /// <returns>
+    /// 終端、または Running かつ保持理由が空のとき <see langword="true"/>。
+    /// </returns>
+    public static bool IsContentDiscardCandidate(
+        string projectionStatus,
+        RuntimeCheckpointRetainReasons retainReasons)
+    {
+        if (!string.Equals(
+                projectionStatus,
+                ExecutionProjectionStatuses.Running,
+                StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return retainReasons == RuntimeCheckpointRetainReasons.None;
+    }
+}

--- a/core/application/Statevia.Core.Application/Services/RuntimeCheckpointRetainReasons.cs
+++ b/core/application/Statevia.Core.Application/Services/RuntimeCheckpointRetainReasons.cs
@@ -1,0 +1,27 @@
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// runtime checkpoint <b>内容</b>を保持する理由（寿命表）。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 破棄判定の正本は <see cref="RuntimeCheckpointLifetimePolicy"/>。
+/// 理由が空で Running のときだけ内容破棄候補になる。
+/// </para>
+/// <para>
+/// Worker 所有 lease（in-process ownership / DB owner 列）は本列挙に含めない。
+/// 所有中の Delete 抑止は <c>DiscardOrRefreshRuntimeCheckpointAsync</c> 側の別関心である。
+/// </para>
+/// </remarks>
+[Flags]
+internal enum RuntimeCheckpointRetainReasons
+{
+    /// <summary>保持理由なし（Running なら内容破棄候補）。</summary>
+    None = 0,
+
+    /// <summary>グラフ上に Engine durable Wait がある。</summary>
+    PendingWaits = 1 << 0,
+
+    /// <summary>親に未終端の物理分岐（<c>execution_branches.status=Running</c>）がある。</summary>
+    PendingPhysicalJoin = 1 << 1,
+}

--- a/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Engine/ForkExpansionHandlerTests.cs
@@ -2,6 +2,7 @@ using Statevia.Core.Engine.Abstractions;
 using Statevia.Core.Engine.Definition;
 using Statevia.Core.Engine.Engine;
 using Statevia.Core.Engine.Execution;
+using Statevia.Core.Engine.Join;
 using Xunit;
 
 namespace Statevia.Core.Engine.Tests.Engine;
@@ -27,6 +28,106 @@ public sealed class ForkExpansionHandlerTests
         Assert.NotNull(snapshot);
         Assert.True(snapshot.IsCompleted);
         Assert.False(snapshot.IsFailed);
+    }
+
+    /// <summary>
+    /// checkpoint に前回の startedJoins が残っていても CompletePhysicalJoin で再入場できる。
+    /// </summary>
+    [Fact]
+    public async Task CompletePhysicalJoin_WhenStartedJoinsAlreadySet_ReentersAndCompletes()
+    {
+        // Arrange
+        var def = CreateForkDefinition();
+        var engine = ExecutionEngineTestHarness.Create(maxParallelism: 2);
+        var forked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        engine.SetForkExpansionHandler(_ =>
+        {
+            forked.TrySetResult(true);
+            return Task.CompletedTask;
+        });
+
+        var parentId = engine.Start(def);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await forked.Task.WaitAsync(timeout.Token).ConfigureAwait(false);
+        await Task.Delay(50).ConfigureAwait(false);
+
+        var exported = engine.ExportCheckpoint(parentId)
+            ?? throw new InvalidOperationException("checkpoint missing");
+        engine.Unload(parentId);
+
+        // 循環 1 周目相当: Join 開始済みマークが残った断面を hydrate する。
+        var checkpoint = new ExecutionRuntimeCheckpoint
+        {
+            SchemaVersion = exported.SchemaVersion,
+            ExecutionId = exported.ExecutionId,
+            DefinitionName = exported.DefinitionName,
+            IsCompleted = exported.IsCompleted,
+            IsCancelled = exported.IsCancelled,
+            IsFailed = exported.IsFailed,
+            ActiveStates = exported.ActiveStates,
+            StateAttempts = exported.StateAttempts,
+            StateOutputs = exported.StateOutputs,
+            AppliedPublishClientEventIds = exported.AppliedPublishClientEventIds,
+            AppliedCancelClientEventIds = exported.AppliedCancelClientEventIds,
+            Context = exported.Context,
+            Graph = exported.Graph,
+            PendingWaits = exported.PendingWaits,
+            Join = new CheckpointJoinData
+            {
+                StartedJoins = ["Join1"],
+                JoinSourceNodeIds = exported.Join.JoinSourceNodeIds,
+                JoinStateResults = new Dictionary<string, IReadOnlyDictionary<string, CheckpointJoinObserved>>(
+                    StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Join1"] = new Dictionary<string, CheckpointJoinObserved>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["A"] = new CheckpointJoinObserved { Fact = "Completed", Output = null },
+                        ["B"] = new CheckpointJoinObserved { Fact = "Completed", Output = null }
+                    }
+                }
+            }
+        };
+        engine.ImportCheckpoint(def, checkpoint);
+
+        // Act
+        engine.CompletePhysicalJoin(
+            parentId,
+            "Join1",
+            new Dictionary<string, object?>
+            {
+                ["A"] = "round-2-a",
+                ["B"] = "round-2-b"
+            });
+        await Task.Delay(300).ConfigureAwait(false);
+        var snapshot = engine.GetSnapshot(parentId);
+
+        // Assert
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot.IsCompleted);
+        Assert.False(snapshot.IsFailed);
+    }
+
+    /// <summary>ResetForPhysicalJoinReentry 後は同一 Join を再度 Begin できる。</summary>
+    [Fact]
+    public void JoinTracker_ResetForPhysicalJoinReentry_AllowsSecondBegin()
+    {
+        // Arrange
+        var tracker = new JoinTracker(CreateForkDefinition());
+        Assert.Null(tracker.RecordFact("A", "Completed", "a1"));
+        Assert.Equal("Join1", tracker.RecordFact("B", "Completed", "b1"));
+        Assert.True(tracker.TryBeginJoinExecution("Join1"));
+        Assert.False(tracker.TryBeginJoinExecution("Join1"));
+
+        // Act
+        tracker.ResetForPhysicalJoinReentry("Join1");
+        Assert.Null(tracker.RecordFact("A", "Completed", "a2"));
+        Assert.Equal("Join1", tracker.RecordFact("B", "Completed", "b2"));
+
+        // Assert
+        Assert.True(tracker.TryBeginJoinExecution("Join1"));
+        var inputs = tracker.GetJoinInputs("Join1");
+        Assert.Equal("a2", inputs["A"]);
+        Assert.Equal("b2", inputs["B"]);
     }
 
     /// <summary>CompletePhysicalJoin は候補 input で Join を充足し親を進める。</summary>

--- a/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
+++ b/core/engine/Statevia.Core.Engine/Engine/ExecutionEngine.cs
@@ -828,6 +828,9 @@ public sealed partial class ExecutionEngine : IExecutionEngine, IDisposable
             }
         }
 
+        // 循環再入場: 前回訪問の startedJoins / 観測事実を捨ててから物理 Join を再実行する。
+        instance.JoinTracker.ResetForPhysicalJoinReentry(joinStateName);
+
         foreach (var (branchState, branchOutput) in branchOutputs)
         {
             instance.JoinTracker.RecordFact(branchState, Fact.Completed, branchOutput);

--- a/core/engine/Statevia.Core.Engine/Join/IJoinTracker.cs
+++ b/core/engine/Statevia.Core.Engine/Join/IJoinTracker.cs
@@ -21,4 +21,15 @@ public interface IJoinTracker
     /// <param name="joinStateName">Join 状態名。</param>
     /// <returns>実行可能なら <see langword="true"/>。</returns>
     bool IsJoinReadyToExecute(string joinStateName);
+
+    /// <summary>
+    /// Hosted 物理 Join の再入場用に、当該 Join の開始マークと観測事実をクリアする。
+    /// </summary>
+    /// <remarks>
+    /// 循環で同一 Join 状態名へ戻るとき、前回訪問の <c>startedJoins</c> が残ると
+    /// <see cref="TryBeginJoinExecution"/> が永続的に false になるため、
+    /// <c>CompletePhysicalJoin</c> 直前に呼ぶ。
+    /// </remarks>
+    /// <param name="joinStateName">クリアする Join 状態名。</param>
+    void ResetForPhysicalJoinReentry(string joinStateName);
 }

--- a/core/engine/Statevia.Core.Engine/Join/JoinTracker.cs
+++ b/core/engine/Statevia.Core.Engine/Join/JoinTracker.cs
@@ -133,6 +133,18 @@ public sealed class JoinTracker : IJoinTracker
         }
     }
 
+    /// <inheritdoc />
+    public void ResetForPhysicalJoinReentry(string joinStateName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(joinStateName);
+        lock (_lock)
+        {
+            _startedJoins.Remove(joinStateName);
+            _joinStateResults.Remove(joinStateName);
+            _joinSourceNodeIds.Remove(joinStateName);
+        }
+    }
+
     /// <summary>
     /// Join の依存事実が揃い、まだ開始されていないときに実行可能か（開始マークはしない）。
     /// </summary>

--- a/docs/concepts/durability.md
+++ b/docs/concepts/durability.md
@@ -3,8 +3,8 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Concept |
-| Version | 1.4 |
-| 更新日 | 2026-08-09 |
+| Version | 1.5 |
+| 更新日 | 2026-08-10 |
 | 関連 | [../specifications/data-integration.md](../specifications/data-integration.md), [../specifications/execution/fork-join.md](../specifications/execution/fork-join.md) |
 
 ---
@@ -38,13 +38,29 @@ in-process の `GetSnapshot` はデバッグやコールバック経路向けで
 
 実行中の所有正本は `execution_runtime_checkpoints` の `owner_worker_id` / `lease_until` / `owner_generation` です。`lease_until` は recovery 検討のトリガに過ぎず、排他は **`owner_generation` 一致更新（fencing）** で担保します。ハートビートまたは世代付き更新が失敗した Worker はローカル実行を即停止します。`ExecutionOwnershipRecoveryHostedService` は期限切れ所有を世代 +1 したうえで `Resume mode=recovery` を enqueue します（Wait イベントは消費しない）。DelayWait 期限は `DelayWaitSchedulerHostedService` が `FOR UPDATE SKIP LOCKED` で wait を排他 claim し、同一トランザクションで wait 削除と `Resume mode=event` を投入します。これらの HostedService は既定では Service API 内で動きますが、`Statevia:Runtime` で無効化し `service/runtime` の Scheduler / Worker へ分離できます。
 
-ステップ完了ごとに checkpoint を更新し、Unload は durable Wait 到達または終端に限定します。recovery で Action が再実行されうる場合、Action 側の冪等（または適用済み検知）を前提とします。
+ステップ完了ごとに checkpoint を更新し、Unload は durable Wait 到達・物理 Join 待ち解消後の不要時・または終端に限定します。recovery で Action が再実行されうる場合、Action 側の冪等（または適用済み検知）を前提とします。
+
+## runtime checkpoint 寿命表
+
+内容の保持理由は次の 2 つのみ（Application: `RuntimeCheckpointRetainReasons`）。
+
+| 保持理由 | 意味 |
+| --- | --- |
+| `PendingWaits` | グラフ上に Engine durable Wait がある |
+| `PendingPhysicalJoin` | 親に未終端の物理分岐（`execution_branches.status=Running`）がある |
+
+- **内容破棄候補**: 投影が終端、または Running かつ上記理由が空。
+- **OwnedLease（Worker 所有）は同列にしない**。内容破棄候補でも所有中は行を Delete せず runtime JSON のみ refresh する（lease / fencing 都合）。
+
+Hosted Fork の詳細は [fork-join.md](../specifications/execution/fork-join.md)。
 
 ## Hosted Fork と耐久
 
 - Fork 展開・子 Start・親子リンクは `execution_branches` と work item で耐久化する。展開一時失敗はリトライし、上限後に親 Failed。
 - 子終端は親向け予約 Resume（`statevia.event.child.completed`）で起こし、Join を再評価する。
-- ネスト Fork も同一経路で再帰分割する。循環再入時の Join hydrate など残課題は実装フォローアップの対象。
+- ネスト Fork も同一経路で再帰分割する。
+- 親の runtime checkpoint は上記寿命表に従う。`BeginOwnedSession` の seed `{}` は lease 用であり hydrate 正本にしない。
+- 合成読みモデルの辺規則（枝先頭のみ Fork、内側 Join→外側は Next）は [fork-join.md](../specifications/execution/fork-join.md) を正とする。
 
 ## 次に読むもの
 

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -3,6 +3,8 @@
 Version: 1.17
 Project: 実行型ステートマシン
 
+**Version 1.18（2026-08-10）**: `execution_branches.fork_node_id` の役割を明確化（並列エピソードの相関キー。定義名／Join `nodeId` ではない）。
+
 **Version 1.17（2026-08-07）**: `execution_branches` に `states_json` / `vars_json` を追加（Join 後の親 Context マージ用）。
 
 **Version 1.16（2026-08-06）**: `execution_branches` 追加（Hosted Fork 物理子の親子リンク正本。`fork_node_id` は実行ノード ID、`join_state` / `branch_state` は定義の状態名空間）。
@@ -306,7 +308,7 @@ Hosted Runtime が Fork を物理子 execution に展開したときの親子リ
 | カラム | 型 | 制約 | 説明 |
 | --- | --- | --- | --- |
 | parent_execution_id | uuid | PK, FK → executions, NOT NULL | 親（ネスト時は親役）execution |
-| fork_node_id | varchar(64) | PK, NOT NULL | 親実行グラフ上の Fork 到達インスタンス（実行ノード ID） |
+| fork_node_id | varchar(64) | PK, NOT NULL | 当該並列エピソードの相関キー（親グラフ上の Fork 到達 `nodeId`。定義名／Join `nodeId` ではない） |
 | branch_state | varchar(256) | PK, NOT NULL | 分岐先頭状態名 |
 | execution_id | uuid | UNIQUE, FK → executions, NOT NULL | 子 execution |
 | join_state | varchar(256) | NOT NULL | Join 状態名 |

--- a/docs/samples/ui-nested-fork.yaml
+++ b/docs/samples/ui-nested-fork.yaml
@@ -1,11 +1,12 @@
 # =============================================================================
-# 公式サンプル: ネスト Fork / Join（nodes 形式・version: 1）
+# 公式サンプル: 3 重ネスト Fork / Join（nodes 形式・version: 1）
 # -----------------------------------------------------------------------------
 # 配置: docs/samples/ui-nested-fork.yaml
 #
-# 外側 Fork の一方の枝先頭が内側 Fork。内側 Join の next が外側 Join。
+# 外側 → 中間 → 最内の 3 段。各段は「即時枝 + 一段深い Fork」で分岐し、
+# 最内だけ並列タスク 2 本。各 Join の next は一段外側の Join（最外は notify）。
 # nodes 変換は「枝が Join を供給する」（直接 next、またはネスト Fork→内側 Join→外口）
-# で外側 Join と照合する。
+# で各 Join と照合する。
 #
 # 起動 input 例: {}
 # CLI の Statevia.Service.Cli は states 形式のみ。本ファイルは Service API 経由で検証してください。
@@ -17,8 +18,9 @@ workflow:
   id: sample.nested.fork
   name: NestedForkSample
   description: >
-    外側並列（即時枝 + 内側並列）→ 内側合流 → 外側合流 → 完了。
-    Hosted では外側・内側とも物理子 execution に展開される。
+    3 重ネスト並列。外側（即時 + 中間 Fork）→ 中間（即時 + 最内 Fork）→
+    最内（A/B）→ 各段の合流 → 完了。
+    Hosted では各 Fork が物理子 execution に再帰展開される。
 
 nodes:
   - name: nest.start
@@ -26,12 +28,13 @@ nodes:
     label: 開始
     next: nest.outer.fork
 
+  # --- L1 外側 ---
   - name: nest.outer.fork
     type: fork
     label: 外側並列
     branches:
       - nest.outer.fast
-      - nest.inner.fork
+      - nest.mid.fork
 
   - name: nest.outer.fast
     type: action
@@ -39,16 +42,31 @@ nodes:
     action: noop
     next: nest.outer.join
 
+  # --- L2 中間 ---
+  - name: nest.mid.fork
+    type: fork
+    label: 中間並列
+    branches:
+      - nest.mid.fast
+      - nest.inner.fork
+
+  - name: nest.mid.fast
+    type: action
+    label: 中間・即時処理
+    action: noop
+    next: nest.mid.join
+
+  # --- L3 最内 ---
   - name: nest.inner.fork
     type: fork
-    label: 内側並列
+    label: 最内並列
     branches:
       - nest.inner.a
       - nest.inner.b
 
   - name: nest.inner.a
     type: action
-    label: 内側 A
+    label: 最内 A
     action: sleep
     input:
       duration: 1s
@@ -56,7 +74,7 @@ nodes:
 
   - name: nest.inner.b
     type: action
-    label: 内側 B
+    label: 最内 B
     action: sleep
     input:
       duration: 2s
@@ -64,7 +82,13 @@ nodes:
 
   - name: nest.inner.join
     type: join
-    label: 内側合流
+    label: 最内合流
+    mode: all
+    next: nest.mid.join
+
+  - name: nest.mid.join
+    type: join
+    label: 中間合流
     mode: all
     next: nest.outer.join
 

--- a/docs/specifications/execution/fork-join.md
+++ b/docs/specifications/execution/fork-join.md
@@ -3,8 +3,8 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Specification |
-| Version | 1.1 |
-| 更新日 | 2026-08-09 |
+| Version | 1.3 |
+| 更新日 | 2026-08-10 |
 | 関連 | [fsm.md](fsm.md), [../definition.md](../definition.md), [wait-cancel.md](wait-cancel.md), [execution-graph.md](execution-graph.md), [../../concepts/durability.md](../../concepts/durability.md), [../../reference/database-schema.md](../../reference/database-schema.md) |
 
 ---
@@ -36,11 +36,34 @@ Hosted（Service API / Runtime Worker）では、親が Fork に到達すると 
 3. 各子へ `Start` work item を enqueue する（`InitialState` = 分岐先頭、input は定義の写像）。
 4. 親は分岐本体を自インスタンスでは走らず、Join 待ちに入る（Unload 可）。
 
-識別の軸:
+#### 識別子: `forkNodeId`（DB: `fork_node_id`）
+
+Hosted 物理 Fork では、**1 回の Fork 到達（並列エピソード）**を相関する正本キーが `forkNodeId` である。第三の宇宙を増やさず、親実行グラフに既に存在する **Fork 到達ノードの `nodeId`** をそのまま使う。
+
+| 識別子 | 何を指すか | 循環での性質 |
+| --- | --- | --- |
+| 定義の状態名（`nodeName` / `join_state` / `branch_state`） | DSL 上の Fork / Join / 枝先頭の種類 | 周回しても同じ |
+| 実行 `nodeId`（一般） | 親グラフ上の 1 訪問実体（Fork・Wait・Action 等） | 到達のたびに新規 |
+| **`forkNodeId`** | **当該並列エピソードの相関キー**＝その訪問の Fork の `nodeId` | 周回ごとに別値。枝行・Join 再評価・合成の単位 |
+| Join の実行 `nodeId` | Join がグラフに載ったあとの訪問実体 | Fork 展開時点では未作成になりうる |
+
+**役割（MUST）**
+
+- **割り当て時点**: 親 Engine が Fork ノードを実行グラフへ追加したとき。値は親グラフの Fork `nodeId`。
+- **永続**: `execution_branches` の主キー構成要素 `(parent_execution_id, fork_node_id, branch_state)`。同一親・同一 Fork 訪問の兄弟枝を束ねる。
+- **Join 集約**: 子完了 Resume（`statevia.event.child.completed`）は payload の `forkNodeId` で枝集合を引き、充足・失敗伝播・冪等判定の単位とする。
+- **未到達 Join**: Join の `nodeId` はまだ無くてよい。相関は常に `forkNodeId` 側が持つ。Join 実行後にグラフ上の Join `nodeId` へ写像する（合成・冪等投影用）。
+
+**役割に含めないもの**
+
+- 定義上の Fork / Join 状態名の代替ではない（種類の識別は `join_state` / 定義名）。
+- 子 execution の ID ではない（子は `execution_id`）。
+- Join 未到達時の「未来の Join `nodeId`」の先貸しではない。
+
+枝行のその他列:
 
 | 列 | 意味 |
 | --- | --- |
-| `fork_node_id` | 親実行グラフ上の Fork **到達**インスタンス（実行ノード ID）。循環再到達の区別に使う |
 | `join_state` / `branch_state` | 定義の状態名空間（Join 解決・子開始状態） |
 | `execution_id` | 子 execution |
 | `status` | 分岐完了事実の要約（Running / Completed / Failed / Cancelled） |
@@ -69,6 +92,16 @@ Join は複数の状態からの事実を待ってから次に進みます。
 - 子が終端すると、親向け `Resume`（`mode=event`）に予約イベント名 **`statevia.event.child.completed`** を載せて enqueue する。
 - Worker は当該予約イベントを Engine の通常 Wait Resume ではなく **Join 再評価**へ振る。
 - 全必須分岐が Completed → Join 充足。いずれかが Failed / Cancelled → 親へ失敗／キャンセル伝播。
+- 物理 Join 待ち中の親は Engine の durable Wait を持たないため、runtime checkpoint の内容保持は寿命表の **`PendingPhysicalJoin`**（未終端 `execution_branches`）による。`PendingWaits` とあわせた内容寿命の正本は [durability.md](../../concepts/durability.md)。Worker 所有 lease は保持理由と同列にしない。
+- hydrate 入力として欠落・`{}`・必須プロパティ欠落は不正とし、構造化ログのうえ一時失敗とする（lease 用 seed `{}` を Import しない）。
+- 循環で同一 Join 状態名へ戻るとき、`CompletePhysicalJoin` は前回訪問の `startedJoins` / 観測事実をクリアしてから再実行する（残ると Join が無動作のまま Unload され停滞する）。
+- Join 直後の Unload で in-process 投影が欠落しても、checkpoint に Wait / 終端が進んでいれば冪等完了。進んでいなければ一時失敗して `child.completed` を再処理する。
+- `CompletePhysicalJoin` 後は `ActiveStates==0` ですぐ投影しない。durable Wait 登録または Suspend Unload まで待ち、decide Wait 無しの古い graph snapshot を残さない。
+- `child.completed` 再送の冪等は、当該 Fork 訪問に対応する Join ノードが既に `fact=Joined`（または `completedAt`）なら Join 再実行しない。投影の `status` だけ見ると取りこぼし、同一訪問の Join が多重実行されて `pendingWaits` が積み上がる。
+- Resume（Again → Fork）後に Suspend Unload した場合、in-process 投影が欠けても SuspendHandler が書いた DB 断面を使い 500 にしない。
+- 同一実行の checkpoint Persist/Unload は直列化する。加えて、永続済みに `pendingWaits` があるのに空の Fork 待ち断面で上書きしようとした Persist は拒否する（遅延 Fork Unload が decide Wait を消す競合の防止）。
+- Fork 展開通知は非同期のため、`ExpandFork` 完了後の Persist が Join→decide より遅れることがある。その時点で Engine に `activeStates` / `pendingWaits` がある、または当該 Fork 以降の Join が既に `Joined` なら **Unload しない**（Wait Suspend 側の Persist に委ね、初回 Wait 断面の消失を防ぐ）。
+- 定義グラフ（Studio）の Join 辺は `joinTable` 依存のうち **Fork 状態を除外**する。ネストでは OuterJoin の Join.all が InnerFork を含むが、描画経路は InnerJoin→OuterJoin（transitions）とし、InnerFork→OuterJoin の幽霊辺を作らない。
 
 ### Context マージと兄弟参照
 

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceCheckpointGuardTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceCheckpointGuardTests.cs
@@ -1,0 +1,310 @@
+using System.Text.Json;
+using Statevia.Core.Application.Services;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>ExecutionService の checkpoint / Join ガード静的ヘルパー。</summary>
+public sealed class ExecutionServiceCheckpointGuardTests
+{
+    /// <summary>終端 incoming は遅れ判定しない。</summary>
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public void IsRuntimeCheckpointLessAdvanced_WhenIncomingTerminal_ReturnsFalse(
+        bool completed,
+        bool cancelled,
+        bool failed)
+    {
+        // Arrange
+        var incoming = CreateCheckpoint(
+            isCompleted: completed,
+            isCancelled: cancelled,
+            isFailed: failed,
+            nodeCount: 1);
+        var stored = CreateCheckpoint(nodeCount: 3);
+
+        // Act
+        var lessAdvanced = ExecutionService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
+
+        // Assert
+        Assert.False(lessAdvanced);
+    }
+
+    /// <summary>ノード数が少ない incoming は遅れている。</summary>
+    [Fact]
+    public void IsRuntimeCheckpointLessAdvanced_WhenFewerNodes_ReturnsTrue()
+    {
+        // Arrange
+        var incoming = CreateCheckpoint(nodeCount: 1);
+        var stored = CreateCheckpoint(nodeCount: 3);
+
+        // Act
+        var lessAdvanced = ExecutionService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
+
+        // Assert
+        Assert.True(lessAdvanced);
+    }
+
+    /// <summary>stored に Wait があり incoming が空なら遅れている。</summary>
+    [Fact]
+    public void IsRuntimeCheckpointLessAdvanced_WhenStoredHasWaitAndIncomingIdle_ReturnsTrue()
+    {
+        // Arrange
+        var incoming = CreateCheckpoint(nodeCount: 2);
+        var stored = CreateCheckpoint(
+            nodeCount: 2,
+            pendingWaits:
+            [
+                new CheckpointPendingWait
+                {
+                    NodeId = "w1",
+                    NodeName = "Wait1",
+                    AllowedEvents = ["go"]
+                }
+            ]);
+
+        // Act
+        var lessAdvanced = ExecutionService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
+
+        // Assert
+        Assert.True(lessAdvanced);
+    }
+
+    /// <summary>Wait ノード向け Persist は Unload 廃止判定しない。</summary>
+    [Fact]
+    public void IsForkExpansionUnloadObsolete_WhenNotForkNode_ReturnsFalse()
+    {
+        // Arrange
+        var checkpoint = CreateCheckpoint(
+            nodes:
+            [
+                new CheckpointGraphNode
+                {
+                    NodeId = "wait1",
+                    NodeName = "Wait1",
+                    NodeType = "Wait",
+                    StartedAt = DateTime.UtcNow
+                }
+            ],
+            activeStates: ["Decide1"]);
+
+        // Act
+        var obsolete = ExecutionService.IsForkExpansionUnloadObsolete(checkpoint, "wait1");
+
+        // Assert
+        Assert.False(obsolete);
+    }
+
+    /// <summary>Fork 後に Active / Wait があれば Unload は廃止。</summary>
+    [Fact]
+    public void IsForkExpansionUnloadObsolete_WhenActiveAfterFork_ReturnsTrue()
+    {
+        // Arrange
+        var started = DateTime.UtcNow;
+        var checkpoint = CreateCheckpoint(
+            nodes:
+            [
+                new CheckpointGraphNode
+                {
+                    NodeId = "fork1",
+                    NodeName = "Fork1",
+                    NodeType = "Fork",
+                    StartedAt = started
+                }
+            ],
+            activeStates: ["Decide1"]);
+
+        // Act
+        var obsolete = ExecutionService.IsForkExpansionUnloadObsolete(checkpoint, "fork1");
+
+        // Assert
+        Assert.True(obsolete);
+    }
+
+    /// <summary>Fork 以降に Join 完了があれば Unload は廃止。</summary>
+    [Fact]
+    public void IsForkExpansionUnloadObsolete_WhenJoinCompletedAfterFork_ReturnsTrue()
+    {
+        // Arrange
+        var forkStarted = DateTime.UtcNow;
+        var checkpoint = CreateCheckpoint(
+            nodes:
+            [
+                new CheckpointGraphNode
+                {
+                    NodeId = "fork1",
+                    NodeName = "Fork1",
+                    NodeType = "Fork",
+                    StartedAt = forkStarted
+                },
+                new CheckpointGraphNode
+                {
+                    NodeId = "join1",
+                    NodeName = "Join1",
+                    NodeType = "Join",
+                    StartedAt = forkStarted.AddMilliseconds(1),
+                    CompletedAt = forkStarted.AddMilliseconds(2),
+                    Fact = "Joined"
+                }
+            ]);
+
+        // Act
+        var obsolete = ExecutionService.IsForkExpansionUnloadObsolete(checkpoint, "fork1");
+
+        // Assert
+        Assert.True(obsolete);
+    }
+
+    /// <summary>Join fact=Joined なら既完了。</summary>
+    [Fact]
+    public void IsPhysicalJoinAlreadyCompleted_WhenFactJoined_ReturnsTrue()
+    {
+        // Arrange
+        const string graphJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork1","nodeName":"Fork1","nodeType":"Fork"},
+                {"nodeId":"join1","nodeName":"Join1","nodeType":"Join","fact":"Joined"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
+
+        // Assert
+        Assert.True(completed);
+    }
+
+    /// <summary>Join に completedAt があれば既完了。</summary>
+    [Fact]
+    public void IsPhysicalJoinAlreadyCompleted_WhenCompletedAtPresent_ReturnsTrue()
+    {
+        // Arrange
+        const string graphJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork1","nodeName":"Fork1","nodeType":"Fork"},
+                {"nodeId":"join1","nodeName":"Join1","nodeType":"Join","completedAt":"2026-01-01T00:00:00Z"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
+
+        // Assert
+        Assert.True(completed);
+    }
+
+    /// <summary>Join status=SUCCEEDED なら既完了。</summary>
+    [Fact]
+    public void IsPhysicalJoinAlreadyCompleted_WhenStatusSucceeded_ReturnsTrue()
+    {
+        // Arrange
+        const string graphJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork1","nodeName":"Fork1","nodeType":"Fork"},
+                {"nodeId":"join1","nodeName":"Join1","nodeType":"Join","status":"SUCCEEDED"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
+
+        // Assert
+        Assert.True(completed);
+    }
+
+    /// <summary>未解決 Join は未完了。</summary>
+    [Fact]
+    public void IsPhysicalJoinAlreadyCompleted_WhenJoinUnresolved_ReturnsFalse()
+    {
+        // Arrange
+        const string graphJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork1","nodeName":"Fork1","nodeType":"Fork"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
+
+        // Assert
+        Assert.False(completed);
+    }
+
+    /// <summary>不正 JSON は未完了扱い。</summary>
+    [Fact]
+    public void IsPhysicalJoinAlreadyCompleted_WhenInvalidJson_ReturnsFalse()
+    {
+        // Arrange / Act
+        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted("{not-json", "fork1", "Join1");
+
+        // Assert
+        Assert.False(completed);
+    }
+
+    private static ExecutionRuntimeCheckpoint CreateCheckpoint(
+        int nodeCount = 0,
+        bool isCompleted = false,
+        bool isCancelled = false,
+        bool isFailed = false,
+        IReadOnlyList<string>? activeStates = null,
+        IReadOnlyList<CheckpointPendingWait>? pendingWaits = null,
+        IReadOnlyList<CheckpointGraphNode>? nodes = null)
+    {
+        var graphNodes = nodes
+            ?? Enumerable.Range(0, nodeCount)
+                .Select(i => new CheckpointGraphNode
+                {
+                    NodeId = $"n{i}",
+                    NodeName = $"N{i}",
+                    NodeType = "Action",
+                    StartedAt = DateTime.UtcNow
+                })
+                .ToArray();
+
+        return new ExecutionRuntimeCheckpoint
+        {
+            ExecutionId = "exec-1",
+            DefinitionName = "def",
+            IsCompleted = isCompleted,
+            IsCancelled = isCancelled,
+            IsFailed = isFailed,
+            ActiveStates = activeStates ?? [],
+            StateAttempts = new Dictionary<string, int>(StringComparer.Ordinal),
+            StateOutputs = new Dictionary<string, JsonElement?>(StringComparer.Ordinal),
+            AppliedPublishClientEventIds = [],
+            AppliedCancelClientEventIds = [],
+            Context = new CheckpointContextData
+            {
+                States = new Dictionary<string, JsonElement?>(StringComparer.Ordinal)
+            },
+            Graph = new CheckpointGraphData
+            {
+                Nodes = graphNodes,
+                Edges = []
+            },
+            Join = new CheckpointJoinData
+            {
+                JoinStateResults = new Dictionary<string, IReadOnlyDictionary<string, CheckpointJoinObserved>>(
+                    StringComparer.OrdinalIgnoreCase),
+                JoinSourceNodeIds = new Dictionary<string, IReadOnlyDictionary<string, string>>(
+                    StringComparer.OrdinalIgnoreCase),
+                StartedJoins = []
+            },
+            PendingWaits = pendingWaits ?? []
+        };
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4181,6 +4181,9 @@ public sealed class ExecutionServiceTests
             CancellationToken ct) =>
             throw new NotSupportedException();
 
+        public Task<bool> HasPendingPhysicalJoinBranchesAsync(Guid parentExecutionId, CancellationToken ct) =>
+            Task.FromResult(false);
+
         public Task CascadeCancelToRunningChildrenAsync(Guid parentExecutionId, CancellationToken ct) =>
             throw new NotSupportedException();
 

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorNestAndRecoveryTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkChildExecutionCoordinatorNestAndRecoveryTests.cs
@@ -13,7 +13,7 @@ using Statevia.Service.Api.Tests.Infrastructure;
 namespace Statevia.Service.Api.Tests.Services;
 
 /// <summary>
-/// タスク 9: ネスト Fork の基本完走と展開の一時失敗リカバリ（循環耐久・幽霊枝は follow-up）。
+/// ネスト Fork の基本完走・展開リカバリ、および物理 Join 待ち判定（checkpoint 寿命）。
 /// </summary>
 public sealed class ForkChildExecutionCoordinatorNestAndRecoveryTests
 {
@@ -173,6 +173,55 @@ public sealed class ForkChildExecutionCoordinatorNestAndRecoveryTests
         Assert.Contains(midId, ids);
         Assert.Contains(leafId, ids);
         Assert.DoesNotContain(outerId, ids);
+    }
+
+    /// <summary>Running の物理分岐がある親は pending Join ありと判定する。</summary>
+    [Fact]
+    public async Task HasPendingPhysicalJoinBranchesAsync_WhenRunningBranch_ReturnsTrue()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        await SeedExecutionAsync(db.Options, parentId, definitionId, definitionVersionId, now);
+        await SeedExecutionAsync(db.Options, childId, definitionId, definitionVersionId, now);
+        await SeedBranchAsync(db.Options, parentId, childId, "fork-node-1", "Join1", "A", now);
+
+        var sut = CreateSut(db, new CapturingWorkQueue(), new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 });
+
+        // Act
+        var pending = await sut.HasPendingPhysicalJoinBranchesAsync(parentId, CancellationToken.None);
+
+        // Assert
+        Assert.True(pending);
+    }
+
+    /// <summary>全分岐 Completed なら pending Join なしと判定する。</summary>
+    [Fact]
+    public async Task HasPendingPhysicalJoinBranchesAsync_WhenAllCompleted_ReturnsFalse()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var definitionId = Guid.NewGuid();
+        var definitionVersionId = Guid.NewGuid();
+        await SeedExecutionAsync(db.Options, parentId, definitionId, definitionVersionId, now);
+        await SeedExecutionAsync(db.Options, childId, definitionId, definitionVersionId, now);
+        await SeedBranchAsync(db.Options, parentId, childId, "fork-node-1", "Join1", "A", now);
+        await MarkBranchAsync(db.Options, parentId, "A", ExecutionBranchStatuses.Completed, """{"ok":true}""", now.AddSeconds(1));
+
+        var sut = CreateSut(db, new CapturingWorkQueue(), new ForkChildExpansionOptions { MaxAttempts = 1, BaseDelayMs = 0 });
+
+        // Act
+        var pending = await sut.HasPendingPhysicalJoinBranchesAsync(parentId, CancellationToken.None);
+
+        // Assert
+        Assert.False(pending);
     }
 
     private static ForkChildExecutionCoordinator CreateSut(

--- a/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ForkExpansionHostHandlerTests.cs
@@ -366,6 +366,9 @@ public sealed class ForkExpansionHostHandlerTests
             CancellationToken ct) =>
             Task.FromResult(new ForkJoinEvaluation(ForkJoinEvaluationKind.Waiting, "Join1"));
 
+        public Task<bool> HasPendingPhysicalJoinBranchesAsync(Guid parentExecutionId, CancellationToken ct) =>
+            Task.FromResult(false);
+
         public Task CascadeCancelToRunningChildrenAsync(Guid parentExecutionId, CancellationToken ct) =>
             Task.CompletedTask;
 

--- a/service/api/Statevia.Service.Api.Tests/Services/GraphDefinitionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/GraphDefinitionServiceTests.cs
@@ -169,6 +169,64 @@ public sealed class GraphDefinitionServiceTests
     }
 
     /// <summary>
+    /// ネスト Fork では OuterJoin の Join.all に InnerFork が含まれても、
+    /// 定義グラフに InnerFork→OuterJoin の幽霊辺を描かない。
+    /// </summary>
+    [Fact]
+    public async Task GetByGraphIdAsync_NestedFork_DoesNotDrawJoinEdgeFromInnerForkToOuterJoin()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uuid = Guid.NewGuid();
+        var graphId = uuid.ToString("N")[..10];
+        const string compiledJson = """
+            {
+              "name": "NestedForkSample",
+              "initialState": "nest.start",
+              "transitions": {
+                "nest.start": { "Completed": { "next": "nest.outer.fork", "fork": null, "end": false } },
+                "nest.outer.fork": { "Completed": { "next": null, "fork": ["nest.outer.fast", "nest.inner.fork"], "end": false } },
+                "nest.outer.fast": { "Completed": { "next": "nest.outer.join", "fork": null, "end": false } },
+                "nest.inner.fork": { "Completed": { "next": null, "fork": ["nest.inner.a", "nest.inner.b"], "end": false } },
+                "nest.inner.a": { "Completed": { "next": "nest.inner.join", "fork": null, "end": false } },
+                "nest.inner.b": { "Completed": { "next": "nest.inner.join", "fork": null, "end": false } },
+                "nest.inner.join": { "Joined": { "next": "nest.outer.join", "fork": null, "end": false } },
+                "nest.outer.join": { "Joined": { "next": "nest.end", "fork": null, "end": false } },
+                "nest.end": { "Completed": { "next": null, "fork": null, "end": true } }
+              },
+              "forkTable": {
+                "nest.outer.fork": ["nest.outer.fast", "nest.inner.fork"],
+                "nest.inner.fork": ["nest.inner.a", "nest.inner.b"]
+              },
+              "joinTable": {
+                "nest.inner.join": ["nest.inner.a", "nest.inner.b"],
+                "nest.outer.join": ["nest.outer.fast", "nest.inner.fork"]
+              }
+            }
+            """;
+
+        var projectId = await SeedDefaultTenantAndProjectAsync(db.Options);
+
+        await using (var ctx = new CoreDbContext(db.Options))
+        {
+            var now = DateTime.UtcNow;
+            DefinitionTestData.AddDefinitionWithVersion(
+                ctx, TestTenantIds.DefaultTenantId, uuid, "nested", projectId, compiledJson: compiledJson, createdAt: now);
+            await ctx.SaveChangesAsync();
+        }
+
+        var sut = CreateSut(db, new StubDisplayIdService(uuid));
+
+        // Act
+        var res = await sut.GetByGraphIdAsync(graphId, CancellationToken.None);
+
+        // Assert
+        Assert.Contains(res.Edges, e => e.From == "nest.outer.fast" && e.To == "nest.outer.join");
+        Assert.Contains(res.Edges, e => e.From == "nest.inner.join" && e.To == "nest.outer.join");
+        Assert.DoesNotContain(res.Edges, e => e.From == "nest.inner.fork" && e.To == "nest.outer.join");
+    }
+
+    /// <summary>
     /// 終端遷移がない状態を通常ノードとして組み立てる。
     /// </summary>
     [Fact]

--- a/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkGraphComposerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkGraphComposerTests.cs
@@ -177,6 +177,58 @@ public sealed class PhysicalForkGraphComposerTests
                 && e["to"]!.GetValue<string>() == "outer-join");
     }
 
+    /// <summary>
+    /// 内側合成が Fork+Join のみ（子辺なし）でも、InnerFork→OuterJoin の幽霊辺を付けない。
+    /// </summary>
+    [Fact]
+    public void Compose_WhenNestedForkChildHasNoInnerEdges_DoesNotJoinFromInnerForkToOuterJoin()
+    {
+        // Arrange: 再帰合成前の内側親スナップショット相当（edges 空）
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"outer-fork","nodeName":"OuterFork","nodeType":"Fork"},
+                {"nodeId":"outer-join","nodeName":"OuterJoin","nodeType":"Join"}
+              ],
+              "edges": []
+            }
+            """;
+        const string nestedChildWithoutInnerEdges = """
+            {
+              "nodes": [
+                {"nodeId":"inner-fork","nodeName":"InnerFork","nodeType":"Fork"},
+                {"nodeId":"inner-join","nodeName":"InnerJoin","nodeType":"Join"}
+              ],
+              "edges": []
+            }
+            """;
+        const string fastChildJson = """
+            {"nodes":[{"nodeId":"outer-fast","nodeName":"OuterFast","nodeType":"Task"}],"edges":[]}
+            """;
+
+        // Act
+        var composed = PhysicalForkGraphComposer.Compose(
+            parentJson,
+            [
+                new PhysicalForkGraphComposer.BranchGraph(
+                    "outer-fork", "outer-join", "OuterFast", fastChildJson),
+                new PhysicalForkGraphComposer.BranchGraph(
+                    "outer-fork", "outer-join", "InnerFork", nestedChildWithoutInnerEdges)
+            ]);
+
+        // Assert
+        var edges = JsonNode.Parse(composed)!["edges"]!.AsArray().OfType<JsonObject>().ToList();
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "inner-fork"
+                && e["to"]!.GetValue<string>() == "outer-join");
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "inner-join"
+                && e["to"]!.GetValue<string>() == "outer-join"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Next);
+    }
+
     /// <summary>循環で同名 Join が複数でも、各 Fork 訪問の Join nodeId に辺が付く。</summary>
     [Fact]
     public void Compose_WhenCyclicForkJoin_AttachesJoinEdgesToVisitSpecificNodeIds()
@@ -307,5 +359,112 @@ public sealed class PhysicalForkGraphComposerTests
 
         // Assert
         Assert.Equal(parentJson, composed);
+    }
+
+    /// <summary>時刻が無い循環 Fork/Join は訪問インデックスで Join を対応付ける。</summary>
+    [Fact]
+    public void ResolveJoinNodeId_WhenNoTimestamps_UsesVisitIndex()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork-v1","nodeName":"Fork1","nodeType":"Fork"},
+                {"nodeId":"join-v1","nodeName":"Join1","nodeType":"Join"},
+                {"nodeId":"fork-v2","nodeName":"Fork1","nodeType":"Fork"},
+                {"nodeId":"join-v2","nodeName":"Join1","nodeType":"Join"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var joinV1 = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork-v1", "Join1");
+        var joinV2 = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork-v2", "Join1");
+
+        // Assert
+        Assert.Equal("join-v1", joinV1);
+        Assert.Equal("join-v2", joinV2);
+    }
+
+    /// <summary>空白の joinState は未解決。</summary>
+    [Fact]
+    public void ResolveJoinNodeId_WhenJoinStateBlank_ReturnsNull()
+    {
+        // Arrange
+        const string parentJson = """
+            {"nodes":[{"nodeId":"fork1","nodeName":"Fork1","nodeType":"Fork"}],"edges":[]}
+            """;
+
+        // Act
+        var joinId = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork1", "  ");
+
+        // Assert
+        Assert.Null(joinId);
+    }
+
+    /// <summary>不明な forkNodeId は未解決。</summary>
+    [Fact]
+    public void ResolveJoinNodeId_WhenForkMissing_ReturnsNull()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"join1","nodeName":"Join1","nodeType":"Join"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var joinId = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "missing-fork", "Join1");
+
+        // Assert
+        Assert.Null(joinId);
+    }
+
+    /// <summary>同名 Join 候補が無いときは未解決。</summary>
+    [Fact]
+    public void ResolveJoinNodeId_WhenNoJoinCandidates_ReturnsNull()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork1","nodeName":"Fork1","nodeType":"Fork"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var joinId = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork1", "Join1");
+
+        // Assert
+        Assert.Null(joinId);
+    }
+
+    /// <summary>Fork の nodeName が欠けるときは先頭 Join 候補へフォールバックする。</summary>
+    [Fact]
+    public void ResolveJoinNodeId_WhenForkNodeNameMissing_ReturnsFirstJoinCandidate()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork1","nodeType":"Fork"},
+                {"nodeId":"join-a","nodeName":"Join1","nodeType":"Join"},
+                {"nodeId":"join-b","nodeName":"Join1","nodeType":"Join"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var joinId = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork1", "Join1");
+
+        // Assert
+        Assert.Equal("join-a", joinId);
     }
 }

--- a/service/api/Statevia.Service.Api.Tests/Services/RuntimeCheckpointLifetimePolicyTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/RuntimeCheckpointLifetimePolicyTests.cs
@@ -1,0 +1,70 @@
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Services;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>runtime checkpoint 内容寿命表（PendingWaits / PendingPhysicalJoin）の単体。</summary>
+public sealed class RuntimeCheckpointLifetimePolicyTests
+{
+    /// <summary>終端は保持理由があっても内容破棄候補。</summary>
+    [Theory]
+    [InlineData(ExecutionProjectionStatuses.Completed)]
+    [InlineData(ExecutionProjectionStatuses.Failed)]
+    [InlineData(ExecutionProjectionStatuses.Cancelled)]
+    public void IsContentDiscardCandidate_WhenTerminal_ReturnsTrue(
+        string status)
+    {
+        // Arrange
+        var reasons = RuntimeCheckpointRetainReasons.PendingWaits
+            | RuntimeCheckpointRetainReasons.PendingPhysicalJoin;
+
+        // Act
+        var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(status, reasons);
+
+        // Assert
+        Assert.True(discard);
+    }
+
+    /// <summary>Running かつ保持理由なしは内容破棄候補。</summary>
+    [Fact]
+    public void IsContentDiscardCandidate_WhenRunningWithoutReasons_ReturnsTrue()
+    {
+        // Arrange / Act
+        var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(
+            ExecutionProjectionStatuses.Running,
+            RuntimeCheckpointRetainReasons.None);
+
+        // Assert
+        Assert.True(discard);
+    }
+
+    /// <summary>PendingWaits がある Running は保持。</summary>
+    [Fact]
+    public void IsContentDiscardCandidate_WhenPendingWaits_ReturnsFalse()
+    {
+        // Arrange / Act
+        var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(
+            ExecutionProjectionStatuses.Running,
+            RuntimeCheckpointRetainReasons.PendingWaits);
+
+        // Assert
+        Assert.False(discard);
+    }
+
+    /// <summary>両方の保持理由がある Running も内容破棄しない。</summary>
+    [Fact]
+    public void IsContentDiscardCandidate_WhenBothRetainReasons_ReturnsFalse()
+    {
+        // Arrange
+        var reasons = RuntimeCheckpointRetainReasons.PendingWaits
+            | RuntimeCheckpointRetainReasons.PendingPhysicalJoin;
+
+        // Act
+        var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(
+            ExecutionProjectionStatuses.Running,
+            reasons);
+
+        // Assert
+        Assert.False(discard);
+    }
+}

--- a/service/api/Statevia.Service.Api/Services/GraphDefinitionService.cs
+++ b/service/api/Statevia.Service.Api/Services/GraphDefinitionService.cs
@@ -129,7 +129,9 @@ internal sealed class GraphDefinitionService : IGraphDefinitionService
         AddEdgesFromConditionalTransitions(edges, dto.ConditionalTransitions);
         AddEdgesFromWaitEventRouteTable(edges, dto.WaitEventRouteTable);
         AddEdgesFromStateTable(edges, dto.ForkTable);
-        AddEdgesFromJoinTable(edges, dto.JoinTable);
+        // Join.all の依存にネスト枝先頭の Fork が含まれるが、描画では内側 Join→外側の遷移辺を使う。
+        // Fork→Join を JoinTable から描くと幽霊枝になるため、Fork 依存は除外する。
+        AddEdgesFromJoinTable(edges, dto.JoinTable, dto.ForkTable);
         return edges;
     }
 
@@ -335,12 +337,24 @@ internal sealed class GraphDefinitionService : IGraphDefinitionService
     /// <summary>
     /// join テーブル（joinState ← dependencies）から描画用エッジを追加する。
     /// </summary>
-    private static void AddEdgesFromJoinTable(List<GraphEdgeDefinition> edges, Dictionary<string, List<string>?>? joinTable)
+    /// <remarks>
+    /// 依存が <paramref name="forkTable"/> 上の Fork 状態のときは辺を作らない。
+    /// ネストでは OuterJoin の Join.all が InnerFork を依存に持つが、見た目の経路は
+    /// InnerJoin → OuterJoin（transitions）であり、InnerFork → OuterJoin は幽霊枝になる。
+    /// </remarks>
+    private static void AddEdgesFromJoinTable(
+        List<GraphEdgeDefinition> edges,
+        Dictionary<string, List<string>?>? joinTable,
+        Dictionary<string, List<string>?>? forkTable)
     {
         if (joinTable is null) return;
         joinTable
             .Where(pair => pair.Value is not null)
-            .SelectMany(pair => pair.Value!.Select(from => new GraphEdgeDefinition { From = from, To = pair.Key }))
+            .SelectMany(pair => pair.Value!
+                .Where(from =>
+                    !string.IsNullOrWhiteSpace(from)
+                    && (forkTable is null || !forkTable.ContainsKey(from)))
+                .Select(from => new GraphEdgeDefinition { From = from, To = pair.Key }))
             .ToList()
             .ForEach(edges.Add);
     }

--- a/ui/studio/features/definition-editor/actionSchema/actionSchemaIndexSessionCache.ts
+++ b/ui/studio/features/definition-editor/actionSchema/actionSchemaIndexSessionCache.ts
@@ -29,3 +29,11 @@ export async function loadActionSchemaIndex(
     });
   return inflightRequest;
 }
+
+/**
+ * テスト間で index キャッシュを共有しないためのリセット。
+ */
+export function resetActionSchemaIndexSessionCacheForTests(): void {
+  cachedItems = null;
+  inflightRequest = null;
+}

--- a/ui/studio/features/executions/hooks/useExecution.ts
+++ b/ui/studio/features/executions/hooks/useExecution.ts
@@ -67,11 +67,34 @@ export function useExecution(executionDisplayId: string, options: UseExecutionOp
   const applyExecutionSnapshot = (view: ExecutionView) => {
     setExecution(view);
     setSelectedNodeId((current) => {
-      if (!current) return view.nodes[0]?.nodeId ?? null;
+      const waitingNodes = view.nodes.filter((node) => node.status === "WAITING");
+      const soleWaiting = waitingNodes.length === 1 ? waitingNodes[0] : null;
+
+      if (!current) {
+        return soleWaiting?.nodeId ?? view.nodes[0]?.nodeId ?? null;
+      }
+
       const key = current.trim();
-      if (view.nodes.some((node) => node.nodeId === key)) return current;
-      if (view.nodes.some((node) => (node.nodeName?.trim() ?? "") === key)) return current;
-      return view.nodes[0]?.nodeId ?? null;
+      const byRuntimeId = view.nodes.find((node) => node.nodeId === key);
+      if (byRuntimeId) {
+        // 循環で同名 Wait が再入場したとき、完了済みの旧 nodeId 選択を WAITING へ追従する。
+        if (
+          soleWaiting
+          && byRuntimeId.status !== "WAITING"
+          && typeof byRuntimeId.nodeName === "string"
+          && byRuntimeId.nodeName.trim().length > 0
+          && byRuntimeId.nodeName.trim().toLowerCase() === (soleWaiting.nodeName?.trim() ?? "").toLowerCase()
+        ) {
+          return soleWaiting.nodeId;
+        }
+        return key;
+      }
+
+      if (view.nodes.some((node) => (node.nodeName?.trim() ?? "") === key)) {
+        return key;
+      }
+
+      return soleWaiting?.nodeId ?? view.nodes[0]?.nodeId ?? null;
     });
   };
 

--- a/ui/studio/features/executions/hooks/useGraphData.ts
+++ b/ui/studio/features/executions/hooks/useGraphData.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { resolveGroupBounds } from "../lib/grouping";
 import { layoutGraph } from "@/shared/lib/graphLayout";
 import { mergeGraph, type MergedGraphEdge, type MergedGraphNode } from "../lib/mergeGraph";
+import { pickPreferredRuntimeNode } from "../lib/pickPreferredRuntimeNode";
 import type { ExecutionNodeDTO, ExecutionView } from "../types";
 import type { GroupBounds } from "../lib/grouping";
 import type { LayoutEdgeInput, PositionedNode } from "@/shared/lib/graphLayout";
@@ -56,6 +57,7 @@ export function useGraphData(
  * ノード詳細・Resume 用に `ExecutionNodeDTO` を解決する。
  * リストはランタイム `nodeId`（UUID）、グラフは定義の `name`（状態キー）で選択するため、
  * `nodeName` およびマージ結果の `nodeName` でランタイム行へ寄せる。
+ * 循環で同名 Wait が複数あるときは {@link pickPreferredRuntimeNode} で WAITING 行を優先する。
  */
 export function getNodeWithFallback(
   execution: ExecutionView | null,
@@ -68,12 +70,7 @@ export function getNodeWithFallback(
   const byRuntimeId = execution.nodes.find((n) => n.nodeId === key);
   if (byRuntimeId) return byRuntimeId;
 
-  const byNodeNameKey = execution.nodes.find(
-    (n) =>
-      typeof n.nodeName === "string" &&
-      n.nodeName.trim().length > 0 &&
-      n.nodeName.trim().toLowerCase() === key.toLowerCase()
-  );
+  const byNodeNameKey = pickPreferredRuntimeNode(execution.nodes, key);
   if (byNodeNameKey) return byNodeNameKey;
 
   const mergedNode = graphData?.mergedNodes.find((n) => n.name === key);
@@ -81,11 +78,7 @@ export function getNodeWithFallback(
 
   const mergedState = mergedNode.nodeName.trim();
   if (mergedState.length > 0) {
-    const byMergedNodeName = execution.nodes.find(
-      (n) =>
-        typeof n.nodeName === "string" &&
-        n.nodeName.trim().toLowerCase() === mergedState.toLowerCase()
-    );
+    const byMergedNodeName = pickPreferredRuntimeNode(execution.nodes, mergedState);
     if (byMergedNodeName) return byMergedNodeName;
   }
 

--- a/ui/studio/features/executions/lib/mergeGraph.ts
+++ b/ui/studio/features/executions/lib/mergeGraph.ts
@@ -1,5 +1,6 @@
 import type { GraphDefinition, GraphEdgeDef, GraphGroupDef, GraphDefinitionMeta } from "@/features/executions/graphs/types";
 import type { ExecutionNodeDTO, NodeStatus, ExecutionView } from "../types";
+import { pickPreferredRuntimeNode } from "./pickPreferredRuntimeNode";
 
 /** 実行＋定義をマージしたグラフノード。 */
 export type MergedGraphNode = {
@@ -83,8 +84,15 @@ export function mergeGraph(execution: ExecutionView, definition: GraphDefinition
     byRuntimeId.set(n.nodeId, n);
     const trimmed = typeof n.nodeName === "string" ? n.nodeName.trim() : "";
     if (trimmed.length === 0) continue;
-    byNodeNameKey.set(trimmed, n);
     nodeNameByRuntimeId.set(n.nodeId, trimmed);
+    // 循環で同名が複数あるときは WAITING / 最新 attempt を代表にする。
+    const existing = byNodeNameKey.get(trimmed);
+    if (!existing) {
+      byNodeNameKey.set(trimmed, n);
+      continue;
+    }
+    const preferred = pickPreferredRuntimeNode([existing, n], trimmed);
+    if (preferred) byNodeNameKey.set(trimmed, preferred);
   }
 
   const traversedEdgeKeys = new Set(

--- a/ui/studio/features/executions/lib/pickPreferredRuntimeNode.ts
+++ b/ui/studio/features/executions/lib/pickPreferredRuntimeNode.ts
@@ -1,0 +1,50 @@
+import type { ExecutionNodeDTO, NodeStatus } from "../types";
+
+/**
+ * 同名（循環再入）の実行ノードから、UI 表示・Resume に使う代表行を選ぶ優先度。
+ * WAITING を最優先し、次に進行中、最後に attempt の大きい完了行へ寄せる。
+ */
+const STATUS_PRIORITY: Record<NodeStatus, number> = {
+  WAITING: 400,
+  RUNNING: 300,
+  READY: 250,
+  FAILED: 200,
+  CANCELED: 200,
+  SUCCEEDED: 100,
+  IDLE: 0
+};
+
+/**
+ * 同一 `nodeName` を持つ実行ノードから、グラフマージ／詳細パネル用の代表を選ぶ。
+ *
+ * @param nodes 実行ビューの全ノード。
+ * @param nodeNameKey 定義上の状態名、または選択キー（大小無視・前後空白無視）。
+ * @returns 該当が無ければ `undefined`。複数あれば WAITING → RUNNING → 高 attempt → 後ろ勝ち。
+ */
+export function pickPreferredRuntimeNode(
+  nodes: readonly ExecutionNodeDTO[],
+  nodeNameKey: string
+): ExecutionNodeDTO | undefined {
+  const key = nodeNameKey.trim().toLowerCase();
+  if (key.length === 0) return undefined;
+
+  const matches = nodes.filter((node) => {
+    const name = typeof node.nodeName === "string" ? node.nodeName.trim().toLowerCase() : "";
+    return name.length > 0 && name === key;
+  });
+  if (matches.length === 0) return undefined;
+
+  const [first, ...rest] = matches;
+  return rest.reduce((best, current) => {
+    const bestPriority = STATUS_PRIORITY[best.status] ?? 0;
+    const currentPriority = STATUS_PRIORITY[current.status] ?? 0;
+    if (currentPriority !== bestPriority) {
+      return currentPriority > bestPriority ? current : best;
+    }
+    if (current.attempt !== best.attempt) {
+      return current.attempt > best.attempt ? current : best;
+    }
+    // 同等なら配列後方（通常は後から追加された訪問）を採用する。
+    return current;
+  }, first);
+}

--- a/ui/studio/shared/ui/TenantMissingBanner.tsx
+++ b/ui/studio/shared/ui/TenantMissingBanner.tsx
@@ -20,6 +20,11 @@ export function TenantMissingBanner() {
   const [sessionLoaded, setSessionLoaded] = useState(false);
 
   useEffect(() => {
+    // 環境変数でテナントが付いているときはセッション確認不要（無駄な setState も避ける）。
+    if (tenantId) {
+      return;
+    }
+
     let cancelled = false;
     fetch("/api/auth/session", { credentials: "same-origin" })
       .then((res) => (res.ok ? res.json() : null))
@@ -37,7 +42,7 @@ export function TenantMissingBanner() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [tenantId]);
 
   if (tenantId) return null;
   if (!sessionLoaded) return null;

--- a/ui/studio/tests/components/editor/DefinitionGraphEditor.test.tsx
+++ b/ui/studio/tests/components/editor/DefinitionGraphEditor.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { useState } from "react";
 import { DefinitionGraphEditor } from "@/features/definition-editor/ui/DefinitionGraphEditor";
+import { resetActionSchemaIndexSessionCacheForTests } from "@/features/definition-editor/actionSchema/actionSchemaIndexSessionCache";
 import { defaultDefinitionYaml } from "@/features/definition-editor/lib/defaultDefinitionYaml";
 import { parseDefinitionYaml } from "@/features/definition-editor/lib/parseDefinitionYaml";
 import type { DefinitionGraphDocument } from "@/features/definition-editor/lib/types";
@@ -20,6 +21,21 @@ const parseOpts = {
   nodesArrayRequired: () => "nodes"
 };
 
+/**
+ * GraphInspector の mount 時 schema index 取得と setState を act 内で完了させる。
+ * 未待ちだと "An update to GraphInspector was not wrapped in act(...)" が出る。
+ */
+async function settleGraphInspectorSchemaIndex(): Promise<void> {
+  await waitFor(() => {
+    expect(vi.mocked(apiGet)).toHaveBeenCalledWith("/actions/schema/index");
+  });
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+}
+
 function StatefulGraphEditorHarness({
   initialDocument
 }: Readonly<{ initialDocument: DefinitionGraphDocument }>) {
@@ -36,6 +52,7 @@ function StatefulGraphEditorHarness({
 
 describe("DefinitionGraphEditor", () => {
   beforeEach(() => {
+    resetActionSchemaIndexSessionCacheForTests();
     vi.mocked(apiGet).mockReset();
     vi.mocked(apiGet).mockImplementation(async (path: string) => {
       if (path === "/actions/schema/index") {
@@ -58,7 +75,7 @@ describe("DefinitionGraphEditor", () => {
     });
   });
 
-  it("ドキュメントをグラフとして描画する", () => {
+  it("ドキュメントをグラフとして描画する", async () => {
     const parsed = parseDefinitionYaml(defaultDefinitionYaml, parseOpts);
     expect(parsed.document).not.toBeNull();
 
@@ -70,6 +87,7 @@ describe("DefinitionGraphEditor", () => {
         labels={definitionGraphEditorTestLabels}
       />
     );
+    await settleGraphInspectorSchemaIndex();
 
     expect(screen.getByText(definitionGraphEditorTestLabels.title)).toBeInTheDocument();
   });
@@ -87,7 +105,7 @@ describe("DefinitionGraphEditor", () => {
     expect(screen.getByText(definitionGraphEditorTestLabels.empty)).toBeInTheDocument();
   });
 
-  it("バリデーションメッセージとフルスクリーンを操作できる", () => {
+  it("バリデーションメッセージとフルスクリーンを操作できる", async () => {
     const parsed = parseDefinitionYaml(defaultDefinitionYaml, parseOpts);
     expect(parsed.document).not.toBeNull();
 
@@ -99,13 +117,14 @@ describe("DefinitionGraphEditor", () => {
         labels={definitionGraphEditorTestLabels}
       />
     );
+    await settleGraphInspectorSchemaIndex();
 
     expect(screen.getByText("node id required")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: definitionGraphEditorTestLabels.fullscreenEnter }));
     expect(screen.getByRole("button", { name: definitionGraphEditorTestLabels.fullscreenExit })).toBeInTheDocument();
   });
 
-  it("wait ノード追加で onDocumentChange を呼ぶ", () => {
+  it("wait ノード追加で onDocumentChange を呼ぶ", async () => {
     const parsed = parseDefinitionYaml(defaultDefinitionYaml, parseOpts);
     expect(parsed.document).not.toBeNull();
     const onDocumentChange = vi.fn();
@@ -118,6 +137,7 @@ describe("DefinitionGraphEditor", () => {
         labels={definitionGraphEditorTestLabels}
       />
     );
+    await settleGraphInspectorSchemaIndex();
 
     fireEvent.click(screen.getByRole("button", { name: "wait" }));
     expect(onDocumentChange).toHaveBeenCalled();
@@ -125,7 +145,7 @@ describe("DefinitionGraphEditor", () => {
     expect(nextDocument.nodes.some((node) => node.type === "wait")).toBe(true);
   });
 
-  it("action 変更時に input をクリアする", () => {
+  it("action 変更時に input をクリアする", async () => {
     const parsed = parseDefinitionYaml(defaultDefinitionYaml, parseOpts);
     expect(parsed.document).not.toBeNull();
     const onDocumentChange = vi.fn();
@@ -152,11 +172,20 @@ describe("DefinitionGraphEditor", () => {
         labels={definitionGraphEditorTestLabels}
       />
     );
+    await settleGraphInspectorSchemaIndex();
 
     fireEvent.click(screen.getByText("slowStep"));
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("sleep")).toBeInTheDocument();
+    });
     const actionInput = screen.getByDisplayValue("sleep");
-    fireEvent.change(actionInput, { target: { value: "statevia.action.builtin.noop" } });
-    fireEvent.blur(actionInput);
+    await act(async () => {
+      fireEvent.change(actionInput, { target: { value: "statevia.action.builtin.noop" } });
+      fireEvent.blur(actionInput);
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
 
     const nextDocument = onDocumentChange.mock.calls.at(-1)?.[0] as DefinitionGraphDocument;
     const updatedNode = nextDocument.nodes.find((entry) => entry.name === "slowStep");
@@ -167,7 +196,7 @@ describe("DefinitionGraphEditor", () => {
     }
   });
 
-  it("ノード選択後に action を更新する", () => {
+  it("ノード選択後に action を更新する", async () => {
     const parsed = parseDefinitionYaml(defaultDefinitionYaml, parseOpts);
     expect(parsed.document).not.toBeNull();
     const onDocumentChange = vi.fn();
@@ -180,8 +209,14 @@ describe("DefinitionGraphEditor", () => {
         labels={definitionGraphEditorTestLabels}
       />
     );
+    await settleGraphInspectorSchemaIndex();
 
     fireEvent.click(screen.getByText("slowStep"));
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
     const actionInput = screen.getByDisplayValue("sleep");
     fireEvent.change(actionInput, { target: { value: "noop" } });
     fireEvent.blur(actionInput);
@@ -193,9 +228,10 @@ describe("DefinitionGraphEditor", () => {
     expect(parsed.document).not.toBeNull();
 
     renderWithUiText(<StatefulGraphEditorHarness initialDocument={parsed.document!} />);
+    await settleGraphInspectorSchemaIndex();
 
     fireEvent.click(screen.getByText("slowStep"));
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByDisplayValue("sleep")).toBeInTheDocument();
     });
 
@@ -217,6 +253,22 @@ describe("DefinitionGraphEditor", () => {
     const parsed = parseDefinitionYaml(defaultDefinitionYaml, parseOpts);
     expect(parsed.document).not.toBeNull();
     vi.mocked(apiGet).mockImplementation(async (path: string) => {
+      if (path === "/actions/schema/index") {
+        return {
+          items: [
+            {
+              actionId: "statevia.action.builtin.noop",
+              displayName: "No-op",
+              version: "1.0.0"
+            },
+            {
+              actionId: "statevia.action.builtin.rest",
+              displayName: "REST",
+              version: "1.0.0"
+            }
+          ]
+        };
+      }
       if (path.startsWith("/actions/schema/")) {
         return {
           descriptor: { actionId: "statevia.action.builtin.noop", version: "1.0.0", displayName: "Noop" },
@@ -231,9 +283,10 @@ describe("DefinitionGraphEditor", () => {
     });
 
     renderWithUiText(<StatefulGraphEditorHarness initialDocument={parsed.document!} />);
+    await settleGraphInspectorSchemaIndex();
 
     fireEvent.click(screen.getByText("slowStep"));
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByDisplayValue("sleep")).toBeInTheDocument();
     });
     vi.mocked(apiGet).mockClear();
@@ -259,10 +312,15 @@ describe("DefinitionGraphEditor", () => {
     expect(detailPathCalls(vi.mocked(apiGet).mock.calls)).toHaveLength(0);
 
     fireEvent.change(actionInput, { target: { value: "statevia.action.builtin.rest" } });
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(
         vi.mocked(apiGet).mock.calls.filter((call) => call[0] === "/actions/schema/statevia.action.builtin.rest")
       ).toHaveLength(1);
+    });
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
     });
     expect(detailPathCalls(vi.mocked(apiGet).mock.calls)).toHaveLength(1);
   });

--- a/ui/studio/tests/components/execution/TenantMissingBanner.test.tsx
+++ b/ui/studio/tests/components/execution/TenantMissingBanner.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { TenantMissingBanner } from "@/shared/ui/TenantMissingBanner";
 import * as api from "@/shared/api";
 import { uiText } from "@/shared/i18n/uiText";
@@ -7,6 +7,15 @@ import { uiText } from "@/shared/i18n/uiText";
 vi.mock("@/shared/api", () => ({
   getApiConfig: vi.fn()
 }));
+
+/** session fetch の setState を act 内で完了させる。 */
+async function settleSessionFetch(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+}
 
 describe("TenantMissingBanner", () => {
   beforeEach(() => {
@@ -19,6 +28,10 @@ describe("TenantMissingBanner", () => {
         } as Response)
       )
     );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("セッション確認中はバナーを表示しない", async () => {
@@ -42,7 +55,9 @@ describe("TenantMissingBanner", () => {
         ok: true,
         json: () => Promise.resolve({ authenticated: false, tenantKey: "" })
       } as Response);
-      await Promise.resolve();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
     });
 
     await waitFor(() => {
@@ -56,6 +71,7 @@ describe("TenantMissingBanner", () => {
 
     // Act
     render(<TenantMissingBanner />);
+    await settleSessionFetch();
     const noticeParts = uiText.tenantMissingBanner.noticeParts(
       uiText.actions.load,
       uiText.actions.cancel,
@@ -79,6 +95,7 @@ describe("TenantMissingBanner", () => {
 
     // Assert
     expect(container.firstChild).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("Cookie セッション時は何も表示しない", async () => {
@@ -96,6 +113,7 @@ describe("TenantMissingBanner", () => {
 
     // Act
     const { container } = render(<TenantMissingBanner />);
+    await settleSessionFetch();
 
     // Assert
     await waitFor(() => {

--- a/ui/studio/tests/features/graph/useGraphData.test.ts
+++ b/ui/studio/tests/features/graph/useGraphData.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { useGraphData } from "../../../features/executions/hooks/useGraphData";
+import { getNodeWithFallback, useGraphData } from "../../../features/executions/hooks/useGraphData";
 import type { ExecutionNodeDTO, ExecutionView } from "@/features/executions/types";
 import { getGraphDefinition } from "@/features/executions/graphs/registry";
+import type { GraphDefinition } from "@/features/executions/graphs/types";
 
 function execution(nodes: ExecutionNodeDTO[], graphId = "hello"): ExecutionView {
   return {
@@ -61,5 +62,51 @@ describe("useGraphData", () => {
     expect(result.current?.definitionBased).toBe(false);
     expect(result.current?.mergedNodes).toHaveLength(1);
     expect(result.current?.edges).toHaveLength(0);
+  });
+});
+
+describe("getNodeWithFallback", () => {
+  it("定義名で選択したとき同名の完了 Wait より WAITING を返す", () => {
+    // Arrange
+    const def: GraphDefinition = {
+      graphId: "cyclic-wait",
+      nodes: [{ nodeName: "cycle.decide", nodeType: "Wait" }],
+      edges: []
+    };
+    const exec = execution(
+      [
+        {
+          nodeId: "decide-old",
+          nodeName: "cycle.decide",
+          nodeType: "Wait",
+          status: "SUCCEEDED",
+          attempt: 1,
+          workerId: null,
+          waitKey: null,
+          allowedEvents: ["Again", "Finish"],
+          canceledByExecution: false
+        },
+        {
+          nodeId: "decide-new",
+          nodeName: "cycle.decide",
+          nodeType: "Wait",
+          status: "WAITING",
+          attempt: 2,
+          workerId: null,
+          waitKey: null,
+          allowedEvents: ["Again", "Finish"],
+          canceledByExecution: false
+        }
+      ],
+      "cyclic-wait"
+    );
+    const { result } = renderHook(() => useGraphData(exec, def));
+
+    // Act
+    const resolved = getNodeWithFallback(exec, result.current, "cycle.decide");
+
+    // Assert
+    expect(resolved?.nodeId).toBe("decide-new");
+    expect(resolved?.status).toBe("WAITING");
   });
 });

--- a/ui/studio/tests/lib/mergeGraph.test.ts
+++ b/ui/studio/tests/lib/mergeGraph.test.ts
@@ -188,6 +188,51 @@ describe("mergeGraph", () => {
     const mergedStart = result.nodes.find((n) => n.name === "start");
     expect(mergedStart?.nodeName).toBe("startStateApi");
   });
+
+  it("循環で同名 Wait が複数あるとき WAITING のランタイム行を定義ノードへマージする", () => {
+    // Arrange: 定義グラフは 1 ノードだが実行は attempt 1 完了 + attempt 2 待機
+    const def: GraphDefinition = {
+      graphId: "cyclic-wait",
+      nodes: [{ nodeName: "cycle.decide", nodeType: "Wait", label: "Decide" }],
+      edges: []
+    };
+    const exec = execution(
+      [
+        {
+          nodeId: "decide-old",
+          nodeName: "cycle.decide",
+          nodeType: "Wait",
+          status: "SUCCEEDED",
+          attempt: 1,
+          workerId: null,
+          waitKey: null,
+          allowedEvents: ["Again", "Finish"],
+          canceledByExecution: false
+        },
+        {
+          nodeId: "decide-new",
+          nodeName: "cycle.decide",
+          nodeType: "Wait",
+          status: "WAITING",
+          attempt: 2,
+          workerId: null,
+          waitKey: null,
+          allowedEvents: ["Again", "Finish"],
+          canceledByExecution: false
+        }
+      ],
+      "cyclic-wait"
+    );
+
+    // Act
+    const result = mergeGraph(exec, def);
+    const decide = result.nodes.find((n) => n.name === "cycle.decide");
+
+    // Assert
+    expect(decide?.status).toBe("WAITING");
+    expect(decide?.nodeId).toBe("decide-new");
+    expect(decide?.attempt).toBe(2);
+  });
 });
 
 describe("mergeGraph (境界値)", () => {

--- a/ui/studio/tests/lib/pickPreferredRuntimeNode.test.ts
+++ b/ui/studio/tests/lib/pickPreferredRuntimeNode.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { pickPreferredRuntimeNode } from "../../features/executions/lib/pickPreferredRuntimeNode";
+import type { ExecutionNodeDTO } from "@/features/executions/types";
+
+function node(
+  overrides: Partial<ExecutionNodeDTO> & Pick<ExecutionNodeDTO, "nodeId" | "status" | "attempt">
+): ExecutionNodeDTO {
+  return {
+    nodeName: "cycle.decide",
+    nodeType: "Wait",
+    workerId: null,
+    waitKey: null,
+    allowedEvents: ["Again", "Finish"],
+    canceledByExecution: false,
+    ...overrides
+  };
+}
+
+describe("pickPreferredRuntimeNode", () => {
+  it("同名の完了 Wait と WAITING があるとき WAITING を選ぶ", () => {
+    // Arrange
+    const nodes = [
+      node({ nodeId: "decide-1", status: "SUCCEEDED", attempt: 1 }),
+      node({ nodeId: "decide-2", status: "WAITING", attempt: 2 })
+    ];
+
+    // Act
+    const preferred = pickPreferredRuntimeNode(nodes, "cycle.decide");
+
+    // Assert
+    expect(preferred?.nodeId).toBe("decide-2");
+    expect(preferred?.status).toBe("WAITING");
+  });
+
+  it("WAITING が配列先頭でも優先する（find 先頭勝ちの回帰防止）", () => {
+    // Arrange
+    const nodes = [
+      node({ nodeId: "decide-1", status: "SUCCEEDED", attempt: 1 }),
+      node({ nodeId: "decide-2", status: "SUCCEEDED", attempt: 2 }),
+      node({ nodeId: "decide-3", status: "WAITING", attempt: 3 })
+    ];
+
+    // Act
+    const preferred = pickPreferredRuntimeNode(nodes, "CYCLE.DECIDE");
+
+    // Assert
+    expect(preferred?.nodeId).toBe("decide-3");
+  });
+
+  it("すべて完了なら attempt 最大を選ぶ", () => {
+    // Arrange
+    const nodes = [
+      node({ nodeId: "decide-1", status: "SUCCEEDED", attempt: 1 }),
+      node({ nodeId: "decide-3", status: "SUCCEEDED", attempt: 3 }),
+      node({ nodeId: "decide-2", status: "SUCCEEDED", attempt: 2 })
+    ];
+
+    // Act
+    const preferred = pickPreferredRuntimeNode(nodes, "cycle.decide");
+
+    // Assert
+    expect(preferred?.nodeId).toBe("decide-3");
+  });
+
+  it("該当 nodeName が無ければ undefined", () => {
+    // Arrange
+    const nodes = [node({ nodeId: "decide-1", status: "WAITING", attempt: 1 })];
+
+    // Act / Assert
+    expect(pickPreferredRuntimeNode(nodes, "cycle.fork")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- 循環 Hosted 物理 Fork で Join が停滞しないよう、runtime checkpoint の保持理由（PendingWaits / PendingPhysicalJoin）と寿命表を導入し、Join 再入場・古い Unload 抑止を追加する
- ネスト合成の幽霊枝を抑え、実行 UI は同名ノードの代表訪問を選ぶ（詳細の全訪問ナビは別 Spec）
- docs / サンプル（3 段ネスト）と API・Engine・UI テストを追従し、React act 警告も是正する

## Test plan
- [x] 循環サンプル（ui-cyclic-fork）で親が 2 周目以降も Join 完走し Finish まで到達する
- [x] ネストサンプル（ui-nested-fork）の合成グラフに定義外の幽霊辺が出ない
- [x] API の checkpoint / PhysicalFork / ForkChild 周辺テストと UI の mergeGraph / pickPreferredRuntimeNode / act 修正テストが緑
- [x] SonarQube StateviaServiceApi Quality Gate（new_coverage ≥ 80）を確認する