### PR TITLE
ServiceApi / Runtime カバレッジを 85% 以上へ底上げ

### DIFF
--- a/service/api/Statevia.Service.Api.Tests/Application/Actions/Builtins/RestUrlValidatorTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Actions/Builtins/RestUrlValidatorTests.cs
@@ -50,4 +50,43 @@ public sealed class RestUrlValidatorTests
         Assert.Throws<ArgumentException>(() =>
             RestUrlValidator.EnsureAllowedHttpsUrl("https://127.0.0.1/hook"));
     }
+
+    /// <summary>相対 URL は拒否される。</summary>
+    [Fact]
+    public void EnsureAllowedHttpsUrl_Relative_Throws()
+    {
+        // Act + Assert
+        Assert.Throws<ArgumentException>(() =>
+            RestUrlValidator.EnsureAllowedHttpsUrl("/relative"));
+    }
+
+    /// <summary>.local / .internal ホストは拒否される。</summary>
+    [Theory]
+    [InlineData("https://svc.local/hook")]
+    [InlineData("https://svc.internal/hook")]
+    public void EnsureAllowedHttpsUrl_LocalSuffix_Throws(string url)
+    {
+        // Act + Assert
+        Assert.Throws<ArgumentException>(() => RestUrlValidator.EnsureAllowedHttpsUrl(url));
+    }
+
+    /// <summary>RFC1918 / link-local IPv4 は拒否される。</summary>
+    [Theory]
+    [InlineData("https://172.16.0.1/hook")]
+    [InlineData("https://192.168.1.1/hook")]
+    [InlineData("https://169.254.1.1/hook")]
+    public void EnsureAllowedHttpsUrl_BlockedIpv4Ranges_Throws(string url)
+    {
+        // Act + Assert
+        Assert.Throws<ArgumentException>(() => RestUrlValidator.EnsureAllowedHttpsUrl(url));
+    }
+
+    /// <summary>IPv6 link-local は拒否される。</summary>
+    [Fact]
+    public void EnsureAllowedHttpsUrl_Ipv6LinkLocal_Throws()
+    {
+        // Act + Assert
+        Assert.Throws<ArgumentException>(() =>
+            RestUrlValidator.EnsureAllowedHttpsUrl("https://[fe80::1]/hook"));
+    }
 }

--- a/service/api/Statevia.Service.Api.Tests/Application/Actions/Builtins/WorkflowActionStateTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Actions/Builtins/WorkflowActionStateTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Statevia.Core.Engine.Abstractions;
+using Statevia.Service.Api.Application.Actions.Builtins;
+using Statevia.Service.Api.Application.Actions.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Application.Actions.Builtins;
+
+/// <summary><see cref="WorkflowActionState"/> の入力検証と runner 委譲。</summary>
+public sealed class WorkflowActionStateTests
+{
+    /// <summary>async モードで runner 結果を辞書として返す。</summary>
+    [Fact]
+    public async Task ExecuteAsync_AsyncMode_ReturnsRunnerResult()
+    {
+        // Arrange
+        var runner = new FakeChildWorkflowRunner
+        {
+            Result = new ChildWorkflowResult("exec-1", "wf-1", "Running")
+        };
+        var sut = new WorkflowActionState(BuildScopeFactory(runner));
+        var input = JsonSerializer.SerializeToElement(new
+        {
+            definitionId = "def-1",
+            mode = "async",
+            timeout = 30,
+            input = new { foo = "bar" }
+        });
+
+        // Act
+        var result = await sut.ExecuteAsync(MakeContext(), input, CancellationToken.None);
+
+        // Assert
+        var map = Assert.IsType<Dictionary<string, object?>>(result);
+        Assert.Equal("exec-1", map["workflowId"]);
+        Assert.Equal("wf-1", map["displayId"]);
+        Assert.Equal("Running", map["status"]);
+        Assert.Equal("def-1", runner.LastRequest!.DefinitionId);
+        Assert.Equal("async", runner.LastRequest.Mode);
+        Assert.Equal(TimeSpan.FromSeconds(30), runner.LastRequest.Timeout);
+    }
+
+    /// <summary>入力がオブジェクトでないとき ArgumentException。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenInputNotObject_Throws()
+    {
+        // Arrange
+        var sut = new WorkflowActionState(BuildScopeFactory(new FakeChildWorkflowRunner()));
+        var input = JsonSerializer.SerializeToElement("plain");
+
+        // Act + Assert
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => sut.ExecuteAsync(MakeContext(), input, CancellationToken.None));
+        Assert.Contains("definitionId", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>mode が async/sync 以外なら拒否する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenModeInvalid_Throws()
+    {
+        // Arrange
+        var sut = new WorkflowActionState(BuildScopeFactory(new FakeChildWorkflowRunner()));
+        var input = JsonSerializer.SerializeToElement(new { definitionId = "d1", mode = "fire" });
+
+        // Act + Assert
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => sut.ExecuteAsync(MakeContext(), input, CancellationToken.None));
+        Assert.Contains("async or sync", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IServiceScopeFactory BuildScopeFactory(IChildWorkflowRunner runner)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(runner);
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private static StateContext MakeContext() =>
+        new()
+        {
+            Events = new NoopEvents(),
+            Store = new NoopStore(),
+            ExecutionId = Guid.NewGuid().ToString("D"),
+            StateName = "Workflow"
+        };
+
+    private sealed class FakeChildWorkflowRunner : IChildWorkflowRunner
+    {
+        public ChildWorkflowResult Result { get; init; } = new("id", "disp", "Running");
+        public ChildWorkflowRequest? LastRequest { get; private set; }
+
+        public Task<ChildWorkflowResult> RunAsync(ChildWorkflowRequest request, CancellationToken ct)
+        {
+            LastRequest = request;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private sealed class NoopEvents : IEventProvider
+    {
+        public Task WaitAsync(string eventName, CancellationToken ct) => Task.CompletedTask;
+        public Task<string> WaitForEventAsync(string nodeId, IReadOnlyList<string> eventNames, CancellationToken ct) =>
+            Task.FromResult(eventNames[0]);
+        public void Signal(string signalName) { }
+        public void Resume(string nodeId, string eventName) { }
+        public void PublishTopic(string topic, object? payloadSummary) { }
+    }
+
+    private sealed class NoopStore : IReadOnlyStateStore
+    {
+        public bool TryGetOutput(string stateName, out object? output)
+        {
+            output = null;
+            return false;
+        }
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Application/Actions/Infrastructure/ChildWorkflowRunnerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Actions/Infrastructure/ChildWorkflowRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Statevia.Core.Application.Contracts;
 using Statevia.Core.Application.Contracts.Services;
@@ -56,6 +57,105 @@ public sealed class ChildWorkflowRunnerTests
             runner.RunAsync(new ChildWorkflowRequest("def-1", "async", null, null), CancellationToken.None));
     }
 
+    /// <summary>sync モードは終端 status までポーリングする。</summary>
+    [Fact]
+    public async Task RunAsync_SyncMode_PollsUntilTerminal()
+    {
+        // Arrange
+        var executionId = Guid.NewGuid();
+        var services = new ServiceCollection();
+        var executions = new FakeExecutionService
+        {
+            StartResult = new ExecutionResponse
+            {
+                DisplayId = "wf-sync",
+                ResourceId = executionId,
+                Status = "Running",
+            },
+            PollResults =
+            [
+                new ExecutionResponse { DisplayId = "wf-sync", ResourceId = executionId, Status = "Running" },
+                new ExecutionResponse { DisplayId = "wf-sync", ResourceId = executionId, Status = "Completed" },
+            ]
+        };
+        services.AddSingleton<IExecutionService>(executions);
+        services.AddSingleton<ITenantContextAccessor>(new FakeTenantContextAccessor(Guid.NewGuid()));
+        await using var provider = services.BuildServiceProvider();
+        var runner = new ChildWorkflowRunner(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            provider.GetRequiredService<ITenantContextAccessor>());
+
+        // Act
+        var result = await runner.RunAsync(
+            new ChildWorkflowRequest("def-1", "sync", Input: new { x = 1 }, Timeout: TimeSpan.FromSeconds(5)),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal("Completed", result.Status);
+        Assert.True(executions.GetCallCount >= 1);
+    }
+
+    /// <summary>sync が終端に達しないと TimeoutException。</summary>
+    [Fact]
+    public async Task RunAsync_SyncMode_WhenNeverTerminal_ThrowsTimeout()
+    {
+        // Arrange
+        var executionId = Guid.NewGuid();
+        var services = new ServiceCollection();
+        services.AddSingleton<IExecutionService>(new FakeExecutionService
+        {
+            StartResult = new ExecutionResponse
+            {
+                DisplayId = "wf-to",
+                ResourceId = executionId,
+                Status = "Running",
+            }
+        });
+        services.AddSingleton<ITenantContextAccessor>(new FakeTenantContextAccessor(Guid.NewGuid()));
+        await using var provider = services.BuildServiceProvider();
+        var runner = new ChildWorkflowRunner(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            provider.GetRequiredService<ITenantContextAccessor>());
+
+        // Act + Assert
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            runner.RunAsync(
+                new ChildWorkflowRequest("def-1", "sync", null, TimeSpan.FromMilliseconds(50)),
+                CancellationToken.None));
+    }
+
+    /// <summary>JsonElement 入力はそのまま Start に渡る。</summary>
+    [Fact]
+    public async Task RunAsync_WithJsonElementInput_StartsSuccessfully()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var executions = new FakeExecutionService
+        {
+            StartResult = new ExecutionResponse
+            {
+                DisplayId = "wf-json",
+                ResourceId = Guid.NewGuid(),
+                Status = "Running",
+            }
+        };
+        services.AddSingleton<IExecutionService>(executions);
+        services.AddSingleton<ITenantContextAccessor>(new FakeTenantContextAccessor(Guid.NewGuid()));
+        await using var provider = services.BuildServiceProvider();
+        var runner = new ChildWorkflowRunner(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            provider.GetRequiredService<ITenantContextAccessor>());
+        using var doc = JsonDocument.Parse("""{"k":"v"}""");
+
+        // Act
+        var result = await runner.RunAsync(
+            new ChildWorkflowRequest("def-1", "async", doc.RootElement, null),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal("Running", result.Status);
+    }
+
     private sealed class FakeTenantContextAccessor : ITenantContextAccessor
     {
         private readonly Guid? _tenantId;
@@ -77,12 +177,18 @@ public sealed class ChildWorkflowRunnerTests
 
     private sealed class FakeExecutionService : IExecutionService
     {
+        private int _pollIndex;
+
         public ExecutionResponse StartResult { get; init; } = new()
         {
             DisplayId = "wf",
             ResourceId = Guid.NewGuid(),
             Status = "Running",
         };
+
+        public IReadOnlyList<ExecutionResponse> PollResults { get; init; } = [];
+
+        public int GetCallCount { get; private set; }
 
         public Task<ExecutionResponse> StartAsync(
             StartExecutionRequest request,
@@ -94,8 +200,18 @@ public sealed class ChildWorkflowRunnerTests
         public Task<PagedResult<ExecutionResponse>> ListPagedAsync(ExecutionListPageQuery query, CancellationToken ct) =>
             throw new NotImplementedException();
 
-        public Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct) =>
-            Task.FromResult(StartResult);
+        public Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct)
+        {
+            GetCallCount += 1;
+            if (_pollIndex < PollResults.Count)
+            {
+                var next = PollResults[_pollIndex];
+                _pollIndex += 1;
+                return Task.FromResult(next);
+            }
+
+            return Task.FromResult(StartResult);
+        }
 
         public Task EnsureExecutionExistsAsync(Guid executionId, CancellationToken ct) =>
             Task.CompletedTask;

--- a/service/api/Statevia.Service.Api.Tests/Application/Actions/Validation/ActionInputSchemaValidatorTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Actions/Validation/ActionInputSchemaValidatorTests.cs
@@ -324,6 +324,196 @@ public sealed class ActionInputSchemaValidatorTests
         Assert.Empty(errors);
     }
 
+    /// <summary>path 専用フィールドにリテラルを渡すとエラーになる。</summary>
+    [Fact]
+    public void Validate_PathOnlyField_WithLiteral_ReturnsError()
+    {
+        // Arrange
+        var schema = ParseSchema(
+            """
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ref": {
+                  "type": "string",
+                  "x-statevia-valueKind": "path"
+                }
+              }
+            }
+            """);
+        var input = CreateValuesInput(("ref", "plain"));
+
+        // Act
+        var errors = ActionInputSchemaValidator.Validate(StateName, ActionId, input, schema);
+
+        // Assert
+        Assert.Contains(errors, e => e.JsonPath.Contains("ref", StringComparison.Ordinal));
+    }
+
+    /// <summary>oneOf に一致しないリテラルはエラーになる。</summary>
+    [Fact]
+    public void Validate_OneOfLiteral_WhenNoVariantMatches_ReturnsError()
+    {
+        // Arrange
+        var schema = ParseSchema(
+            """
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "mode": {
+                  "oneOf": [
+                    { "type": "string", "enum": ["a"] },
+                    { "type": "integer" }
+                  ]
+                }
+              }
+            }
+            """);
+        var input = new StateInputDefinition
+        {
+            Values = new Dictionary<string, StateInputValueDefinition>
+            {
+                ["mode"] = new() { Literal = true }
+            }
+        };
+
+        // Act
+        var errors = ActionInputSchemaValidator.Validate(StateName, ActionId, input, schema);
+
+        // Assert
+        Assert.NotEmpty(errors);
+    }
+
+    /// <summary>integer の minimum 未満はエラーになる。</summary>
+    [Fact]
+    public void Validate_IntegerBelowMinimum_ReturnsError()
+    {
+        // Arrange
+        var schema = ParseSchema(
+            """
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            }
+            """);
+        var input = new StateInputDefinition
+        {
+            Values = new Dictionary<string, StateInputValueDefinition>
+            {
+                ["count"] = new() { Literal = 0 }
+            }
+        };
+
+        // Act
+        var errors = ActionInputSchemaValidator.Validate(StateName, ActionId, input, schema);
+
+        // Assert
+        Assert.NotEmpty(errors);
+    }
+
+    /// <summary>email format 不正は MatchesString で弾かれる。</summary>
+    [Fact]
+    public void Validate_EmailFormatInvalid_ReturnsError()
+    {
+        // Arrange
+        var schema = ParseSchema(
+            """
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "to": {
+                  "type": "string",
+                  "format": "email"
+                }
+              }
+            }
+            """);
+        var input = CreateValuesInput(("to", "@invalid"));
+
+        // Act
+        var errors = ActionInputSchemaValidator.Validate(StateName, ActionId, input, schema);
+
+        // Assert
+        Assert.NotEmpty(errors);
+    }
+
+    /// <summary>type 配列の不一致メッセージを返す。</summary>
+    [Fact]
+    public void Validate_TypeArrayMismatch_ReturnsCombinedExpectedMessage()
+    {
+        // Arrange
+        var schema = ParseSchema(
+            """
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "value": {
+                  "type": ["string", "null"]
+                }
+              }
+            }
+            """);
+        var input = new StateInputDefinition
+        {
+            Values = new Dictionary<string, StateInputValueDefinition>
+            {
+                ["value"] = new() { Literal = 42 }
+            }
+        };
+
+        // Act
+        var errors = ActionInputSchemaValidator.Validate(StateName, ActionId, input, schema);
+
+        // Assert
+        Assert.Contains(errors, e => e.Message.Contains("string", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>additionalProperties false のオブジェクトリテラルにキーがあると失敗する。</summary>
+    [Fact]
+    public void Validate_ObjectLiteral_WithDisallowedAdditionalProperties_ReturnsError()
+    {
+        // Arrange
+        var schema = ParseSchema(
+            """
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "meta": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              }
+            }
+            """);
+        var input = new StateInputDefinition
+        {
+            Values = new Dictionary<string, StateInputValueDefinition>
+            {
+                ["meta"] = new()
+                {
+                    Literal = new Dictionary<string, object?> { ["k"] = "v" }
+                }
+            }
+        };
+
+        // Act
+        var errors = ActionInputSchemaValidator.Validate(StateName, ActionId, input, schema);
+
+        // Assert
+        Assert.NotEmpty(errors);
+    }
+
     private static StateInputDefinition CreateValuesInput(params (string Key, string Value)[] entries)
     {
         var values = entries.ToDictionary(

--- a/service/api/Statevia.Service.Api.Tests/Application/Actions/Versioning/ModuleVersionRangeTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Actions/Versioning/ModuleVersionRangeTests.cs
@@ -1,0 +1,61 @@
+using Statevia.Service.Api.Application.Actions.Versioning;
+
+namespace Statevia.Service.Api.Tests.Application.Actions.Versioning;
+
+/// <summary><see cref="ModuleVersionRange"/> の解析と Satisfies。</summary>
+public sealed class ModuleVersionRangeTests
+{
+    /// <summary>空 / LATEST は最新安定レンジになる。</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("LATEST")]
+    [InlineData("*")]
+    public void Parse_LatestExpressions_AreLatest(string? expression)
+    {
+        // Act
+        var range = ModuleVersionRange.Parse(expression);
+
+        // Assert
+        Assert.True(range.IsLatest);
+        Assert.False(range.IsExact);
+        Assert.True(range.Satisfies(ModuleVersion.Parse("1.2.3")));
+        Assert.False(range.Satisfies(ModuleVersion.Parse("1.2.3-rc.1")));
+    }
+
+    /// <summary>exact / caret / tilde / bare を解析できる。</summary>
+    [Theory]
+    [InlineData("=1.2.3", true, "1.2.3", true)]
+    [InlineData("1.2.3", true, "1.2.3", true)]
+    [InlineData("^1.2.3", false, "1.2.4", true)]
+    [InlineData("^1.2.3", false, "2.0.0", false)]
+    [InlineData("~1.2.3", false, "1.2.9", true)]
+    [InlineData("~1.2.3", false, "1.3.0", false)]
+    [InlineData("1.2", false, "1.2.5", true)]
+    [InlineData("1.x", false, "1.9.0", true)]
+    [InlineData("1", false, "1.0.0", true)]
+    public void Parse_CommonForms_SatisfiesExpected(
+        string expression,
+        bool expectExact,
+        string candidate,
+        bool expected)
+    {
+        // Arrange
+        var range = ModuleVersionRange.Parse(expression);
+
+        // Act
+        var ok = range.Satisfies(ModuleVersion.Parse(candidate));
+
+        // Assert
+        Assert.Equal(expectExact, range.IsExact);
+        Assert.Equal(expected, ok);
+    }
+
+    /// <summary>不正な式は FormatException。</summary>
+    [Fact]
+    public void Parse_InvalidExpression_ThrowsFormatException()
+    {
+        // Act + Assert
+        Assert.Throws<FormatException>(() => ModuleVersionRange.Parse("!!"));
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Application/Definition/CompiledDefinitionJsonReaderTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Definition/CompiledDefinitionJsonReaderTests.cs
@@ -125,6 +125,92 @@ public sealed class CompiledDefinitionJsonReaderTests
         Assert.Throws<ArgumentNullException>(() => CompiledDefinitionJsonReader.Read(MinimalCompiledJson, null!));
     }
 
+    /// <summary>bindings 有無を判定できる。</summary>
+    [Fact]
+    public void HasStoredBindings_DetectsPresence()
+    {
+        // Arrange
+        const string withBindings = """
+            {
+              "name": "W",
+              "initialState": "A",
+              "transitions": {},
+              "stateActionBindings": {
+                "A": {
+                  "logicalActionId": "demo.echo",
+                  "resolvedModuleVersion": "1.0.0",
+                  "moduleId": "demo",
+                  "actionName": "echo"
+                }
+              }
+            }
+            """;
+
+        // Act + Assert
+        Assert.True(CompiledDefinitionJsonReader.HasStoredBindings(withBindings));
+        Assert.False(CompiledDefinitionJsonReader.HasStoredBindings(MinimalCompiledJson));
+    }
+
+    /// <summary>ReadStoredBindings は modules / bindings を返す。</summary>
+    [Fact]
+    public void ReadStoredBindings_ReturnsMaps()
+    {
+        // Arrange
+        const string json = """
+            {
+              "name": "W",
+              "initialState": "A",
+              "transitions": {},
+              "resolvedModules": {
+                "mail": { "moduleId": "demo.module", "resolvedVersion": "1.0.0" }
+              },
+              "stateActionBindings": {
+                "A": {
+                  "logicalActionId": "demo.module.echo",
+                  "resolvedModuleVersion": "1.0.0",
+                  "moduleId": "demo.module",
+                  "actionName": "echo"
+                }
+              }
+            }
+            """;
+
+        // Act
+        var (modules, bindings) = CompiledDefinitionJsonReader.ReadStoredBindings(json);
+
+        // Assert
+        Assert.Equal("demo.module", modules["mail"].ModuleId);
+        Assert.Equal("echo", bindings["A"].ActionName);
+    }
+
+    /// <summary>end 付き遷移と Wait ルートを復元する。</summary>
+    [Fact]
+    public void Read_WithEndTransitionAndWaitRoute_RestoresTables()
+    {
+        // Arrange
+        const string json = """
+            {
+              "name": "W",
+              "initialState": "A",
+              "transitions": {
+                "A": { "Ok": { "end": true } }
+              },
+              "waitEventRouteTable": {
+                "W1": {
+                  "done": { "next": "End" }
+                }
+              }
+            }
+            """;
+
+        // Act
+        var compiled = CompiledDefinitionJsonReader.Read(json, new StubExecutorFactory());
+
+        // Assert
+        Assert.True(compiled.Transitions["A"]["Ok"].End);
+        Assert.Equal("End", compiled.WaitEventRouteTable["W1"]["done"].Next);
+    }
+
     private sealed class StubExecutorFactory : IStateExecutorFactory
     {
         public IStateExecutor? GetExecutor(string stateName) => null;

--- a/service/api/Statevia.Service.Api.Tests/Application/Definition/NodesWorkflowDefinitionLoaderTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Definition/NodesWorkflowDefinitionLoaderTests.cs
@@ -1503,4 +1503,297 @@ public sealed class NodesWorkflowDefinitionLoaderTests
         Assert.Contains("retry", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("input", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>wait で exits を使うと拒否する。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitUsesExits()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitExits
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                exits:
+                  done: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.Contains("must not use 'exits'", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>wait で events と subscribe の併用は拒否する。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitHasEventsAndSubscribe()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitBoth
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                events:
+                  done: endNode
+                subscribe:
+                  - topic: t
+                    next: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.Contains("both 'events' and 'subscribe'", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>wait で events と legacy event の併用は拒否する。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitHasEventsAndLegacyEvent()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitEventsAndEvent
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                event: done
+                events:
+                  done: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.Contains("both 'events' and 'event'", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>wait.subscribe を正規化する。</summary>
+    [Fact]
+    public void Load_WaitNode_ParsesSubscribeList()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitSubscribe
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                subscribe:
+                  - topic: orders
+                    key: "$.id"
+                    next: endNode
+                  - topic: cancel
+                    next: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var definition = _loader.Load(yaml);
+
+        // Assert
+        var subscribe = definition.States["wait1"].Wait?.Subscribe;
+        Assert.NotNull(subscribe);
+        Assert.Equal(2, subscribe!.Count);
+        Assert.Equal("orders", subscribe[0].Topic);
+        Assert.Equal("$.id", subscribe[0].Key);
+        Assert.Equal("endNode", subscribe[0].Next);
+    }
+
+    /// <summary>空の subscribe は拒否する。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitSubscribeEmpty()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitSubscribeEmpty
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                subscribe: []
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.Contains("subscribe must not be empty", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>subscribe がリストでないとき拒否する。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitSubscribeNotList()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitSubscribeScalar
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                subscribe: not-a-list
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.Contains("subscribe must be a list", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>events の next が空なら拒否する。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitEventsTargetEmpty()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitEventsEmptyTarget
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                events:
+                  done: ""
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.Contains("must specify a next node name", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>events が空マップなら拒否する。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitEventsMapEmpty()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitEventsEmpty
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                events: {}
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.Contains("non-empty 'events'", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>events の重複キーは拒否する（YAML では後勝ちになり得るため JSON 相当で検証）。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitEventsDuplicateKeyViaObject()
+    {
+        // Arrange — ローダーは Dictionary 構築時に TryAdd 失敗を検出する経路を持つ。
+        // YAML では同一キーが後勝ちになるため、直接 Compiled 前の nodes 形式で
+        // 空キーを使って events キー検証を別経路でカバーする。
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitEventsEmptyKey
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                events:
+                  " ": endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.Contains("events keys must be non-empty", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>events が null 相当のとき拒否する。</summary>
+    [Fact]
+    public void Load_Throws_WhenWaitEventsIsNull()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: WaitEventsNull
+            nodes:
+              - name: start
+                type: start
+                next: wait1
+              - name: wait1
+                type: wait
+                events:
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+
+        // Assert
+        Assert.True(
+            ex.Message.Contains("events", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("subscribe", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/service/api/Statevia.Service.Api.Tests/Application/Definition/StoredDefinitionBindingResolverTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Definition/StoredDefinitionBindingResolverTests.cs
@@ -1,0 +1,174 @@
+using Statevia.Core.Actions.Abstractions.Catalog;
+using Statevia.Core.Engine.Definition;
+using Statevia.Service.Api.Application.Actions;
+using Statevia.Service.Api.Application.Actions.Catalog;
+using Statevia.Service.Api.Application.Actions.Versioning;
+using Statevia.Service.Api.Application.Definition;
+
+namespace Statevia.Service.Api.Tests.Application.Definition;
+
+/// <summary><see cref="StoredDefinitionBindingResolver"/> の単体テスト。</summary>
+public sealed class StoredDefinitionBindingResolverTests
+{
+    private const string CompiledJsonWithoutBindings = """
+        {
+          "name": "W",
+          "initialState": "A",
+          "transitions": {}
+        }
+        """;
+
+    /// <summary>保存済みピン版がロード済みなら bindings をそのまま返す。</summary>
+    [Fact]
+    public void Resolve_WhenStoredBindingsPresentAndPinnedVersionLoaded_ReturnsStoredBindings()
+    {
+        // Arrange
+        var catalog = CreateCatalog("demo.module", ["1.0.0"]);
+        var definition = CreateDefinition(("A", ActionState("demo.module.echo")));
+        var compiledJson = """
+            {
+              "name": "W",
+              "initialState": "A",
+              "transitions": {},
+              "resolvedModules": {
+                "mail": { "moduleId": "demo.module", "resolvedVersion": "1.0.0" }
+              },
+              "stateActionBindings": {
+                "A": {
+                  "logicalActionId": "demo.module.echo",
+                  "resolvedModuleVersion": "1.0.0",
+                  "moduleId": "demo.module",
+                  "actionName": "echo"
+                }
+              }
+            }
+            """;
+
+        // Act
+        var result = StoredDefinitionBindingResolver.Resolve(definition, compiledJson, catalog);
+
+        // Assert
+        Assert.Equal("1.0.0", result.StateActionBindings["A"].ResolvedModuleVersion);
+        Assert.Equal("demo.module", result.StateActionBindings["A"].ModuleId);
+    }
+
+    /// <summary>ピン版が未ロードなら MigrationRequired になる。</summary>
+    [Fact]
+    public void Resolve_WhenStoredPinnedVersionNotLoaded_ThrowsDefinitionMigrationRequiredException()
+    {
+        // Arrange
+        var catalog = CreateCatalog("demo.module", ["1.0.0"]);
+        var definition = CreateDefinition(("A", ActionState("demo.module.echo")));
+        var compiledJson = """
+            {
+              "name": "W",
+              "initialState": "A",
+              "transitions": {},
+              "stateActionBindings": {
+                "A": {
+                  "logicalActionId": "demo.module.echo",
+                  "resolvedModuleVersion": "9.9.9",
+                  "moduleId": "demo.module",
+                  "actionName": "echo"
+                }
+              }
+            }
+            """;
+
+        // Act + Assert
+        var ex = Assert.Throws<DefinitionMigrationRequiredException>(
+            () => StoredDefinitionBindingResolver.Resolve(definition, compiledJson, catalog));
+        Assert.Contains("9.9.9", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>bindings が無いときは Legacy Bind にフォールバックする。</summary>
+    [Fact]
+    public void Resolve_WhenNoStoredBindings_FallsBackToLegacyBind()
+    {
+        // Arrange
+        var catalog = CreateCatalog("demo.module", ["1.2.3"]);
+        var definition = CreateDefinition(("A", ActionState("demo.module.echo")));
+
+        // Act
+        var result = StoredDefinitionBindingResolver.Resolve(
+            definition,
+            CompiledJsonWithoutBindings,
+            catalog);
+
+        // Assert
+        Assert.Equal("1.2.3", result.StateActionBindings["A"].ResolvedModuleVersion);
+    }
+
+    /// <summary>Legacy で Module に複数版があると MigrationRequired になる。</summary>
+    [Fact]
+    public void Resolve_WhenLegacyFqcnHasMultipleVersions_ThrowsDefinitionMigrationRequiredException()
+    {
+        // Arrange
+        var catalog = CreateCatalog("demo.module", ["1.0.0", "2.0.0"]);
+        var definition = CreateDefinition(("A", ActionState("demo.module.echo")));
+
+        // Act + Assert
+        var ex = Assert.Throws<DefinitionMigrationRequiredException>(
+            () => StoredDefinitionBindingResolver.Resolve(
+                definition,
+                CompiledJsonWithoutBindings,
+                catalog));
+        Assert.Contains("multiple loaded versions", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>引数検証: null / 空白で例外になる。</summary>
+    [Fact]
+    public void Resolve_InvalidArguments_Throw()
+    {
+        // Arrange
+        var catalog = new InMemoryActionCatalog();
+        var definition = CreateDefinition(("A", ActionState("noop")));
+
+        // Act + Assert
+        Assert.Throws<ArgumentNullException>(
+            () => StoredDefinitionBindingResolver.Resolve(null!, CompiledJsonWithoutBindings, catalog));
+        Assert.Throws<ArgumentException>(
+            () => StoredDefinitionBindingResolver.Resolve(definition, "  ", catalog));
+        Assert.Throws<ArgumentNullException>(
+            () => StoredDefinitionBindingResolver.Resolve(definition, CompiledJsonWithoutBindings, null!));
+    }
+
+    private static InMemoryActionCatalog CreateCatalog(string moduleId, IReadOnlyList<string> versions)
+    {
+        var catalog = new InMemoryActionCatalog();
+        foreach (var version in versions)
+        {
+            catalog.Register(
+                new ActionDescriptor
+                {
+                    ActionId = $"{moduleId}.echo",
+                    ModuleId = moduleId,
+                    Version = version,
+                    TrustLevel = ActionTrustLevel.Community,
+                    Source = ActionSourceKind.Filesystem,
+                    OwnerTenantId = "11111111-1111-1111-1111-111111111111",
+                    Visibility = ActionVisibility.Tenant,
+                },
+                new ActionCatalogEntry(InProcessFactory: _ => throw new NotSupportedException()));
+        }
+
+        return catalog;
+    }
+
+    private static WorkflowDefinition CreateDefinition(params (string Name, StateDefinition State)[] states) =>
+        new()
+        {
+            Name = "W",
+            States = states.ToDictionary(s => s.Name, s => s.State, StringComparer.OrdinalIgnoreCase),
+        };
+
+    private static StateDefinition ActionState(string? action) =>
+        new()
+        {
+            Action = action,
+            On = new Dictionary<string, TransitionDefinition>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Completed"] = new TransitionDefinition { End = true },
+            },
+        };
+}

--- a/service/api/Statevia.Service.Api.Tests/Contracts/Admin/AdminContractsValidationTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Contracts/Admin/AdminContractsValidationTests.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using Statevia.Service.Api.Contracts.Admin;
+
+namespace Statevia.Service.Api.Tests.Contracts.Admin;
+
+/// <summary>AdminContracts の IValidatableObject 検証。</summary>
+public sealed class AdminContractsValidationTests
+{
+    /// <summary>CreateAdminUserRequest は email / password 必須。</summary>
+    [Fact]
+    public void CreateAdminUserRequest_Validate_RequiresEmailAndPassword()
+    {
+        // Arrange
+        var request = new CreateAdminUserRequest { Email = " ", Password = "" };
+        var context = new ValidationContext(request);
+
+        // Act
+        var results = request.Validate(context).ToList();
+
+        // Assert
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(CreateAdminUserRequest.Email)));
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(CreateAdminUserRequest.Password)));
+    }
+
+    /// <summary>CreateAdminApiKeyRequest の name / scopes / expiresAt を検証する。</summary>
+    [Fact]
+    public void CreateAdminApiKeyRequest_Validate_CoversNameScopesAndExpiry()
+    {
+        // Arrange
+        var blank = new CreateAdminApiKeyRequest
+        {
+            Name = " ",
+            AllowedScopes = Array.Empty<string>(),
+            ExpiresAt = DateTime.UtcNow.AddMinutes(-1)
+        };
+        var tooLong = new CreateAdminApiKeyRequest
+        {
+            Name = new string('a', 200),
+            AllowedScopes = ["executions.read"]
+        };
+
+        // Act
+        var blankResults = blank.Validate(new ValidationContext(blank)).ToList();
+        var longResults = tooLong.Validate(new ValidationContext(tooLong)).ToList();
+
+        // Assert
+        Assert.Contains(blankResults, r => r.MemberNames.Contains(nameof(CreateAdminApiKeyRequest.Name)));
+        Assert.Contains(blankResults, r => r.MemberNames.Contains(nameof(CreateAdminApiKeyRequest.AllowedScopes)));
+        Assert.Contains(blankResults, r => r.MemberNames.Contains(nameof(CreateAdminApiKeyRequest.ExpiresAt)));
+        Assert.Contains(longResults, r => r.MemberNames.Contains(nameof(CreateAdminApiKeyRequest.Name)));
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Persistence/ExecutionMutationPersistenceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Persistence/ExecutionMutationPersistenceTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using Statevia.Core.Application.Configuration;
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Service.Api.Hosting;
+using Statevia.Service.Api.Persistence;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Persistence;
+
+/// <summary>ExecutionMutationPersistence の単体テスト。</summary>
+public sealed class ExecutionMutationPersistenceTests
+{
+    private static readonly IOptions<EventDeliveryRetryOptions> RetryOptions = Options.Create(
+        new EventDeliveryRetryOptions
+        {
+            MaxAttempts = 3,
+            BaseDelayMs = 0,
+            MaxDelayMs = 1,
+            Jitter = false,
+            MaxTotalBackoffMs = 10_000,
+            SerializablePersistenceMaxAttempts = 3
+        });
+
+    /// <summary>成功時は apply → SaveChanges → Commit で完了する。</summary>
+    [Fact]
+    public async Task ExecuteSerializableWithRetryAsync_WhenApplySucceeds_CommitsOnce()
+    {
+        // Arrange
+        using var sqlite = new SqliteTestDatabase();
+        var dedup = new RecordingEventDeliveryDedup();
+        var sut = CreateSut(sqlite, dedup);
+        var applyCalls = 0;
+
+        // Act
+        await sut.ExecuteSerializableWithRetryAsync(
+            TestTenantIds.T1TenantId,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            (_, _) =>
+            {
+                applyCalls++;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, applyCalls);
+        Assert.Equal(0, dedup.FailedStatusUpdates);
+    }
+
+    /// <summary>再試行可能な Serializable 競合は maxAttempts まで再実行する。</summary>
+    [Fact]
+    public async Task ExecuteSerializableWithRetryAsync_WhenSerializableConflictRetriesExhausted_MarksFailedAndThrows()
+    {
+        // Arrange
+        using var sqlite = new SqliteTestDatabase();
+        var dedup = new RecordingEventDeliveryDedup();
+        var sut = CreateSut(sqlite, dedup);
+        var applyCalls = 0;
+
+        // Act
+        var ex = await Assert.ThrowsAsync<DbUpdateException>(() =>
+            sut.ExecuteSerializableWithRetryAsync(
+                TestTenantIds.T1TenantId,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                (_, _) =>
+                {
+                    applyCalls++;
+                    var pg = new PostgresException(
+                        messageText: "could not serialize access",
+                        severity: "ERROR",
+                        invariantSeverity: "ERROR",
+                        sqlState: "40001");
+                    throw new DbUpdateException("serialize conflict", pg);
+                },
+                CancellationToken.None));
+
+        // Assert
+        Assert.Equal(3, applyCalls);
+        Assert.IsType<PostgresException>(ex.InnerException);
+        Assert.True(dedup.FailedStatusUpdates >= 1);
+    }
+
+    /// <summary>タイムアウト系は再試行せず Failed を付けて再throw する。</summary>
+    [Fact]
+    public async Task ExecuteSerializableWithRetryAsync_WhenOperationCanceled_MarksFailedAndRethrows()
+    {
+        // Arrange
+        using var sqlite = new SqliteTestDatabase();
+        var dedup = new RecordingEventDeliveryDedup();
+        var sut = CreateSut(sqlite, dedup);
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            sut.ExecuteSerializableWithRetryAsync(
+                TestTenantIds.T1TenantId,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                (_, _) => throw new OperationCanceledException("cancelled in apply"),
+                CancellationToken.None));
+
+        // Assert
+        Assert.True(dedup.FailedStatusUpdates >= 1);
+    }
+
+    private static ExecutionMutationPersistence CreateSut(
+        SqliteTestDatabase sqlite,
+        IEventDeliveryDedupRepository dedup)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items[RequestLogContext.TraceIdItemKey] = "trace-mutation";
+        return new ExecutionMutationPersistence(
+            new TestCoreUnitOfWorkFactory(sqlite.Factory),
+            dedup,
+            RetryOptions,
+            new HttpContextAccessor { HttpContext = httpContext },
+            NullLogger<ExecutionMutationPersistence>.Instance);
+    }
+
+    private sealed class RecordingEventDeliveryDedup : IEventDeliveryDedupRepository
+    {
+        public int FailedStatusUpdates { get; private set; }
+
+        public Task AddReceivedAsync(
+            ICoreUnitOfWork uow,
+            EventDeliveryDedupRow row,
+            CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public Task<EventDeliveryDedupRow?> FindAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            Guid executionId,
+            Guid clientEventId,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<EventDeliveryDedupRow?>(null);
+
+        public Task<bool> TryUpdateStatusAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            Guid executionId,
+            Guid clientEventId,
+            EventDeliveryDedupStatusUpdate update,
+            CancellationToken cancellationToken)
+        {
+            _ = uow;
+            if (update.Status == EventDeliveryDedupStatuses.Failed)
+                FailedStatusUpdates++;
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/DisplayIdServiceImplTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/DisplayIdServiceImplTests.cs
@@ -227,5 +227,31 @@ public sealed class DisplayIdServiceImplTests
         var dict = await sut.GetDisplayIdsAsync("definition", new[] { id1, id1, id2 }, CancellationToken.None);
         Assert.Equal(new Dictionary<Guid, string> { [id1] = "D1", [id2] = "D2" }, dict);
     }
+
+    /// <summary>AllocateAsync は一意な display_id を採番する。</summary>
+    [Fact]
+    public async Task AllocateAsync_ReturnsUniqueDisplayId()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var sut = new DisplayIdServiceImpl(new TestCoreTransactionExecutor(new TestCoreUnitOfWorkFactory(db.Factory)));
+        var resourceId = Guid.NewGuid();
+        string allocated;
+
+        // Act
+        await using (var ctx = await db.Factory.CreateDbContextAsync())
+        {
+            await using var uow = new CoreUnitOfWork(ctx);
+            allocated = await sut.AllocateAsync(uow, "definition", resourceId, CancellationToken.None);
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Equal(10, allocated.Length);
+        await using var verify = await db.Factory.CreateDbContextAsync();
+        var row = await verify.DisplayIds.SingleAsync(x => x.DisplayId == allocated);
+        Assert.Equal(resourceId, row.ResourceId);
+        Assert.Equal("definition", row.Kind);
+    }
 }
 

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionOwnershipRecoveryHostedServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionOwnershipRecoveryHostedServiceTests.cs
@@ -1,28 +1,57 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Statevia.Core.Application.Contracts.Persistence;
 using Statevia.Runtime.Services;
 
 namespace Statevia.Service.Api.Tests.Services;
 
-/// <summary>DelayWaitScheduler が排他 claim API のみを呼ぶことの単体テスト。</summary>
-public sealed class DelayWaitSchedulerHostedServiceTests
+/// <summary>ExecutionOwnershipRecoveryHostedService の単体テスト（Runtime カバレッジ用）。</summary>
+public sealed class ExecutionOwnershipRecoveryHostedServiceTests
 {
-    /// <summary>イテレーションごとに EnqueueExpiredDelayWaitResumesAsync だけを呼ぶ。</summary>
+    /// <summary>イテレーションごとに EnqueueExpiredOwnershipRecoveriesAsync を呼ぶ。</summary>
     [Fact]
-    public async Task ExecuteAsync_CallsExclusiveClaimEnqueueApi()
+    public async Task ExecuteAsync_CallsOwnershipRecoveryEnqueueApi()
     {
         // Arrange
-        var queue = new RecordingWorkQueue();
+        var queue = new RecordingOwnershipQueue();
         var services = new ServiceCollection();
         services.AddSingleton<IExecutionWorkQueue>(queue);
         await using var provider = services.BuildServiceProvider();
-        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        var sut = new ExecutionOwnershipRecoveryHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionOwnershipRecoveryHostedService>.Instance);
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(180), CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            // テスト側待機キャンセルは無視する。
+        }
+
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(queue.EnqueueOwnershipRecoveryCallCount >= 1);
+    }
+
+    /// <summary>batch 上限に達したときは idle delay を挟まず再ポーリングする。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenBatchFull_ReclaimsWithoutIdleDelay()
+    {
+        // Arrange
+        var queue = new RecordingOwnershipQueue { EnqueueResult = 64 };
+        var services = new ServiceCollection();
+        services.AddSingleton<IExecutionWorkQueue>(queue);
+        await using var provider = services.BuildServiceProvider();
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
-        var sut = new DelayWaitSchedulerHostedService(
-            scopeFactory,
-            NullLogger<DelayWaitSchedulerHostedService>.Instance);
+        var sut = new ExecutionOwnershipRecoveryHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionOwnershipRecoveryHostedService>.Instance);
 
         // Act
         await sut.StartAsync(cts.Token);
@@ -32,60 +61,28 @@ public sealed class DelayWaitSchedulerHostedServiceTests
         }
         catch (OperationCanceledException)
         {
-            // テスト側の待機キャンセルは無視する。
-        }
-
-        await sut.StopAsync(CancellationToken.None);
-
-        // Assert
-        Assert.True(queue.EnqueueExpiredDelayWaitCallCount >= 1);
-        Assert.Equal(0, queue.EnqueueManyCallCount);
-    }
-
-    /// <summary>バッチ上限いっぱいなら idle delay なしで再ポーリングする。</summary>
-    [Fact]
-    public async Task ExecuteAsync_WhenBatchFull_ContinuesWithoutIdleDelay()
-    {
-        // Arrange
-        var queue = new RecordingWorkQueue { EnqueueResult = 64 };
-        var services = new ServiceCollection();
-        services.AddSingleton<IExecutionWorkQueue>(queue);
-        await using var provider = services.BuildServiceProvider();
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
-        var sut = new DelayWaitSchedulerHostedService(
-            provider.GetRequiredService<IServiceScopeFactory>(),
-            NullLogger<DelayWaitSchedulerHostedService>.Instance);
-
-        // Act
-        await sut.StartAsync(cts.Token);
-        try
-        {
-            await Task.Delay(TimeSpan.FromMilliseconds(180), CancellationToken.None);
-        }
-        catch (OperationCanceledException)
-        {
             // ignore
         }
 
         await sut.StopAsync(CancellationToken.None);
 
-        // Assert — idle 5s を挟まないため短時間で複数回呼べる
-        Assert.True(queue.EnqueueExpiredDelayWaitCallCount >= 2);
+        // Assert: idle 5s を挟まないため短時間で複数回呼ばれる
+        Assert.True(queue.EnqueueOwnershipRecoveryCallCount >= 2);
     }
 
-    /// <summary>enqueue 例外でもポーリングを継続する。</summary>
+    /// <summary>キュー API が例外でも反復が継続する。</summary>
     [Fact]
     public async Task ExecuteAsync_WhenEnqueueThrows_ContinuesPolling()
     {
         // Arrange
-        var queue = new RecordingWorkQueue { ThrowOnEnqueue = true };
+        var queue = new RecordingOwnershipQueue { ThrowOnEnqueue = true };
         var services = new ServiceCollection();
         services.AddSingleton<IExecutionWorkQueue>(queue);
         await using var provider = services.BuildServiceProvider();
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
-        var sut = new DelayWaitSchedulerHostedService(
+        var sut = new ExecutionOwnershipRecoveryHostedService(
             provider.GetRequiredService<IServiceScopeFactory>(),
-            NullLogger<DelayWaitSchedulerHostedService>.Instance);
+            NullLogger<ExecutionOwnershipRecoveryHostedService>.Instance);
 
         // Act
         await sut.StartAsync(cts.Token);
@@ -101,13 +98,12 @@ public sealed class DelayWaitSchedulerHostedServiceTests
         await sut.StopAsync(CancellationToken.None);
 
         // Assert
-        Assert.True(queue.EnqueueExpiredDelayWaitCallCount >= 1);
+        Assert.True(queue.EnqueueOwnershipRecoveryCallCount >= 1);
     }
 
-    private sealed class RecordingWorkQueue : IExecutionWorkQueue
+    private sealed class RecordingOwnershipQueue : IExecutionWorkQueue
     {
-        public int EnqueueExpiredDelayWaitCallCount { get; private set; }
-        public int EnqueueManyCallCount { get; private set; }
+        public int EnqueueOwnershipRecoveryCallCount { get; private set; }
         public int EnqueueResult { get; set; }
         public bool ThrowOnEnqueue { get; set; }
 
@@ -117,11 +113,8 @@ public sealed class DelayWaitSchedulerHostedServiceTests
         public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
             throw new NotImplementedException();
 
-        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
-        {
-            EnqueueManyCallCount++;
-            return Task.CompletedTask;
-        }
+        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct) =>
+            throw new NotImplementedException();
 
         public Task EnqueueManyAsync(
             ICoreUnitOfWork uow,
@@ -158,18 +151,18 @@ public sealed class DelayWaitSchedulerHostedServiceTests
         public Task<int> EnqueueExpiredOwnershipRecoveriesAsync(
             DateTime nowUtc,
             int limit,
-            CancellationToken ct) =>
-            throw new NotImplementedException();
-
-        public Task<int> EnqueueExpiredDelayWaitResumesAsync(
-            DateTime nowUtc,
-            int limit,
             CancellationToken ct)
         {
-            EnqueueExpiredDelayWaitCallCount++;
+            EnqueueOwnershipRecoveryCallCount++;
             if (ThrowOnEnqueue)
                 throw new InvalidOperationException("enqueue failed");
             return Task.FromResult(EnqueueResult);
         }
+
+        public Task<int> EnqueueExpiredDelayWaitResumesAsync(
+            DateTime nowUtc,
+            int limit,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
     }
 }

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionProjectionUpdateQueueServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionProjectionUpdateQueueServiceTests.cs
@@ -18,6 +18,8 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
     private sealed class FakeExecutionEngine : IExecutionEngine
     {
         private Func<string, Task>? _nodeCompletedHandler;
+        private Func<string, string, Task>? _suspendHandler;
+        private Func<ForkExpansionEvent, Task>? _forkExpansionHandler;
 
         public string Start(
             CompiledWorkflowDefinition definition,
@@ -54,10 +56,12 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
 
         public void SetSuspendHandler(Func<string, string, Task>? handler)
         {
+            _suspendHandler = handler;
         }
 
         public void SetForkExpansionHandler(Func<ForkExpansionEvent, Task>? handler)
         {
+            _forkExpansionHandler = handler;
         }
 
         public void CompletePhysicalJoin(
@@ -78,6 +82,12 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
 
         internal Task EmitNodeCompletedAsync(Guid executionId) =>
             _nodeCompletedHandler?.Invoke(executionId.ToString("D")) ?? Task.CompletedTask;
+
+        internal Task EmitSuspendAsync(string executionId, string nodeId) =>
+            _suspendHandler?.Invoke(executionId, nodeId) ?? Task.CompletedTask;
+
+        internal Task EmitForkExpansionAsync(ForkExpansionEvent evt) =>
+            _forkExpansionHandler?.Invoke(evt) ?? Task.CompletedTask;
     }
 
     private sealed class FakeExecutionService : IExecutionService
@@ -118,8 +128,14 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
         public Task AbandonLocalOwnedSessionAsync(Guid executionId) => Task.CompletedTask;
 
         public Task AwaitLocalExecutionLoadAsync(Guid executionId, CancellationToken ct) => Task.CompletedTask;
-        public Task PersistCheckpointAndUnloadByEngineIdAsync(string engineExecutionId, string nodeId, CancellationToken ct) => Task.CompletedTask;
 
+        internal int PersistCheckpointAndUnloadByEngineIdCallCount { get; private set; }
+
+        public Task PersistCheckpointAndUnloadByEngineIdAsync(string engineExecutionId, string nodeId, CancellationToken ct)
+        {
+            PersistCheckpointAndUnloadByEngineIdCallCount += 1;
+            return Task.CompletedTask;
+        }
 
         public Task<ExecutionResponse> StartAsync(StartExecutionRequest request, string? idempotencyKey, CommandRequestContext requestContext, CancellationToken ct) =>
             throw new NotSupportedException();
@@ -578,13 +594,246 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
     }
 
     /// <summary>投影キューが要求する Platform lookup のスタブ。</summary>
+    /// <summary>Suspend 通知で PersistCheckpointAndUnload が呼ばれる。</summary>
+    [Fact]
+    public async Task EmitSuspendAsync_WhenTenantFound_PersistsCheckpointAndUnload()
+    {
+        // Arrange
+        var executionId = Guid.NewGuid();
+        var executionEngine = new FakeExecutionEngine();
+        var executionService = new FakeExecutionService(failuresBeforeSuccess: 0);
+        await using var serviceProvider = BuildServiceProvider(executionService);
+        var queue = BuildQueueService(executionEngine, serviceProvider, new ExecutionProjectionQueueOptions
+        {
+            MaxGlobalQueueSize = 10,
+            ProjectionFlushDebounceMs = 0,
+            MaxRetryAttempts = 3,
+            RetryBaseDelayMs = 0,
+            RetryMaxDelayMs = 0
+        });
+        await queue.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Act
+            await executionEngine.EmitSuspendAsync(executionId.ToString("D"), "wait1");
+
+            // Assert
+            Assert.Equal(1, executionService.PersistCheckpointAndUnloadByEngineIdCallCount);
+        }
+        finally
+        {
+            await queue.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>不正な executionId の Suspend は checkpoint をスキップする。</summary>
+    [Fact]
+    public async Task EmitSuspendAsync_WhenExecutionIdInvalid_SkipsPersist()
+    {
+        // Arrange
+        var executionEngine = new FakeExecutionEngine();
+        var executionService = new FakeExecutionService(failuresBeforeSuccess: 0);
+        await using var serviceProvider = BuildServiceProvider(executionService);
+        var queue = BuildQueueService(executionEngine, serviceProvider, new ExecutionProjectionQueueOptions
+        {
+            MaxGlobalQueueSize = 10,
+            ProjectionFlushDebounceMs = 0,
+            MaxRetryAttempts = 1,
+            RetryBaseDelayMs = 0,
+            RetryMaxDelayMs = 0
+        });
+        await queue.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Act
+            await executionEngine.EmitSuspendAsync("not-a-guid", "wait1");
+
+            // Assert
+            Assert.Equal(0, executionService.PersistCheckpointAndUnloadByEngineIdCallCount);
+        }
+        finally
+        {
+            await queue.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>テナントが無い Suspend は checkpoint をスキップする。</summary>
+    [Fact]
+    public async Task EmitSuspendAsync_WhenTenantMissing_SkipsPersist()
+    {
+        // Arrange
+        var executionId = Guid.NewGuid();
+        var executionEngine = new FakeExecutionEngine();
+        var executionService = new FakeExecutionService(failuresBeforeSuccess: 0);
+        var platform = new StubPlatformDataAccess { TenantToReturn = null };
+        await using var serviceProvider = BuildServiceProvider(
+            executionService,
+            new TenantContextAccessor(),
+            platform);
+        var queue = BuildQueueService(executionEngine, serviceProvider, new ExecutionProjectionQueueOptions
+        {
+            MaxGlobalQueueSize = 10,
+            ProjectionFlushDebounceMs = 0,
+            MaxRetryAttempts = 1,
+            RetryBaseDelayMs = 0,
+            RetryMaxDelayMs = 0
+        });
+        await queue.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Act
+            await executionEngine.EmitSuspendAsync(executionId.ToString("D"), "wait1");
+
+            // Assert
+            Assert.Equal(0, executionService.PersistCheckpointAndUnloadByEngineIdCallCount);
+        }
+        finally
+        {
+            await queue.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>ForkExpansion 通知で HostHandler が呼ばれる。</summary>
+    [Fact]
+    public async Task EmitForkExpansionAsync_WhenTenantFound_InvokesHostHandler()
+    {
+        // Arrange
+        var executionId = Guid.NewGuid();
+        var executionEngine = new FakeExecutionEngine();
+        var executionService = new FakeExecutionService(failuresBeforeSuccess: 0);
+        var forkHandler = new RecordingForkExpansionHostHandler();
+        await using var serviceProvider = BuildServiceProvider(executionService, forkHandler: forkHandler);
+        var queue = BuildQueueService(executionEngine, serviceProvider, new ExecutionProjectionQueueOptions
+        {
+            MaxGlobalQueueSize = 10,
+            ProjectionFlushDebounceMs = 0,
+            MaxRetryAttempts = 1,
+            RetryBaseDelayMs = 0,
+            RetryMaxDelayMs = 0
+        });
+        await queue.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Act
+            await executionEngine.EmitForkExpansionAsync(new ForkExpansionEvent(
+                executionId.ToString("D"),
+                "fork1",
+                "n1",
+                [new ForkBranchExpansionPlan("branchA", null)]));
+
+            // Assert
+            Assert.Equal(1, forkHandler.HandleCallCount);
+        }
+        finally
+        {
+            await queue.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>不正な executionId の ForkExpansion は HostHandler を呼ばない。</summary>
+    [Fact]
+    public async Task EmitForkExpansionAsync_WhenExecutionIdInvalid_SkipsHandler()
+    {
+        // Arrange
+        var executionEngine = new FakeExecutionEngine();
+        var executionService = new FakeExecutionService(failuresBeforeSuccess: 0);
+        var forkHandler = new RecordingForkExpansionHostHandler();
+        await using var serviceProvider = BuildServiceProvider(executionService, forkHandler: forkHandler);
+        var queue = BuildQueueService(executionEngine, serviceProvider, new ExecutionProjectionQueueOptions
+        {
+            MaxGlobalQueueSize = 10,
+            ProjectionFlushDebounceMs = 0,
+            MaxRetryAttempts = 1,
+            RetryBaseDelayMs = 0,
+            RetryMaxDelayMs = 0
+        });
+        await queue.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Act
+            await executionEngine.EmitForkExpansionAsync(new ForkExpansionEvent(
+                "bad-id",
+                "fork1",
+                "n1",
+                [new ForkBranchExpansionPlan("branchA", null)]));
+
+            // Assert
+            Assert.Equal(0, forkHandler.HandleCallCount);
+        }
+        finally
+        {
+            await queue.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>テナント欠落の ForkExpansion は HostHandler を呼ばない。</summary>
+    [Fact]
+    public async Task EmitForkExpansionAsync_WhenTenantMissing_SkipsHandler()
+    {
+        // Arrange
+        var executionId = Guid.NewGuid();
+        var executionEngine = new FakeExecutionEngine();
+        var executionService = new FakeExecutionService(failuresBeforeSuccess: 0);
+        var forkHandler = new RecordingForkExpansionHostHandler();
+        var platform = new StubPlatformDataAccess { TenantToReturn = null };
+        await using var serviceProvider = BuildServiceProvider(
+            executionService,
+            new TenantContextAccessor(),
+            platform,
+            forkHandler);
+        var queue = BuildQueueService(executionEngine, serviceProvider, new ExecutionProjectionQueueOptions
+        {
+            MaxGlobalQueueSize = 10,
+            ProjectionFlushDebounceMs = 0,
+            MaxRetryAttempts = 1,
+            RetryBaseDelayMs = 0,
+            RetryMaxDelayMs = 0
+        });
+        await queue.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Act
+            await executionEngine.EmitForkExpansionAsync(new ForkExpansionEvent(
+                executionId.ToString("D"),
+                "fork1",
+                "n1",
+                [new ForkBranchExpansionPlan("branchA", null)]));
+
+            // Assert
+            Assert.Equal(0, forkHandler.HandleCallCount);
+        }
+        finally
+        {
+            await queue.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private sealed class RecordingForkExpansionHostHandler : IForkExpansionHostHandler
+    {
+        public int HandleCallCount { get; private set; }
+
+        public Task HandleAsync(ForkExpansionEvent evt, CancellationToken ct)
+        {
+            HandleCallCount += 1;
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class StubPlatformDataAccess : IPlatformDataAccess
     {
+        public ExecutionTenantLookup? TenantToReturn { get; set; } = new(
+            TestTenantIds.T1TenantId,
+            "t1",
+            TenantLifecycle.Active);
+
         public Task<ExecutionTenantLookup?> FindExecutionTenantAsync(Guid executionId, CancellationToken cancellationToken) =>
-            Task.FromResult<ExecutionTenantLookup?>(new ExecutionTenantLookup(
-                TestTenantIds.T1TenantId,
-                "t1",
-                TenantLifecycle.Active));
+            Task.FromResult(TenantToReturn);
 
         public Task<TenantRow?> FindTenantByKeyAsync(string tenantKey, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
@@ -623,24 +872,29 @@ public sealed class ExecutionProjectionUpdateQueueServiceTests
             throw new NotSupportedException();
     }
 
-    private static ServiceProvider BuildServiceProvider(IExecutionService executionService)
+    private static ServiceProvider BuildServiceProvider(
+        IExecutionService executionService,
+        IForkExpansionHostHandler? forkHandler = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton<ITenantContextAccessor, TenantContextAccessor>();
         services.AddSingleton<IPlatformDataAccess, StubPlatformDataAccess>();
         services.AddScoped<IExecutionService>(_ => executionService);
+        services.AddScoped<IForkExpansionHostHandler>(_ => forkHandler ?? new RecordingForkExpansionHostHandler());
         return services.BuildServiceProvider();
     }
 
     private static ServiceProvider BuildServiceProvider(
         IExecutionService executionService,
         ITenantContextAccessor tenantContextAccessor,
-        IPlatformDataAccess platformDataAccess)
+        IPlatformDataAccess platformDataAccess,
+        IForkExpansionHostHandler? forkHandler = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton(tenantContextAccessor);
         services.AddSingleton(platformDataAccess);
         services.AddScoped<IExecutionService>(_ => executionService);
+        services.AddScoped<IForkExpansionHostHandler>(_ => forkHandler ?? new RecordingForkExpansionHostHandler());
         return services.BuildServiceProvider();
     }
 

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -226,11 +226,31 @@ public sealed class ExecutionServiceTests
             // no-op for tests
         }
 
-        public ExecutionRuntimeCheckpoint? ExportCheckpoint(string executionId) => null;
+        /// <summary>設定時、<see cref="ExportCheckpoint"/> がこの値を返す。</summary>
+        public ExecutionRuntimeCheckpoint? CheckpointToExport { get; set; }
+
+        /// <summary>設定時、<see cref="Unload"/> がこの例外を投げる。</summary>
+        public Exception? UnloadExceptionToThrow { get; set; }
+
+        /// <summary><see cref="ImportCheckpoint"/> が呼ばれた回数。</summary>
+        public int ImportCheckpointCalls { get; private set; }
+
+        public ExecutionRuntimeCheckpoint? ExportCheckpoint(string executionId) => CheckpointToExport;
 
         public void ImportCheckpoint(CompiledWorkflowDefinition definition, ExecutionRuntimeCheckpoint checkpoint)
         {
-            // no-op for tests
+            _ = definition;
+            _ = checkpoint;
+            ImportCheckpointCalls += 1;
+            SnapshotToReturn ??= new ExecutionSnapshot
+            {
+                ExecutionId = checkpoint.ExecutionId,
+                WorkflowName = checkpoint.DefinitionName,
+                ActiveStates = checkpoint.ActiveStates,
+                IsCompleted = checkpoint.IsCompleted,
+                IsCancelled = checkpoint.IsCancelled,
+                IsFailed = checkpoint.IsFailed
+            };
         }
 
         /// <summary><see cref="Unload"/> が呼ばれた回数。</summary>
@@ -238,6 +258,9 @@ public sealed class ExecutionServiceTests
 
         public bool Unload(string executionId)
         {
+            if (UnloadExceptionToThrow is { } unloadEx)
+                throw unloadEx;
+
             UnloadCalls += 1;
             SnapshotToReturn = null;
             return true;
@@ -517,16 +540,36 @@ public sealed class ExecutionServiceTests
 
     private sealed class FakeExecutionCheckpointStore : IExecutionCheckpointStore
     {
+        public int UpsertCalls { get; private set; }
+        public int AcquireCalls { get; private set; }
+        public int RenewCalls { get; private set; }
+        public int ClearOwnershipCalls { get; private set; }
+        public int GenerationUpsertCalls { get; private set; }
+        public long? AcquireGenerationToReturn { get; set; } = 1;
+        public bool RenewResult { get; set; } = true;
+        public bool GenerationUpsertResult { get; set; } = true;
+        public ExecutionCheckpointDocument? DocumentById { get; set; }
+
         public Task UpsertAsync(
             ICoreUnitOfWork uow,
             ExecutionCheckpointDocument document,
-            CancellationToken ct) => Task.CompletedTask;
+            CancellationToken ct)
+        {
+            _ = uow;
+            UpsertCalls += 1;
+            DocumentById = document;
+            return Task.CompletedTask;
+        }
 
         public Task<ExecutionCheckpointDocument?> GetByExecutionIdAsync(
             ICoreUnitOfWork uow,
             Guid executionId,
-            CancellationToken ct) =>
-            Task.FromResult<ExecutionCheckpointDocument?>(null);
+            CancellationToken ct)
+        {
+            _ = uow;
+            _ = executionId;
+            return Task.FromResult(DocumentById);
+        }
 
         public Task DeleteAsync(
             ICoreUnitOfWork uow,
@@ -539,8 +582,16 @@ public sealed class ExecutionServiceTests
             string workerId,
             DateTime leaseUntilUtc,
             ExecutionCheckpointDocument? seed,
-            CancellationToken ct) =>
-            Task.FromResult<long?>(1);
+            CancellationToken ct)
+        {
+            _ = uow;
+            _ = executionId;
+            _ = workerId;
+            _ = leaseUntilUtc;
+            _ = seed;
+            AcquireCalls += 1;
+            return Task.FromResult(AcquireGenerationToReturn);
+        }
 
         public Task<long?> TrySeizeExpiredOwnershipAsync(
             ICoreUnitOfWork uow,
@@ -556,21 +607,39 @@ public sealed class ExecutionServiceTests
             Guid executionId,
             long ownerGeneration,
             DateTime leaseUntilUtc,
-            CancellationToken ct) =>
-            Task.FromResult(true);
+            CancellationToken ct)
+        {
+            _ = uow;
+            _ = executionId;
+            _ = ownerGeneration;
+            _ = leaseUntilUtc;
+            RenewCalls += 1;
+            return Task.FromResult(RenewResult);
+        }
 
         public Task<bool> TryUpsertRuntimeWithGenerationAsync(
             ICoreUnitOfWork uow,
             ExecutionCheckpointRuntimeUpsert upsert,
-            CancellationToken ct) =>
-            Task.FromResult(true);
+            CancellationToken ct)
+        {
+            _ = uow;
+            _ = upsert;
+            GenerationUpsertCalls += 1;
+            return Task.FromResult(GenerationUpsertResult);
+        }
 
         public Task<bool> TryClearOwnershipAsync(
             ICoreUnitOfWork uow,
             Guid executionId,
             long ownerGeneration,
-            CancellationToken ct) =>
-            Task.FromResult(true);
+            CancellationToken ct)
+        {
+            _ = uow;
+            _ = executionId;
+            _ = ownerGeneration;
+            ClearOwnershipCalls += 1;
+            return Task.FromResult(true);
+        }
 
         public Task<IReadOnlyList<Guid>> ListExpiredOwnedExecutionIdsAsync(
             ICoreUnitOfWork uow,
@@ -4162,6 +4231,9 @@ public sealed class ExecutionServiceTests
     private sealed class FakeForkChildCoordinator : IForkChildExecutionCoordinator
     {
         public List<Guid> DescendantIds { get; init; } = [];
+        public ForkJoinEvaluation EvaluateJoinResult { get; set; } =
+            new(ForkJoinEvaluationKind.Waiting, "Join1");
+        public int EvaluateJoinCalls { get; private set; }
 
         public Task<ForkExpansionResult> ExpandForkAsync(ForkExpansionRequest request, CancellationToken ct) =>
             throw new NotSupportedException();
@@ -4178,18 +4250,21 @@ public sealed class ExecutionServiceTests
         public Task<ForkJoinEvaluation> EvaluateJoinAsync(
             Guid parentExecutionId,
             string forkNodeId,
-            CancellationToken ct) =>
-            throw new NotSupportedException();
+            CancellationToken ct)
+        {
+            EvaluateJoinCalls++;
+            return Task.FromResult(EvaluateJoinResult);
+        }
 
         public Task CascadeCancelToRunningChildrenAsync(Guid parentExecutionId, CancellationToken ct) =>
-            throw new NotSupportedException();
+            Task.CompletedTask;
 
         public Task<ForkWaitDeliveryTarget?> TryResolveChildWaitDeliveryAsync(
             Guid requestedExecutionId,
             string? nodeId,
             string eventName,
             CancellationToken ct) =>
-            throw new NotSupportedException();
+            Task.FromResult<ForkWaitDeliveryTarget?>(null);
 
         public Task<string> ComposeReadModelGraphJsonAsync(
             Guid executionId,
@@ -4220,7 +4295,10 @@ public sealed class ExecutionServiceTests
         IExecutionMutationPersistence? mutationPersistence = null,
         IProjectAuthorizationService? projectAuthorization = null,
         FakeExecutionWaitRepository? waitRepo = null,
-        IForkChildExecutionCoordinator? forkChildCoordinator = null)
+        IForkChildExecutionCoordinator? forkChildCoordinator = null,
+        IExecutionWorkQueue? workQueue = null,
+        IExecutionCheckpointStore? checkpointStore = null,
+        ExecutionOwnershipTracker? ownershipTracker = null)
     {
         if (displayIds is not IDisplayIdWriteService displayIdWrites)
             throw new InvalidOperationException("Test display id service must implement IDisplayIdWriteService.");
@@ -4264,10 +4342,10 @@ public sealed class ExecutionServiceTests
             NullLogger<ExecutionService>.Instance,
             retryOptions,
             new FixedCorrelationIdAccessor(),
-            new FakeExecutionCheckpointStore(),
+            checkpointStore ?? new FakeExecutionCheckpointStore(),
             projectionUpdateQueue,
-            workQueue: null,
-            ownershipTracker: null,
+            workQueue,
+            ownershipTracker,
             forkChildCoordinator: forkChildCoordinator);
     }
 
@@ -4333,6 +4411,1132 @@ public sealed class ExecutionServiceTests
 
         // Assert
         Assert.NotEqual(Guid.Empty, response.ResourceId);
+    }
+
+    /// <summary>ChildCompleted Resume で Join Waiting なら親投影を変更しない。</summary>
+    [Fact]
+    public async Task ResumeNodeAsync_ChildCompleted_WhenJoinWaiting_DoesNotUpdateParent()
+    {
+        // Arrange
+        var executionId = Guid.Parse("a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1");
+        var coordinator = new FakeForkChildCoordinator
+        {
+            EvaluateJoinResult = new ForkJoinEvaluation(ForkJoinEvaluationKind.Waiting, "Join1")
+        };
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            new FakeDisplayIdService { ResolveResultExecution = executionId },
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            forkChildCoordinator: coordinator);
+
+        // Act
+        await sut.ResumeNodeAsync(
+            executionId.ToString("D"),
+            "fork-1",
+            ExecutionWaitEventNames.ChildCompleted,
+            idempotencyKey: null,
+            new CommandRequestContext("WORKER", "/internal"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, coordinator.EvaluateJoinCalls);
+        Assert.Empty(executionRepo.Updates);
+    }
+
+    /// <summary>ChildCompleted Resume で Join Failed なら親を Failed に更新する。</summary>
+    [Fact]
+    public async Task ResumeNodeAsync_ChildCompleted_WhenJoinFailed_MarksParentFailed()
+    {
+        // Arrange
+        var executionId = Guid.Parse("b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2");
+        var coordinator = new FakeForkChildCoordinator
+        {
+            EvaluateJoinResult = new ForkJoinEvaluation(
+                ForkJoinEvaluationKind.Failed,
+                "Join1",
+                FailureStatus: ExecutionProjectionStatuses.Failed)
+        };
+        var engine = new FakeExecutionEngine();
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+            SnapshotByExecutionId = new ExecutionGraphSnapshotRow
+            {
+                ExecutionId = executionId,
+                GraphJson = """{"nodes":[],"edges":[]}""",
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService { ResolveResultExecution = executionId },
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            forkChildCoordinator: coordinator);
+
+        // Act
+        await sut.ResumeNodeAsync(
+            executionId.ToString("D"),
+            "fork-1",
+            ExecutionWaitEventNames.ChildCompleted,
+            idempotencyKey: null,
+            new CommandRequestContext("WORKER", "/internal"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, coordinator.EvaluateJoinCalls);
+        Assert.Contains(executionRepo.Updates, u => u.Status == ExecutionProjectionStatuses.Failed);
+        Assert.Equal(1, engine.UnloadCalls);
+    }
+
+    /// <summary>ChildCompleted Resume で Join Satisfied なら物理 Join 完了を呼ぶ。</summary>
+    [Fact]
+    public async Task ResumeNodeAsync_ChildCompleted_WhenJoinSatisfied_CompletesPhysicalJoin()
+    {
+        // Arrange
+        var executionId = Guid.Parse("c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3");
+        var coordinator = new FakeForkChildCoordinator
+        {
+            EvaluateJoinResult = new ForkJoinEvaluation(
+                ForkJoinEvaluationKind.Satisfied,
+                "Join1",
+                CandidateInputs: new Dictionary<string, object?> { ["branchA"] = new { ok = true } })
+        };
+        var engine = new FakeExecutionEngine
+        {
+            SnapshotToReturn = new ExecutionSnapshot
+            {
+                ExecutionId = executionId.ToString(),
+                WorkflowName = "def",
+                ActiveStates = Array.Empty<string>(),
+                IsCompleted = true,
+                IsCancelled = false,
+                IsFailed = false
+            },
+            GraphJsonToReturn = """{"nodes":[],"edges":[]}"""
+        };
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService { ResolveResultExecution = executionId },
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            forkChildCoordinator: coordinator);
+
+        // Act
+        await sut.ResumeNodeAsync(
+            executionId.ToString("D"),
+            "fork-1",
+            ExecutionWaitEventNames.ChildCompleted,
+            idempotencyKey: null,
+            new CommandRequestContext("WORKER", "/internal"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, coordinator.EvaluateJoinCalls);
+        Assert.NotEmpty(executionRepo.Updates);
+    }
+
+    /// <summary>checkpoint がある Recover は Import して投影を更新する。</summary>
+    [Fact]
+    public async Task RecoverExecutionAsync_WhenCheckpointExists_ImportsAndUpdatesProjection()
+    {
+        // Arrange
+        var defUuid = Guid.Parse("d4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4");
+        var versionId = Guid.Parse("e5e5e5e5-e5e5-e5e5-e5e5-e5e5e5e5e5e5");
+        var executionId = Guid.Parse("f6f6f6f6-f6f6-f6f6-f6f6-f6f6f6f6f6f6");
+        var now = DateTime.UtcNow;
+        var version = new DefinitionVersionRow
+        {
+            DefinitionVersionId = versionId,
+            DefinitionId = defUuid,
+            Version = 1,
+            SourceYaml = "yaml",
+            CompiledJson = "{}",
+            CreatedAt = now
+        };
+        var definitionsRepo = new StubDefinitionRepository
+        {
+            LatestDetail = new DefinitionDetail
+            {
+                Definition = new DefinitionRow
+                {
+                    DefinitionId = defUuid,
+                    TenantId = TestTenantIds.T1TenantId,
+                    ProjectId = Guid.NewGuid(),
+                    Slug = "def",
+                    Name = "def",
+                    LatestVersion = 1,
+                    CreatedAt = now,
+                    UpdatedAt = now
+                },
+                Version = version
+            },
+            VersionById = version,
+            VersionByNumber = version
+        };
+        var checkpoint = CreateMinimalCheckpoint(executionId.ToString());
+        var checkpointJson = System.Text.Json.JsonSerializer.Serialize(
+            checkpoint,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+        var checkpointStore = new FakeExecutionCheckpointStore
+        {
+            DocumentById = new ExecutionCheckpointDocument
+            {
+                ExecutionId = executionId,
+                CheckpointJson = checkpointJson,
+                SchemaVersion = ExecutionRuntimeCheckpoint.CurrentSchemaVersion,
+                UpdatedAt = now
+            }
+        };
+        var engine = new FakeExecutionEngine
+        {
+            SnapshotToReturn = null,
+            GraphJsonToReturn = """{"nodes":[],"edges":[]}"""
+        };
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = defUuid,
+                DefinitionVersionId = versionId,
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = now,
+                UpdatedAt = now
+            }
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            definitionsRepo,
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore);
+
+        // Act
+        await sut.RecoverExecutionAsync(
+            executionId,
+            new CommandRequestContext("WORKER", "/internal/execution-work-items"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, engine.ImportCheckpointCalls);
+        Assert.NotEmpty(executionRepo.Updates);
+    }
+
+    /// <summary>HTTP Cancel + 冪等キーで Cancel enqueue 時に dedup を保存する。</summary>
+    [Fact]
+    public async Task CancelAsync_WithWorkQueueAndIdempotency_SavesDedupAndEnqueues()
+    {
+        // Arrange
+        var executionId = Guid.Parse("04040404-0404-0404-0404-040404040404");
+        var workQueue = new CapturingWorkQueue();
+        var dedupKey = new CommandDedupKey
+        {
+            DedupKey = "cancel-dedup",
+            Endpoint = "POST /v1/executions/x/cancel",
+            IdempotencyKey = "idem-cancel"
+        };
+        var dedupRepo = new FakeCommandDedupRepository();
+        var display = new FakeDisplayIdService { ResolveResultExecution = executionId };
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            display,
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(dedupKey),
+            executionRepo,
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            dedupRepo,
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            workQueue: workQueue);
+
+        // Act
+        await sut.CancelAsync(
+            executionId.ToString("D"),
+            idempotencyKey: "idem-cancel",
+            new CommandRequestContext("POST", "/v1/executions/x/cancel"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Single(workQueue.Items);
+        Assert.Single(dedupRepo.SavedRows);
+    }
+
+    /// <summary>HTTP Start + 冪等キーで Start enqueue 時に dedup を保存する。</summary>
+    [Fact]
+    public async Task StartAsync_WithWorkQueueAndIdempotency_SavesDedupAndEnqueues()
+    {
+        // Arrange
+        var defUuid = Guid.Parse("05050505-0505-0505-0505-050505050505");
+        var executionId = Guid.Parse("06060606-0606-0606-0606-060606060606");
+        var workQueue = new CapturingWorkQueue();
+        var dedupKey = new CommandDedupKey
+        {
+            DedupKey = "start-dedup",
+            Endpoint = "POST /v1/executions",
+            IdempotencyKey = "idem-start"
+        };
+        var dedupRepo = new FakeCommandDedupRepository();
+        var display = new FakeDisplayIdService
+        {
+            ResolveResultDefinition = defUuid,
+            AllocateResultWorkflow = "WF-Q-2",
+            GetDisplayIdResult = "def-disp"
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            display,
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(dedupKey),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(defUuid, TestTenantIds.T1TenantId, "def"),
+            dedupRepo,
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            workQueue: workQueue);
+
+        using var inputDoc = JsonDocument.Parse("{}");
+        var request = new StartExecutionRequest { DefinitionId = "def-q", Input = inputDoc.RootElement };
+
+        // Act
+        var response = await sut.StartAsync(
+            request,
+            idempotencyKey: "idem-start",
+            new CommandRequestContext("POST", "/v1/executions"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(executionId, response.ResourceId);
+        Assert.Single(workQueue.Items);
+        Assert.Single(dedupRepo.SavedRows);
+    }
+
+    /// <summary>Owned session 獲得失敗時は null を返す。</summary>
+    [Fact]
+    public async Task BeginOwnedSessionAsync_WhenAcquireFails_ReturnsNull()
+    {
+        // Arrange
+        var executionId = Guid.Parse("01010101-0101-0101-0101-010101010101");
+        var checkpointStore = new FakeExecutionCheckpointStore { AcquireGenerationToReturn = null };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore);
+
+        // Act
+        var generation = await sut.BeginOwnedSessionAsync(
+            executionId,
+            "worker-1",
+            TimeSpan.FromMinutes(1),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Null(generation);
+        Assert.Equal(1, checkpointStore.AcquireCalls);
+    }
+
+    /// <summary>ownership が無い Renew は true を返す。</summary>
+    [Fact]
+    public async Task RenewOwnedSessionLeaseAsync_WhenOwnershipMissing_ReturnsTrue()
+    {
+        // Arrange
+        var executionId = Guid.Parse("02020202-0202-0202-0202-020202020202");
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository());
+
+        // Act
+        var renewed = await sut.RenewOwnedSessionLeaseAsync(
+            executionId,
+            TimeSpan.FromMinutes(1),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(renewed);
+    }
+
+    /// <summary>KeepLoaded の fencing 失敗でも例外にしない。</summary>
+    [Fact]
+    public async Task PersistCheckpointKeepLoadedAsync_WhenGenerationUpsertFails_DoesNotThrow()
+    {
+        // Arrange
+        var executionId = Guid.Parse("03030303-0303-0303-0303-030303030303");
+        var ownership = new ExecutionOwnershipTracker();
+        ownership.Set(executionId, "worker-1", 3);
+        var checkpointStore = new FakeExecutionCheckpointStore { GenerationUpsertResult = false };
+        var engine = new FakeExecutionEngine
+        {
+            CheckpointToExport = CreateMinimalCheckpoint(executionId.ToString())
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore,
+            ownershipTracker: ownership);
+
+        // Act
+        await sut.PersistCheckpointKeepLoadedAsync(executionId.ToString(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, checkpointStore.GenerationUpsertCalls);
+    }
+
+    /// <summary>HTTP Start で work queue があるとき Engine を回さず Start work item を enqueue する。</summary>
+    [Fact]
+    public async Task StartAsync_WithWorkQueue_EnqueuesStartWorkItemWithoutEngineStart()
+    {
+        // Arrange
+        var defUuid = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var executionId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var workQueue = new CapturingWorkQueue();
+        var engine = new FakeExecutionEngine();
+        var display = new FakeDisplayIdService
+        {
+            ResolveResultDefinition = defUuid,
+            AllocateResultWorkflow = "WF-Q-1",
+            GetDisplayIdResult = "def-disp"
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            display,
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(defUuid, TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            workQueue: workQueue);
+
+        using var inputDoc = JsonDocument.Parse("{}");
+        var request = new StartExecutionRequest { DefinitionId = "def-q", Input = inputDoc.RootElement };
+
+        // Act
+        var response = await sut.StartAsync(
+            request,
+            idempotencyKey: null,
+            new CommandRequestContext("POST", "/v1/executions"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(engine.StartCalled);
+        Assert.Equal(executionId, response.ResourceId);
+        Assert.Equal(ExecutionProjectionStatuses.Running, response.Status);
+        Assert.Single(workQueue.Items);
+        Assert.Equal(ExecutionWorkItemKinds.Start, workQueue.Items[0].Kind);
+        Assert.Equal(executionId, workQueue.Items[0].ExecutionId);
+    }
+
+    /// <summary>HTTP Cancel で work queue があるとき Cancel work item を enqueue する。</summary>
+    [Fact]
+    public async Task CancelAsync_WithWorkQueue_EnqueuesCancelWorkItem()
+    {
+        // Arrange
+        var executionId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var workQueue = new CapturingWorkQueue();
+        var display = new FakeDisplayIdService { ResolveResultExecution = executionId };
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            display,
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            workQueue: workQueue);
+
+        // Act
+        await sut.CancelAsync(
+            executionId.ToString("D"),
+            idempotencyKey: null,
+            new CommandRequestContext("POST", "/v1/executions/x/cancel"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Single(workQueue.Items);
+        Assert.Equal(ExecutionWorkItemKinds.Cancel, workQueue.Items[0].Kind);
+        Assert.Equal(executionId, workQueue.Items[0].ExecutionId);
+    }
+
+    /// <summary>Owned session の獲得・延長・解放が checkpoint store を通る。</summary>
+    [Fact]
+    public async Task OwnedSession_BeginRenewEnd_UsesCheckpointStoreGenerations()
+    {
+        // Arrange
+        var executionId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        var checkpointStore = new FakeExecutionCheckpointStore { AcquireGenerationToReturn = 7 };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore);
+
+        // Act
+        var generation = await sut.BeginOwnedSessionAsync(
+            executionId,
+            "worker-1",
+            TimeSpan.FromMinutes(1),
+            CancellationToken.None);
+        var renewed = await sut.RenewOwnedSessionLeaseAsync(
+            executionId,
+            TimeSpan.FromMinutes(1),
+            CancellationToken.None);
+        await sut.EndOwnedSessionAsync(executionId, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(7, generation);
+        Assert.True(renewed);
+        Assert.Equal(1, checkpointStore.AcquireCalls);
+        Assert.Equal(1, checkpointStore.RenewCalls);
+        Assert.Equal(1, checkpointStore.ClearOwnershipCalls);
+    }
+
+    /// <summary>ローカル所有放棄は Unload を呼び、Unload 失敗でも完了する。</summary>
+    [Fact]
+    public async Task AbandonLocalOwnedSessionAsync_UnloadFailure_StillCompletes()
+    {
+        // Arrange
+        var executionId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        var ownership = new ExecutionOwnershipTracker();
+        ownership.Set(executionId, "worker-1", 1);
+        var engine = new FakeExecutionEngine
+        {
+            UnloadExceptionToThrow = new InvalidOperationException("unload failed")
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            ownershipTracker: ownership);
+
+        // Act
+        await sut.AbandonLocalOwnedSessionAsync(executionId);
+
+        // Assert
+        Assert.False(ownership.TryGet(executionId, out _, out _));
+    }
+
+    /// <summary>KeepLoaded checkpoint は ownership 無しで Upsert する。</summary>
+    [Fact]
+    public async Task PersistCheckpointKeepLoadedAsync_WithoutOwnership_UpsertsDocument()
+    {
+        // Arrange
+        var executionId = Guid.Parse("66666666-6666-6666-6666-666666666666");
+        var checkpointStore = new FakeExecutionCheckpointStore();
+        var engine = new FakeExecutionEngine
+        {
+            CheckpointToExport = CreateMinimalCheckpoint(executionId.ToString())
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore);
+
+        // Act
+        await sut.PersistCheckpointKeepLoadedAsync(executionId.ToString(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, checkpointStore.UpsertCalls);
+        Assert.Equal(0, checkpointStore.GenerationUpsertCalls);
+    }
+
+    /// <summary>KeepLoaded checkpoint は ownership ありで世代付き Upsert する。</summary>
+    [Fact]
+    public async Task PersistCheckpointKeepLoadedAsync_WithOwnership_UsesGenerationUpsert()
+    {
+        // Arrange
+        var executionId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+        var ownership = new ExecutionOwnershipTracker();
+        ownership.Set(executionId, "worker-1", 3);
+        var checkpointStore = new FakeExecutionCheckpointStore();
+        var engine = new FakeExecutionEngine
+        {
+            CheckpointToExport = CreateMinimalCheckpoint(executionId.ToString())
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore,
+            ownershipTracker: ownership);
+
+        // Act
+        await sut.PersistCheckpointKeepLoadedAsync(executionId.ToString(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, checkpointStore.GenerationUpsertCalls);
+        Assert.Equal(0, checkpointStore.UpsertCalls);
+    }
+
+    /// <summary>不正な executionId の KeepLoaded は何もしない。</summary>
+    [Fact]
+    public async Task PersistCheckpointKeepLoadedAsync_InvalidExecutionId_NoOps()
+    {
+        // Arrange
+        var checkpointStore = new FakeExecutionCheckpointStore();
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine { CheckpointToExport = CreateMinimalCheckpoint("x") },
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore);
+
+        // Act
+        await sut.PersistCheckpointKeepLoadedAsync("not-a-guid", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, checkpointStore.UpsertCalls);
+    }
+
+    /// <summary>キュー投入済み Start を Worker が実行する経路をカバーする。</summary>
+    [Fact]
+    public async Task ExecuteQueuedStartAsync_WhenExecutionExists_StartsEngineInProcess()
+    {
+        // Arrange
+        var defUuid = Guid.Parse("88888888-8888-8888-8888-888888888888");
+        var versionId = Guid.Parse("99999999-9999-9999-9999-999999999999");
+        var executionId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var now = DateTime.UtcNow;
+        var version = new DefinitionVersionRow
+        {
+            DefinitionVersionId = versionId,
+            DefinitionId = defUuid,
+            Version = 1,
+            SourceYaml = "yaml",
+            CompiledJson = "{}",
+            CreatedAt = now
+        };
+        var definitionsRepo = new StubDefinitionRepository
+        {
+            LatestDetail = new DefinitionDetail
+            {
+                Definition = new DefinitionRow
+                {
+                    DefinitionId = defUuid,
+                    TenantId = TestTenantIds.T1TenantId,
+                    ProjectId = Guid.NewGuid(),
+                    Slug = "def",
+                    Name = "def",
+                    LatestVersion = 1,
+                    CreatedAt = now,
+                    UpdatedAt = now
+                },
+                Version = version
+            },
+            VersionById = version,
+            VersionByNumber = version
+        };
+        var engine = new FakeExecutionEngine
+        {
+            SnapshotToReturn = new ExecutionSnapshot
+            {
+                ExecutionId = executionId.ToString(),
+                WorkflowName = "def",
+                ActiveStates = ["Initial"],
+                IsCompleted = false,
+                IsCancelled = false,
+                IsFailed = false
+            }
+        };
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = defUuid,
+                DefinitionVersionId = versionId,
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = now,
+                UpdatedAt = now
+            }
+        };
+
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService { AllocateResultWorkflow = "WF-QS", GetDisplayIdResult = "def-disp" },
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            definitionsRepo,
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository());
+
+        using var inputDoc = JsonDocument.Parse("{}");
+        var request = new StartExecutionRequest { DefinitionId = "def-q", Input = inputDoc.RootElement };
+
+        // Act
+        var response = await sut.ExecuteQueuedStartAsync(executionId, request, CancellationToken.None);
+
+        // Assert
+        Assert.True(engine.StartCalled);
+        Assert.Equal(executionId, response.ResourceId);
+    }
+
+    /// <summary>終端投影の Recover は Engine を触らず早期 return する。</summary>
+    [Fact]
+    public async Task RecoverExecutionAsync_WhenTerminal_ReturnsWithoutEngineLoad()
+    {
+        // Arrange
+        var executionId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var engine = new FakeExecutionEngine();
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Completed,
+                StartedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository());
+
+        // Act
+        await sut.RecoverExecutionAsync(
+            executionId,
+            new CommandRequestContext("WORKER", "/internal/execution-work-items"),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, engine.ImportCheckpointCalls);
+        Assert.Equal(0, engine.UnloadCalls);
+    }
+
+    /// <summary>実行が無い ExecuteQueuedStart は NotFound を投げる。</summary>
+    [Fact]
+    public async Task ExecuteQueuedStartAsync_WhenExecutionMissing_ThrowsNotFound()
+    {
+        // Arrange
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            new FakeExecutionEngine(),
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository { ByIdResult = null },
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository());
+
+        using var inputDoc = JsonDocument.Parse("{}");
+
+        // Act + Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sut.ExecuteQueuedStartAsync(
+                Guid.NewGuid(),
+                new StartExecutionRequest { DefinitionId = "x", Input = inputDoc.RootElement },
+                CancellationToken.None));
+    }
+
+    /// <summary>checkpoint を保存して Unload する公開 API をカバーする。</summary>
+    [Fact]
+    public async Task PersistCheckpointAndUnloadAsync_WhenCheckpointExists_UnloadsEngine()
+    {
+        // Arrange
+        var executionId = Guid.Parse("c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0");
+        var checkpointStore = new FakeExecutionCheckpointStore();
+        var engine = new FakeExecutionEngine
+        {
+            CheckpointToExport = CreateMinimalCheckpoint(executionId.ToString()),
+            SnapshotToReturn = new ExecutionSnapshot
+            {
+                ExecutionId = executionId.ToString(),
+                WorkflowName = "def",
+                ActiveStates = ["Wait"],
+                IsCompleted = false,
+                IsCancelled = false,
+                IsFailed = false
+            },
+            GraphJsonToReturn = """{"nodes":[],"edges":[]}"""
+        };
+        var executionRepo = new FakeExecutionRepository
+        {
+            ByIdResult = new ExecutionRow
+            {
+                ExecutionId = executionId,
+                TenantId = TestTenantIds.T1TenantId,
+                DefinitionId = Guid.NewGuid(),
+                DefinitionVersionId = Guid.NewGuid(),
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            executionRepo,
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore);
+
+        // Act
+        await sut.PersistCheckpointAndUnloadAsync(executionId, "wait-1", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, checkpointStore.UpsertCalls);
+        Assert.Equal(1, engine.UnloadCalls);
+        Assert.Single(executionRepo.Updates);
+    }
+
+    /// <summary>不正な Engine ID の Unload 経路は早期 return する。</summary>
+    [Fact]
+    public async Task PersistCheckpointAndUnloadByEngineIdAsync_InvalidId_NoOps()
+    {
+        // Arrange
+        var checkpointStore = new FakeExecutionCheckpointStore();
+        var engine = new FakeExecutionEngine
+        {
+            CheckpointToExport = CreateMinimalCheckpoint("x")
+        };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository(),
+            checkpointStore: checkpointStore);
+
+        // Act
+        await sut.PersistCheckpointAndUnloadByEngineIdAsync("not-a-guid", "n1", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, checkpointStore.UpsertCalls);
+        Assert.Equal(0, engine.UnloadCalls);
+    }
+
+    /// <summary>checkpoint が null のときは Unload しない。</summary>
+    [Fact]
+    public async Task PersistCheckpointAndUnloadAsync_WhenExportNull_SkipsUnload()
+    {
+        // Arrange
+        var executionId = Guid.Parse("d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1");
+        var engine = new FakeExecutionEngine { CheckpointToExport = null };
+        using var sqlite = new SqliteTestDatabase();
+        var sut = BuildExecutionService(
+            sqlite,
+            engine,
+            new FakeDisplayIdService(),
+            new StubDefinitionCompilerService((DummyCompiledDefinition("def"), "{}")),
+            new FixedIdGenerator(executionId),
+            new FakeCommandDedupService(null),
+            new FakeExecutionRepository(),
+            StubDefinitionRepositoryFactory.ForDefinition(Guid.NewGuid(), TestTenantIds.T1TenantId, "def"),
+            new FakeCommandDedupRepository(),
+            new FakeEventStoreRepository(),
+            new FakeEventDeliveryDedupRepository());
+
+        // Act
+        await sut.PersistCheckpointAndUnloadAsync(executionId, "wait-1", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, engine.UnloadCalls);
+    }
+
+    private static ExecutionRuntimeCheckpoint CreateMinimalCheckpoint(string executionId) =>
+        new()
+        {
+            ExecutionId = executionId,
+            DefinitionName = "def",
+            ActiveStates = Array.Empty<string>(),
+            StateAttempts = new Dictionary<string, int>(),
+            StateOutputs = new Dictionary<string, JsonElement?>(),
+            AppliedPublishClientEventIds = Array.Empty<Guid>(),
+            AppliedCancelClientEventIds = Array.Empty<Guid>(),
+            Context = new CheckpointContextData { States = new Dictionary<string, JsonElement?>() },
+            Graph = new CheckpointGraphData { Nodes = [], Edges = [] },
+            Join = new CheckpointJoinData
+            {
+                JoinStateResults = new Dictionary<string, IReadOnlyDictionary<string, CheckpointJoinObserved>>(),
+                JoinSourceNodeIds = new Dictionary<string, IReadOnlyDictionary<string, string>>(),
+                StartedJoins = Array.Empty<string>()
+            },
+            PendingWaits = Array.Empty<CheckpointPendingWait>()
+        };
+
+    private sealed class CapturingWorkQueue : IExecutionWorkQueue
+    {
+        public List<ExecutionWorkItemRow> Items { get; } = [];
+
+        public Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct)
+        {
+            Items.Add(item);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            EnqueueAsync(item, ct);
+
+        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct)
+        {
+            Items.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            EnqueueManyAsync(items, ct);
+
+        public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            int limit,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task CompleteAsync(Guid workItemId, string leaseOwner, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<bool> RenewLeaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            CancellationToken ct) =>
+            Task.FromResult(true);
+
+        public Task ReleaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime availableAt,
+            CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<int> EnqueueExpiredOwnershipRecoveriesAsync(
+            DateTime nowUtc,
+            int limit,
+            CancellationToken ct) =>
+            Task.FromResult(0);
+
+        public Task<int> EnqueueExpiredDelayWaitResumesAsync(
+            DateTime nowUtc,
+            int limit,
+            CancellationToken ct) =>
+            Task.FromResult(0);
     }
 
     private static async Task<(SqliteTestDatabase Database, Guid DefinitionId)> SeedSharedDefinitionForStartAsync(

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionWorkItemWorkerHostedServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionWorkItemWorkerHostedServiceTests.cs
@@ -1,0 +1,1011 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Statevia.Core.Application.Contracts;
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Security;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Security;
+using Statevia.Runtime.Services;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>ExecutionWorkItemWorkerHostedService の単体テスト（Runtime カバレッジ用）。</summary>
+public sealed class ExecutionWorkItemWorkerHostedServiceTests
+{
+    /// <summary>空 claim のときポーリング待機へ入る。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenClaimEmpty_PollsWithoutProcessing()
+    {
+        // Arrange
+        var queue = new FakeWorkerQueue();
+        await using var provider = BuildProvider(queue, new RecordingExecutionService(), new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(180), CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            // テスト側待機キャンセルは無視する。
+        }
+
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(queue.ClaimCallCount >= 1);
+        Assert.Equal(0, queue.CompleteCallCount);
+    }
+
+    /// <summary>Start work item を claim すると ExecuteQueuedStart と Complete が呼ばれる。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenStartWorkItemClaimed_CompletesAfterQueuedStart()
+    {
+        // Arrange
+        var executionId = Guid.Parse("10101010-1010-1010-1010-101010101010");
+        var workItemId = Guid.Parse("20202020-2020-2020-2020-202020202020");
+        using var inputDoc = JsonDocument.Parse("{}");
+        var payload = JsonSerializer.Serialize(
+            new ExecutionStartWorkItemPayload(
+                executionId,
+                new StartExecutionRequest { DefinitionId = "d1", Input = inputDoc.RootElement }),
+            ExecutionWorkItemPayloadJson.Options);
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Start,
+            Payload = payload,
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = 3 };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.CompleteCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, executions.ExecuteQueuedStartCalls);
+        Assert.Equal(1, executions.BeginOwnedSessionCalls);
+        Assert.Equal(1, executions.AwaitLocalLoadCalls);
+        Assert.Equal(1, executions.EndOwnedSessionCalls);
+        Assert.Equal(1, queue.CompleteCallCount);
+    }
+
+    /// <summary>テナントが無い work item は Complete してスキップする。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenTenantMissing_CompletesWithoutSession()
+    {
+        // Arrange
+        var executionId = Guid.Parse("30303030-3030-3030-3030-303030303030");
+        var workItemId = Guid.Parse("40404040-4040-4040-4040-404040404040");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Cancel,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService();
+        await using var provider = BuildProvider(
+            queue,
+            executions,
+            new StubPlatformDataAccess { TenantToReturn = null });
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.CompleteCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, queue.CompleteCallCount);
+        Assert.Equal(0, executions.BeginOwnedSessionCalls);
+        Assert.Equal(0, executions.CancelCalls);
+    }
+
+    /// <summary>ownership 獲得失敗時は Release する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenOwnershipAcquireFails_ReleasesWorkItem()
+    {
+        // Arrange
+        var executionId = Guid.Parse("50505050-5050-5050-5050-505050505050");
+        var workItemId = Guid.Parse("60606060-6060-6060-6060-606060606060");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Cancel,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = null };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.ReleaseCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, queue.ReleaseCallCount);
+        Assert.Equal(0, queue.CompleteCallCount);
+        Assert.Equal(0, executions.CancelCalls);
+    }
+
+    /// <summary>Resume(recovery) work item は RecoverExecution を呼ぶ。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenRecoveryResumeClaimed_CallsRecover()
+    {
+        // Arrange
+        var executionId = Guid.Parse("70707070-7070-7070-7070-707070707070");
+        var workItemId = Guid.Parse("80808080-8080-8080-8080-808080808080");
+        var payload = JsonSerializer.Serialize(
+            new ExecutionResumeWorkItemPayload(ExecutionResumeWorkItemModes.Recovery),
+            ExecutionWorkItemPayloadJson.Options);
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Resume,
+            Payload = payload,
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = 1 };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.CompleteCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, executions.RecoverCalls);
+        Assert.Equal(1, queue.CompleteCallCount);
+    }
+
+    /// <summary>Cancel work item 成功時は CancelAsync と Complete が呼ばれる。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenCancelWorkItemClaimed_CompletesAfterCancel()
+    {
+        // Arrange
+        var executionId = Guid.Parse("91919191-9191-9191-9191-919191919191");
+        var workItemId = Guid.Parse("92929292-9292-9292-9292-929292929292");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Cancel,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = 1 };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.CompleteCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, executions.CancelCalls);
+        Assert.Equal(1, queue.CompleteCallCount);
+        Assert.Equal(0, executions.AwaitLocalLoadCalls);
+    }
+
+    /// <summary>Event Resume work item は ResumeNodeAsync を呼ぶ。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenEventResumeClaimed_CallsResumeNode()
+    {
+        // Arrange
+        var executionId = Guid.Parse("93939393-9393-9393-9393-939393939393");
+        var workItemId = Guid.Parse("94949494-9494-9494-9494-949494949494");
+        var payload = JsonSerializer.Serialize(
+            new ExecutionResumeWorkItemPayload(
+                ExecutionResumeWorkItemModes.Event,
+                NodeId: "wait-1",
+                EventName: "Go",
+                IdempotencyKey: "idem-1"),
+            ExecutionWorkItemPayloadJson.Options);
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Resume,
+            Payload = payload,
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = 1 };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.CompleteCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, executions.ResumeCalls);
+        Assert.Equal(1, executions.AwaitLocalLoadCalls);
+        Assert.Equal(1, queue.CompleteCallCount);
+    }
+
+    /// <summary>処理中例外は Release する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenProcessThrows_ReleasesWorkItem()
+    {
+        // Arrange
+        var executionId = Guid.Parse("95959595-9595-9595-9595-959595959595");
+        var workItemId = Guid.Parse("96969696-9696-9696-9696-969696969696");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Cancel,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService
+        {
+            BeginGenerationToReturn = 1,
+            CancelException = new InvalidOperationException("cancel failed")
+        };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.ReleaseCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, queue.ReleaseCallCount);
+        Assert.Equal(0, queue.CompleteCallCount);
+    }
+
+    /// <summary>非 Active テナントの work item は Complete してスキップする。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenTenantSuspended_CompletesWithoutSession()
+    {
+        // Arrange
+        var executionId = Guid.Parse("97979797-9797-9797-9797-979797979797");
+        var workItemId = Guid.Parse("98989898-9898-9898-9898-989898989898");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Cancel,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService();
+        await using var provider = BuildProvider(
+            queue,
+            executions,
+            new StubPlatformDataAccess
+            {
+                TenantToReturn = new ExecutionTenantLookup(
+                    TestTenantIds.T1TenantId,
+                    "t1",
+                    TenantLifecycle.Suspended)
+            });
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.CompleteCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, queue.CompleteCallCount);
+        Assert.Equal(0, executions.BeginOwnedSessionCalls);
+    }
+
+    /// <summary>不正な Resume payload は Release する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenResumePayloadInvalid_ReleasesWorkItem()
+    {
+        // Arrange
+        var executionId = Guid.Parse("99999999-9999-9999-9999-999999999991");
+        var workItemId = Guid.Parse("99999999-9999-9999-9999-999999999992");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Resume,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = 1 };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.ReleaseCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, queue.ReleaseCallCount);
+        Assert.Equal(0, queue.CompleteCallCount);
+    }
+
+    /// <summary>heartbeat で lease 更新失敗すると処理を中断する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenHeartbeatLeaseRenewFails_AbandonsSession()
+    {
+        // Arrange
+        var executionId = Guid.Parse("99999999-9999-9999-9999-999999999993");
+        var workItemId = Guid.Parse("99999999-9999-9999-9999-999999999994");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Cancel,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item], RenewLeaseResult = false };
+        var executions = new RecordingExecutionService
+        {
+            BeginGenerationToReturn = 1,
+            CancelDelay = TimeSpan.FromSeconds(25)
+        };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(35));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => executions.AbandonCalls > 0, TimeSpan.FromSeconds(30));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(executions.AbandonCalls >= 1);
+    }
+
+    /// <summary>claim 反復例外でもポーリングを継続する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenClaimThrows_ContinuesAfterRetryDelay()
+    {
+        // Arrange
+        var queue = new FakeWorkerQueue { ThrowOnClaim = true };
+        var executions = new RecordingExecutionService();
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(400));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(300), CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            // ignore
+        }
+
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(queue.ClaimCallCount >= 1);
+    }
+
+    /// <summary>セッション終了失敗時は Abandon にフォールバックする。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenEndOwnedSessionThrows_AbandonsSession()
+    {
+        // Arrange
+        var executionId = Guid.Parse("99999999-9999-9999-9999-999999999995");
+        var workItemId = Guid.Parse("99999999-9999-9999-9999-999999999996");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Cancel,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService
+        {
+            BeginGenerationToReturn = 1,
+            EndOwnedSessionException = new InvalidOperationException("end failed")
+        };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => executions.AbandonCalls > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(executions.AbandonCalls >= 1);
+        Assert.Equal(1, queue.CompleteCallCount);
+    }
+
+    /// <summary>heartbeat 例外でも処理 CTS をキャンセルする。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenHeartbeatThrows_AbandonsSession()
+    {
+        // Arrange
+        var executionId = Guid.Parse("99999999-9999-9999-9999-999999999997");
+        var workItemId = Guid.Parse("99999999-9999-9999-9999-999999999998");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Cancel,
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue
+        {
+            ItemsToClaim = [item],
+            RenewLeaseException = new InvalidOperationException("renew boom")
+        };
+        var executions = new RecordingExecutionService
+        {
+            BeginGenerationToReturn = 1,
+            CancelDelay = TimeSpan.FromSeconds(25)
+        };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(35));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => executions.AbandonCalls > 0, TimeSpan.FromSeconds(30));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(executions.AbandonCalls >= 1);
+    }
+
+    /// <summary>未知の work item kind は Release する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenKindUnknown_ReleasesWorkItem()
+    {
+        // Arrange
+        var executionId = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+        var workItemId = Guid.Parse("bbbbbbbb-2222-2222-2222-222222222222");
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = "unknown-kind",
+            Payload = "{}",
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = 1 };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.ReleaseCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, queue.ReleaseCallCount);
+    }
+
+    /// <summary>未知の resume mode は Release する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenResumeModeUnknown_ReleasesWorkItem()
+    {
+        // Arrange
+        var executionId = Guid.Parse("cccccccc-3333-3333-3333-333333333333");
+        var workItemId = Guid.Parse("dddddddd-4444-4444-4444-444444444444");
+        var payload = JsonSerializer.Serialize(
+            new ExecutionResumeWorkItemPayload("weird-mode", null, null, null),
+            ExecutionWorkItemPayloadJson.Options);
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Resume,
+            Payload = payload,
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = 1 };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.ReleaseCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, queue.ReleaseCallCount);
+    }
+
+    /// <summary>event resume で nodeId/eventName 欠落は Release する。</summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenEventResumeMissingFields_ReleasesWorkItem()
+    {
+        // Arrange
+        var executionId = Guid.Parse("eeeeeeee-5555-5555-5555-555555555555");
+        var workItemId = Guid.Parse("ffffffff-6666-6666-6666-666666666666");
+        var payload = JsonSerializer.Serialize(
+            new ExecutionResumeWorkItemPayload(ExecutionResumeWorkItemModes.Event, null, null, null),
+            ExecutionWorkItemPayloadJson.Options);
+        var item = new ExecutionWorkItemRow
+        {
+            WorkItemId = workItemId,
+            ExecutionId = executionId,
+            Kind = ExecutionWorkItemKinds.Resume,
+            Payload = payload,
+            AvailableAt = DateTime.UtcNow,
+            Attempts = 0,
+            CreatedAt = DateTime.UtcNow
+        };
+        var queue = new FakeWorkerQueue { ItemsToClaim = [item] };
+        var executions = new RecordingExecutionService { BeginGenerationToReturn = 1 };
+        await using var provider = BuildProvider(queue, executions, new StubPlatformDataAccess());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new ExecutionWorkItemWorkerHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<ExecutionWorkItemWorkerHostedService>.Instance,
+            new FixedIdGenerator());
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await WaitUntilAsync(() => queue.ReleaseCallCount > 0, TimeSpan.FromSeconds(1.5));
+        await sut.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, queue.ReleaseCallCount);
+    }
+
+    private static ServiceProvider BuildProvider(
+        IExecutionWorkQueue queue,
+        IExecutionService executions,
+        IPlatformDataAccess platform)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(queue);
+        services.AddSingleton(platform);
+        services.AddSingleton<ITenantContextAccessor>(new SettableTenantContextAccessor());
+        services.AddSingleton(executions);
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow.Add(timeout);
+        while (!predicate() && DateTime.UtcNow < deadline)
+            await Task.Delay(20, CancellationToken.None);
+    }
+
+    private sealed class FixedIdGenerator : IIdGenerator
+    {
+        public Guid NewSequentialGuid() => Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        public Guid NewRandomGuid() => Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    }
+
+    private sealed class StubPlatformDataAccess : IPlatformDataAccess
+    {
+        public ExecutionTenantLookup? TenantToReturn { get; set; } = new(
+            TestTenantIds.T1TenantId,
+            "t1",
+            TenantLifecycle.Active);
+
+        public Task<ExecutionTenantLookup?> FindExecutionTenantAsync(
+            Guid executionId,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(TenantToReturn);
+
+        public Task<TenantRow?> FindTenantByKeyAsync(string tenantKey, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<TenantRow>> ListActiveTenantsAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<LoginCredentialLookup?> FindLoginCredentialAsync(
+            string tenantKey,
+            string email,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<LoginCredentialLookup?> FindUserPrincipalAsync(
+            Guid tenantId,
+            Guid principalId,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<ApiKeyCredentialLookup?> FindApiKeyCredentialAsync(
+            string keyPrefix,
+            string keyHash,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task TouchApiKeyLastUsedAsync(Guid apiKeyId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task EnsureDefaultTenantAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task EnsurePermissionCatalogAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<bool> IsTenantAdminAsync(Guid principalId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> ExpandPrincipalPermissionKeysAsync(
+            Guid principalId,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<PrincipalRow?> FindPrincipalAsync(Guid principalId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<GroupSnapshot>> GetGroupSnapshotsForPrincipalAsync(
+            Guid principalId,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class FakeWorkerQueue : IExecutionWorkQueue
+    {
+        private int _claimRound;
+
+        public IReadOnlyList<ExecutionWorkItemRow> ItemsToClaim { get; set; } = [];
+        public int ClaimCallCount { get; private set; }
+        public int CompleteCallCount { get; private set; }
+        public int ReleaseCallCount { get; private set; }
+        public bool RenewLeaseResult { get; set; } = true;
+        public bool ThrowOnClaim { get; set; }
+        public Exception? RenewLeaseException { get; set; }
+
+        public Task EnqueueAsync(ExecutionWorkItemRow item, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task EnqueueAsync(ICoreUnitOfWork uow, ExecutionWorkItemRow item, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task EnqueueManyAsync(IReadOnlyList<ExecutionWorkItemRow> items, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task EnqueueManyAsync(
+            ICoreUnitOfWork uow,
+            IReadOnlyList<ExecutionWorkItemRow> items,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<ExecutionWorkItemRow>> ClaimAsync(
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            int limit,
+            CancellationToken ct)
+        {
+            ClaimCallCount++;
+            if (ThrowOnClaim)
+                throw new InvalidOperationException("claim failed");
+            if (_claimRound++ == 0 && ItemsToClaim.Count > 0)
+                return Task.FromResult(ItemsToClaim);
+
+            return Task.FromResult<IReadOnlyList<ExecutionWorkItemRow>>([]);
+        }
+
+        public Task CompleteAsync(Guid workItemId, string leaseOwner, CancellationToken ct)
+        {
+            CompleteCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RenewLeaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime utcNow,
+            TimeSpan leaseDuration,
+            CancellationToken ct)
+        {
+            if (RenewLeaseException is { } renewEx)
+                throw renewEx;
+            return Task.FromResult(RenewLeaseResult);
+        }
+
+        public Task ReleaseAsync(
+            Guid workItemId,
+            string leaseOwner,
+            DateTime availableAt,
+            CancellationToken ct)
+        {
+            ReleaseCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<int> EnqueueExpiredOwnershipRecoveriesAsync(
+            DateTime nowUtc,
+            int limit,
+            CancellationToken ct) =>
+            Task.FromResult(0);
+
+        public Task<int> EnqueueExpiredDelayWaitResumesAsync(
+            DateTime nowUtc,
+            int limit,
+            CancellationToken ct) =>
+            Task.FromResult(0);
+    }
+
+    private sealed class RecordingExecutionService : IExecutionService
+    {
+        public long? BeginGenerationToReturn { get; set; } = 1;
+        public int BeginOwnedSessionCalls { get; private set; }
+        public int EndOwnedSessionCalls { get; private set; }
+        public int ExecuteQueuedStartCalls { get; private set; }
+        public int AwaitLocalLoadCalls { get; private set; }
+        public int CancelCalls { get; private set; }
+        public int RecoverCalls { get; private set; }
+        public int ResumeCalls { get; private set; }
+        public int AbandonCalls { get; private set; }
+        public Exception? CancelException { get; set; }
+        public Exception? EndOwnedSessionException { get; set; }
+        public TimeSpan? CancelDelay { get; set; }
+
+        public Task<long?> BeginOwnedSessionAsync(
+            Guid executionId,
+            string workerId,
+            TimeSpan leaseDuration,
+            CancellationToken ct)
+        {
+            BeginOwnedSessionCalls++;
+            return Task.FromResult(BeginGenerationToReturn);
+        }
+
+        public Task<bool> RenewOwnedSessionLeaseAsync(
+            Guid executionId,
+            TimeSpan leaseDuration,
+            CancellationToken ct) =>
+            Task.FromResult(true);
+
+        public Task EndOwnedSessionAsync(Guid executionId, CancellationToken ct)
+        {
+            EndOwnedSessionCalls++;
+            if (EndOwnedSessionException is { } endEx)
+                throw endEx;
+            return Task.CompletedTask;
+        }
+
+        public Task AbandonLocalOwnedSessionAsync(Guid executionId)
+        {
+            AbandonCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task AwaitLocalExecutionLoadAsync(Guid executionId, CancellationToken ct)
+        {
+            AwaitLocalLoadCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task<ExecutionResponse> ExecuteQueuedStartAsync(
+            Guid executionId,
+            StartExecutionRequest request,
+            CancellationToken ct)
+        {
+            ExecuteQueuedStartCalls++;
+            return Task.FromResult(new ExecutionResponse
+            {
+                DisplayId = "d",
+                ResourceId = executionId,
+                Status = ExecutionProjectionStatuses.Running,
+                StartedAt = DateTime.UtcNow
+            });
+        }
+
+        public async Task CancelAsync(
+            string idOrUuid,
+            string? idempotencyKey,
+            CommandRequestContext requestContext,
+            CancellationToken ct)
+        {
+            CancelCalls++;
+            if (CancelException is { } cancelEx)
+                throw cancelEx;
+            if (CancelDelay is { } delay)
+                await Task.Delay(delay, ct);
+        }
+
+        public Task RecoverExecutionAsync(
+            Guid executionId,
+            CommandRequestContext requestContext,
+            CancellationToken ct)
+        {
+            RecoverCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task ResumeNodeAsync(
+            string idOrUuid,
+            string nodeId,
+            string? resumeKey,
+            string? idempotencyKey,
+            CommandRequestContext requestContext,
+            CancellationToken ct)
+        {
+            ResumeCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task<ExecutionResponse> StartAsync(
+            StartExecutionRequest request,
+            string? idempotencyKey,
+            CommandRequestContext requestContext,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<PagedResult<ExecutionResponse>> ListPagedAsync(
+            ExecutionListPageQuery query,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task EnsureExecutionExistsAsync(Guid executionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<string> GetGraphJsonAsync(string idOrUuid, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<string?> TryGetSnapshotGraphJsonByExecutionIdAsync(Guid executionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task PublishEventAsync(
+            string idOrUuid,
+            string eventName,
+            string? idempotencyKey,
+            CommandRequestContext requestContext,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task PersistCheckpointAndUnloadAsync(Guid executionId, string nodeId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task PersistCheckpointAndUnloadByEngineIdAsync(
+            string engineExecutionId,
+            string nodeId,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task UpdateProjectionFromEngineAsync(Guid executionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<ExecutionViewDto> GetExecutionViewAtSeqAsync(
+            string idOrUuid,
+            long atSeq,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<ExecutionEventsResponseDto> ListEventsAsync(
+            string idOrUuid,
+            long afterSeq,
+            int limit,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkGraphComposerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkGraphComposerTests.cs
@@ -308,4 +308,83 @@ public sealed class PhysicalForkGraphComposerTests
         // Assert
         Assert.Equal(parentJson, composed);
     }
+
+    /// <summary>不正な親 JSON は合成せずそのまま返す。</summary>
+    [Fact]
+    public void Compose_WhenParentJsonInvalid_ReturnsParentUnchanged()
+    {
+        // Arrange
+        const string parentJson = "not-json";
+
+        // Act
+        var composed = PhysicalForkGraphComposer.Compose(
+            parentJson,
+            [new PhysicalForkGraphComposer.BranchGraph("f", "j", "A", """{"nodes":[],"edges":[]}""")]);
+
+        // Assert
+        Assert.Equal(parentJson, composed);
+    }
+
+    /// <summary>Fork に時刻が無いとき visit index で Join を解決する。</summary>
+    [Fact]
+    public void ResolveJoinNodeId_WhenForkHasNoTime_UsesVisitIndex()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork-a","nodeName":"ForkSame"},
+                {"nodeId":"fork-b","nodeName":"ForkSame"},
+                {"nodeId":"join-a","nodeName":"JoinSame","nodeType":"Join","startedAt":"2026-01-01T00:00:00Z"},
+                {"nodeId":"join-b","nodeName":"JoinSame","nodeType":"Join","startedAt":"2026-01-01T00:00:01Z"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var joinForA = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork-a", "JoinSame");
+        var joinForB = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork-b", "JoinSame");
+
+        // Assert
+        Assert.Equal("join-a", joinForA);
+        Assert.Equal("join-b", joinForB);
+    }
+
+    /// <summary>joinState が空白なら null。</summary>
+    [Fact]
+    public void ResolveJoinNodeId_WhenJoinStateBlank_ReturnsNull()
+    {
+        // Act
+        var join = PhysicalForkGraphComposer.ResolveJoinNodeId(
+            """{"nodes":[{"nodeId":"f"}],"edges":[]}""",
+            "f",
+            "  ");
+
+        // Assert
+        Assert.Null(join);
+    }
+
+    /// <summary>Fork の nodeName が空なら先頭 Join 候補を返す。</summary>
+    [Fact]
+    public void ResolveJoinNodeId_WhenForkNameMissing_ReturnsFirstJoinCandidate()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"fork1"},
+                {"nodeId":"join1","nodeName":"J","nodeType":"Join","startedAt":"2026-01-01T00:00:00Z"},
+                {"nodeId":"join2","nodeName":"J","nodeType":"Join","startedAt":"2026-01-01T00:00:01Z"}
+              ],
+              "edges": []
+            }
+            """;
+
+        // Act
+        var join = PhysicalForkGraphComposer.ResolveJoinNodeId(parentJson, "fork1", "J");
+
+        // Assert
+        Assert.Equal("join1", join);
+    }
 }

--- a/service/api/Statevia.Service.Api.Tests/Services/RuntimeServiceCollectionExtensionsTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/RuntimeServiceCollectionExtensionsTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Statevia.Runtime.DependencyInjection;
+using Statevia.Runtime.Services;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>Runtime DI 拡張の薄い登録テスト（Runtime カバレッジ用）。</summary>
+public sealed class RuntimeServiceCollectionExtensionsTests
+{
+    /// <summary>scheduler / worker hosted service が ServiceDescriptor として登録される。</summary>
+    [Fact]
+    public void AddRuntimeHostedServices_RegistersExpectedBackgroundServiceDescriptors()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddStateviaRuntimeSchedulers();
+        services.AddStateviaRuntimeWorkerHostedService();
+        services.AddStateviaRuntimeOptions(new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Statevia:Runtime:WorkerEnabled"] = "true"
+        }).Build());
+
+        // Assert
+        var hostedImplementations = services
+            .Where(descriptor => descriptor.ServiceType == typeof(IHostedService))
+            .Select(descriptor => descriptor.ImplementationType)
+            .ToList();
+        Assert.Contains(typeof(DelayWaitSchedulerHostedService), hostedImplementations);
+        Assert.Contains(typeof(ExecutionOwnershipRecoveryHostedService), hostedImplementations);
+        Assert.Contains(typeof(ExecutionWorkItemWorkerHostedService), hostedImplementations);
+    }
+
+    /// <summary>AddStateviaSchedulerHost は Persistence と Scheduler を登録する。</summary>
+    [Fact]
+    public void AddStateviaSchedulerHost_WithConnectionString_RegistersSchedulers()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DefaultConnection"] = "Host=127.0.0.1;Database=statevia;Username=x;Password=y"
+        }).Build();
+
+        // Act
+        services.AddStateviaSchedulerHost(configuration);
+
+        // Assert
+        var hostedImplementations = services
+            .Where(descriptor => descriptor.ServiceType == typeof(IHostedService))
+            .Select(descriptor => descriptor.ImplementationType)
+            .ToList();
+        Assert.Contains(typeof(DelayWaitSchedulerHostedService), hostedImplementations);
+        Assert.Contains(typeof(ExecutionOwnershipRecoveryHostedService), hostedImplementations);
+    }
+
+    /// <summary>null 引数は ArgumentNullException になる。</summary>
+    [Fact]
+    public void AddRuntimeExtensions_NullArguments_Throw()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        // Act + Assert
+        Assert.Throws<ArgumentNullException>(
+            () => RuntimeServiceCollectionExtensions.AddStateviaSchedulerHost(null!, configuration));
+        Assert.Throws<ArgumentNullException>(() => services.AddStateviaSchedulerHost(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => RuntimeServiceCollectionExtensions.AddStateviaRuntimeSchedulers(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => RuntimeServiceCollectionExtensions.AddStateviaRuntimeWorkerHostedService(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => RuntimeServiceCollectionExtensions.AddStateviaRuntimeOptions(null!, configuration));
+        Assert.Throws<ArgumentNullException>(() => services.AddStateviaRuntimeOptions(null!));
+    }
+}

--- a/sonar/sonar-scanner-runtime.ps1
+++ b/sonar/sonar-scanner-runtime.ps1
@@ -74,7 +74,7 @@ try {
     }
 
     # HostedService の単体テストは Api.Tests 側にある。
-    dotnet-coverage collect 'dotnet test Statevia.Service.Api.Tests/Statevia.Service.Api.Tests.csproj --filter FullyQualifiedName~DelayWaitSchedulerHostedServiceTests|FullyQualifiedName~OptionsValidationTests' -f xml -o "$coverageXml"
+    dotnet-coverage collect 'dotnet test Statevia.Service.Api.Tests/Statevia.Service.Api.Tests.csproj --filter FullyQualifiedName~DelayWaitSchedulerHostedServiceTests|FullyQualifiedName~OptionsValidationTests|FullyQualifiedName~ExecutionWorkItemWorkerHostedServiceTests|FullyQualifiedName~ExecutionOwnershipRecoveryHostedServiceTests|FullyQualifiedName~RuntimeServiceCollectionExtensionsTests' -f xml -o "$coverageXml"
     if ($LASTEXITCODE -ne 0) {
         Write-Error '[ERROR] test / coverage failed'
         exit 1


### PR DESCRIPTION
## Summary
- ServiceApi / Runtime の単体テストを追加し、Sonar overall coverage をそれぞれ 85% / 92% まで底上げする（今後の機能 PR がゲートに引っかからないバッファ用）。
- Runtime 向けに Worker / OwnershipRecovery / DelayWait / DI 拡張のテストを追加し、`sonar-scanner-runtime.ps1` の収集 filter を更新する。
- 本番コードは変更せず、テストとスキャン設定のみ。

## Test plan
- [x] `cd service/api && dotnet test statevia-api.sln` が green
- [x] Sonar `StateviaServiceApi` overall coverage ≥ 85%
- [x] Sonar `StateviaServiceRuntime` overall coverage ≥ 85%（実測 92%）
- [x] 差分に本番コードが含まれないこと（`sonar-scanner-runtime.ps1` の filter 以外）


Made with [Cursor](https://cursor.com)