### PR TITLE
ExecutionService を Facade とドメインサービスに分割する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Sonar / Analyzer: [`docs/development-guidelines.md`](docs/development-guidelines
 - **Read-model**: `GET /v1/executions` / graph は DB projection 正本（[`data-integration.md`](docs/specifications/data-integration.md)）。Hosted 物理 Fork の親 graph / events は **GET 時合成**（UI は分割非認知。[`fork-join.md`](docs/specifications/execution/fork-join.md)）
 - **IO-14**: 既定で `input` / `output` を一覧 GET に含めない。ログは `LogRedaction`（[`io-log-masking.md`](docs/specifications/platform/io-log-masking.md)）
 - **Engine 境界**: `ExecutionEngine` は `IStateExecutor` のみ。Catalog / Policy / ModuleHost は Service API 側。Hosted Fork の親子協調は Application（`execution_branches`・予約 Resume）
+- **Execution Facade**: HTTP / Worker は `IExecutionService` のみ。実処理は `core/application` のドメインサービス（Query / Lifecycle / WaitEvent / Checkpoint / Ownership / Recovery / Projection）。境界は [`docs/architecture/domain-model-boundaries.md`](docs/architecture/domain-model-boundaries.md)
 - **Serena MCP**: プロジェクトごとに `serena-engine` … `serena-ui` の 9 サーバー（`serena-runtime` 含む）。切替は UI トグル（同時 On は原則 1）。未起動時は停止して起動を促す。[`serena-mcp-project-toggle`](.spec/archive/specs/serena-mcp-project-toggle/requirements.md) / [`.cursor/skills/serena-mcp-project-switch/SKILL.md`](.cursor/skills/serena-mcp-project-switch/SKILL.md)
 
 ## .NET SDK

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ExecutionIdempotencyService>();
         services.AddScoped<ExecutionProjectionOrchestrator>();
         services.AddScoped<ExecutionLifecycleCommandService>();
+        services.AddScoped<ExecutionWaitEventService>();
         services.AddScoped<IExecutionService, ExecutionService>();
         services.AddScoped<IEventIngressService, EventIngressService>();
         services.AddScoped<IForkChildExecutionCoordinator, ForkChildExecutionCoordinator>();

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<IDefinitionSchemaService, DefinitionSchemaService>();
         services.AddSingleton<ExecutionOwnershipTracker>();
         services.AddScoped<ExecutionQueryService>();
+        services.AddScoped<ExecutionIdempotencyService>();
         services.AddScoped<IExecutionService, ExecutionService>();
         services.AddScoped<IEventIngressService, EventIngressService>();
         services.AddScoped<IForkChildExecutionCoordinator, ForkChildExecutionCoordinator>();

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ExecutionQueryService>();
         services.AddScoped<ExecutionIdempotencyService>();
         services.AddScoped<ExecutionProjectionOrchestrator>();
+        services.AddScoped<ExecutionLifecycleCommandService>();
         services.AddScoped<IExecutionService, ExecutionService>();
         services.AddScoped<IEventIngressService, EventIngressService>();
         services.AddScoped<IForkChildExecutionCoordinator, ForkChildExecutionCoordinator>();

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -24,6 +24,8 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<IActionSchemaService, ActionSchemaService>();
         services.AddSingleton<IDefinitionSchemaService, DefinitionSchemaService>();
         services.AddSingleton<ExecutionOwnershipTracker>();
+        services.AddScoped<ExecutionAuthorizationGuard>();
+        services.AddScoped<ExecutionEngineSession>();
         services.AddScoped<ExecutionQueryService>();
         services.AddScoped<ExecutionIdempotencyService>();
         services.AddScoped<ExecutionProjectionOrchestrator>();

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<ExecutionOwnershipTracker>();
         services.AddScoped<ExecutionQueryService>();
         services.AddScoped<ExecutionIdempotencyService>();
+        services.AddScoped<ExecutionProjectionOrchestrator>();
         services.AddScoped<IExecutionService, ExecutionService>();
         services.AddScoped<IEventIngressService, EventIngressService>();
         services.AddScoped<IForkChildExecutionCoordinator, ForkChildExecutionCoordinator>();

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -28,8 +28,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ExecutionIdempotencyService>();
         services.AddScoped<ExecutionProjectionOrchestrator>();
         services.AddScoped<ExecutionLifecycleCommandService>();
-        services.AddScoped<ExecutionWaitEventService>();
         services.AddScoped<ExecutionCheckpointService>();
+        services.AddScoped<ExecutionForkJoinCoordinator>();
+        services.AddScoped<ExecutionWaitEventService>();
         services.AddScoped<ExecutionOwnershipService>();
         services.AddScoped<ExecutionRecoveryService>();
         services.AddScoped<IExecutionService, ExecutionService>();

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<IActionSchemaService, ActionSchemaService>();
         services.AddSingleton<IDefinitionSchemaService, DefinitionSchemaService>();
         services.AddSingleton<ExecutionOwnershipTracker>();
+        services.AddScoped<ExecutionQueryService>();
         services.AddScoped<IExecutionService, ExecutionService>();
         services.AddScoped<IEventIngressService, EventIngressService>();
         services.AddScoped<IForkChildExecutionCoordinator, ForkChildExecutionCoordinator>();

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ExecutionProjectionOrchestrator>();
         services.AddScoped<ExecutionLifecycleCommandService>();
         services.AddScoped<ExecutionWaitEventService>();
+        services.AddScoped<ExecutionCheckpointService>();
         services.AddScoped<IExecutionService, ExecutionService>();
         services.AddScoped<IEventIngressService, EventIngressService>();
         services.AddScoped<IForkChildExecutionCoordinator, ForkChildExecutionCoordinator>();

--- a/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/core/application/Statevia.Core.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -30,6 +30,8 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ExecutionLifecycleCommandService>();
         services.AddScoped<ExecutionWaitEventService>();
         services.AddScoped<ExecutionCheckpointService>();
+        services.AddScoped<ExecutionOwnershipService>();
+        services.AddScoped<ExecutionRecoveryService>();
         services.AddScoped<IExecutionService, ExecutionService>();
         services.AddScoped<IEventIngressService, EventIngressService>();
         services.AddScoped<IForkChildExecutionCoordinator, ForkChildExecutionCoordinator>();

--- a/core/application/Statevia.Core.Application/Services/ExecutionAuthorizationGuard.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionAuthorizationGuard.cs
@@ -1,0 +1,70 @@
+using Statevia.Core.Application.Infrastructure;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 実行系コマンド／照会入口の認可チェックを横断で提供する。
+/// </summary>
+/// <remarks>
+/// <para>各ドメインサービスの入口から呼び、認可呼び出し箇所を一覧可能にする。</para>
+/// <para>定義受理時のプロジェクト実行権と、Runtime / mutation snapshot ベースの read/write を担う。</para>
+/// </remarks>
+/// <param name="runtimeAuth">Runtime 権限。</param>
+/// <param name="mutationAuth">実行ミューテーション認可。</param>
+/// <param name="projectAuth">プロジェクト認可。</param>
+/// <param name="definitions">定義リポジトリ（プロジェクト解決）。</param>
+/// <param name="executor">トランザクション実行。</param>
+internal sealed class ExecutionAuthorizationGuard(
+    IRuntimePermissionAuthorization runtimeAuth,
+    IExecutionMutationAuthorization mutationAuth,
+    IProjectAuthorizationService projectAuth,
+    IDefinitionRepository definitions,
+    ICoreTransactionExecutor executor)
+{
+    /// <summary>Runtime の executions:read を要求する。</summary>
+    /// <param name="ct">キャンセル。</param>
+    public Task EnsureExecutionsReadAsync(CancellationToken ct) =>
+        runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsRead, ct);
+
+    /// <summary>Runtime の executions:write を要求する。</summary>
+    /// <param name="ct">キャンセル。</param>
+    public Task EnsureExecutionsWriteAsync(CancellationToken ct) =>
+        runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsWrite, ct);
+
+    /// <summary>実行行の security snapshot に基づきミューテーション権限を要求する。</summary>
+    /// <param name="execution">実行投影行。</param>
+    /// <param name="ct">キャンセル。</param>
+    public Task EnsureExecutionMutationWriteAsync(ExecutionRow execution, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(execution);
+        var snapshot = ExecutionSecuritySnapshotJson.TryDeserialize(execution.SecuritySnapshotJson);
+        return mutationAuth.EnsureMutationPermissionAsync(
+            snapshot,
+            RuntimePermissionRequirements.ExecutionsWrite,
+            ct);
+    }
+
+    /// <summary>定義が属するプロジェクト上で実行開始可能かを要求する。</summary>
+    /// <param name="tenantId">テナント ID。</param>
+    /// <param name="definitionId">定義 ID。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <exception cref="NotFoundException">定義が見つからないとき。</exception>
+    public Task EnsureCanExecuteOnDefinitionAsync(
+        Guid tenantId,
+        Guid definitionId,
+        CancellationToken ct) =>
+        executor.ExecuteReadOnlyAsync(
+            async (uow, innerCt) =>
+            {
+                var projectId = await definitions
+                    .ResolveProjectIdAsync(uow, tenantId, definitionId, innerCt)
+                    .ConfigureAwait(false);
+                if (projectId is null)
+                    throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
+
+                await projectAuth
+                    .EnsureCanExecuteAsync(uow, tenantId, projectId.Value, innerCt)
+                    .ConfigureAwait(false);
+            },
+            ct);
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionCheckpointService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionCheckpointService.cs
@@ -158,11 +158,16 @@ internal sealed class ExecutionCheckpointService(
     /// 内容破棄候補の checkpoint を削除するか、Worker 所有中なら runtime JSON のみ更新する。
     /// </summary>
     /// <remarks>
-    /// 所有（OwnedLease）は寿命表の保持理由ではない。Worker 都合で行を残し refresh する別層。
+    /// <para>所有（OwnedLease）は寿命表の保持理由ではない。Worker 都合で行を残し refresh する別層。</para>
+    /// <para>
+    /// Running 中も保持理由が空なら内容破棄候補になるが、実行中 Engine は落とさない。
+    /// 終端のときだけ <see langword="true"/> を返し、投影同期後の Unload を許可する。
+    /// </para>
     /// </remarks>
     /// <returns>
-    /// 投影同期後に Engine を Unload してよいとき <see langword="true"/>。
-    /// 所有中の refresh や削除のみの場合は <see langword="false"/>。
+    /// 投影同期後に Engine を Unload してよいとき <see langword="true"/>
+    ///（checkpoint 削除後かつ Engine が終端）。所有中 refresh や Running 中の削除のみは
+    /// <see langword="false"/>。
     /// </returns>
     public async Task<bool> DiscardOrRefreshRuntimeCheckpointAsync(
         ICoreUnitOfWork uow,
@@ -179,7 +184,10 @@ internal sealed class ExecutionCheckpointService(
         }
 
         await checkpointStore.DeleteAsync(uow, executionId, ct).ConfigureAwait(false);
-        return false;
+
+        // Running（保持理由なし）でも内容は捨てるが、進行中 Load は投影から落とさない。
+        var snapshot = engine.GetSnapshot(engineExecutionId);
+        return snapshot is { IsCompleted: true } or { IsCancelled: true } or { IsFailed: true };
     }
 
     /// <summary>
@@ -230,7 +238,30 @@ internal sealed class ExecutionCheckpointService(
         finally
         {
             gate.Release();
+            TryRemoveIdlePersistUnloadGate(executionId, gate);
         }
+    }
+
+    /// <summary>
+    /// 待ちが無い Persist+Unload ゲートを辞書から除去し Dispose する。
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ConcurrentDictionary{TKey,TValue}.TryRemove(KeyValuePair{TKey,TValue})"/> で
+    /// 値一致時のみ除去し、除去後に待ちがある場合は再登録して Dispose しない。
+    /// </remarks>
+    private static void TryRemoveIdlePersistUnloadGate(Guid executionId, SemaphoreSlim gate)
+    {
+        if (!PersistUnloadGates.TryRemove(new KeyValuePair<Guid, SemaphoreSlim>(executionId, gate)))
+            return;
+
+        // Release 後に他スレッドが同一ゲートを待ち始めた場合は戻して生きたままにする。
+        if (gate.CurrentCount != 1)
+        {
+            _ = PersistUnloadGates.TryAdd(executionId, gate);
+            return;
+        }
+
+        gate.Dispose();
     }
 
     /// <summary>ゲート取得後の Persist + Unload 本体。</summary>

--- a/core/application/Statevia.Core.Application/Services/ExecutionCheckpointService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionCheckpointService.cs
@@ -363,7 +363,7 @@ internal sealed class ExecutionCheckpointService(
                     .GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
                     .ConfigureAwait(false);
                 if (existingCheckpoint is not null
-                    && ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(existingCheckpoint.CheckpointJson, out var stored, out _)
+                    && ExecutionEngineSession.TryParseRuntimeCheckpoint(existingCheckpoint.CheckpointJson, out var stored, out _)
                     && IsRuntimeCheckpointLessAdvanced(request.Checkpoint, stored))
                 {
                     skippedStalePersist = true;

--- a/core/application/Statevia.Core.Application/Services/ExecutionCheckpointService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionCheckpointService.cs
@@ -321,6 +321,9 @@ internal sealed class ExecutionCheckpointService(
         if (skippedStalePersist)
             return;
 
+        // fencing 喪失時もローカル所有と Engine は必ず破棄する（docs/concepts/durability.md）。
+        // DB の owner 列は触らない: TryUpsert 失敗は世代不一致＝他 Worker が正本のまま残すため。
+        // メモリだけ Clear するのは「このプロセスが所有を主張しなくなる」ための意図的な非対称である。
         ownership.Clear(executionId);
         engine.Unload(engineExecutionId);
 
@@ -410,6 +413,7 @@ internal sealed class ExecutionCheckpointService(
                                 request.UpdatedAt),
                             innerCt)
                         .ConfigureAwait(false);
+                    // false = 世代不一致。DB 所有は勝者側に残し、呼び出し側でローカル Clear/Unload する。
                     if (!upserted)
                         return true;
 

--- a/core/application/Statevia.Core.Application/Services/ExecutionCheckpointService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionCheckpointService.cs
@@ -1,0 +1,479 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 実行 runtime checkpoint の永続化と Unload / KeepLoaded、世代フェンス。
+/// </summary>
+/// <remarks>
+/// <para><see cref="ExecutionService"/> Facade から委譲される。HTTP / Worker 契約は変更しない。</para>
+/// <para>同一実行の Persist+Unload は <c>PersistUnloadGates</c> で直列化し、古い Fork Unload の上書きを防ぐ。</para>
+/// <para>寿命表に基づく破棄判定もここに集約し、投影 / Wait Resume からフックとして利用する。</para>
+/// </remarks>
+/// <param name="engine">実行エンジン。</param>
+/// <param name="checkpointStore">runtime checkpoint 永続化。</param>
+/// <param name="ownership">Worker 所有トラッカー。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="executions">executions / snapshot 永続化。</param>
+/// <param name="projection">投影オーケストレータ。</param>
+/// <param name="lifecycle">ライフサイクル（checkpoint upsert）。</param>
+/// <param name="logger">構造化ログ。</param>
+/// <param name="forkChildCoordinator">物理 Join 保留判定（任意）。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
+internal sealed class ExecutionCheckpointService(
+    IExecutionEngine engine,
+    IExecutionCheckpointStore checkpointStore,
+    ExecutionOwnershipTracker ownership,
+    ICoreTransactionExecutor executor,
+    IExecutionRepository executions,
+    ExecutionProjectionOrchestrator projection,
+    ExecutionLifecycleCommandService lifecycle,
+    ILogger<ExecutionCheckpointService> logger,
+    IForkChildExecutionCoordinator? forkChildCoordinator = null)
+{
+    /// <summary>
+    /// 同一実行の <see cref="PersistCheckpointAndUnloadCoreAsync"/> を直列化し、
+    /// 古い Fork Unload が新しい Wait 断面を上書きしないようにする。
+    /// </summary>
+    private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> PersistUnloadGates = new();
+
+    /// <summary>
+    /// ステップ完了時に checkpoint を保存する（Unload しない）。
+    /// </summary>
+    /// <remarks>
+    /// Worker 所有中は世代付き upsert（fencing 失敗時はログのみ）。所有外は通常 upsert。
+    /// Engine ID が GUID でない、または export が null のときは no-op。
+    /// </remarks>
+    /// <param name="engineExecutionId">Engine 辞書キー。</param>
+    /// <param name="ct">キャンセル。</param>
+    public async Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(engineExecutionId);
+        if (!Guid.TryParse(engineExecutionId, out var executionId))
+        {
+            logger.SkipKeepLoadedCheckpointInvalidExecutionId(engineExecutionId);
+            return;
+        }
+
+        var checkpoint = engine.ExportCheckpoint(engineExecutionId);
+        if (checkpoint is null)
+            return;
+
+        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
+        var updatedAt = DateTime.UtcNow;
+
+        await executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                if (ownership.TryGet(executionId, out _, out var generation))
+                {
+                    var ok = await checkpointStore.TryUpsertRuntimeWithGenerationAsync(
+                            uow,
+                            new ExecutionCheckpointRuntimeUpsert(
+                                executionId,
+                                generation,
+                                json,
+                                checkpoint.SchemaVersion,
+                                updatedAt),
+                            innerCt)
+                        .ConfigureAwait(false);
+                    if (!ok)
+                    {
+                        logger.KeepLoadedCheckpointRejectedByFencing(executionId);
+                    }
+
+                    return;
+                }
+
+                await checkpointStore.UpsertAsync(
+                        uow,
+                        new ExecutionCheckpointDocument
+                        {
+                            ExecutionId = executionId,
+                            CheckpointJson = json,
+                            SchemaVersion = checkpoint.SchemaVersion,
+                            UpdatedAt = updatedAt
+                        },
+                        innerCt)
+                    .ConfigureAwait(false);
+            },
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 寿命表に従い checkpoint <b>内容</b>の破棄候補か。
+    /// </summary>
+    /// <remarks>
+    /// 保持理由は <see cref="RuntimeCheckpointRetainReasons"/> のみ
+    ///（PendingWaits / PendingPhysicalJoin）。
+    /// Worker 所有 lease は同列にせず、破棄候補でも
+    /// <see cref="DiscardOrRefreshRuntimeCheckpointAsync"/> が Delete を抑止する。
+    /// </remarks>
+    public async Task<bool> ShouldDiscardRuntimeCheckpointAsync(
+        Guid executionId,
+        string status,
+        string graphJson,
+        CancellationToken ct)
+    {
+        var retainReasons = await EvaluateRuntimeCheckpointRetainReasonsAsync(
+                executionId,
+                graphJson,
+                ct)
+            .ConfigureAwait(false);
+        return RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(status, retainReasons);
+    }
+
+    /// <summary>
+    /// 寿命表の内容保持理由を評価する（OwnedLease は含めない）。
+    /// </summary>
+    private async Task<RuntimeCheckpointRetainReasons> EvaluateRuntimeCheckpointRetainReasonsAsync(
+        Guid executionId,
+        string graphJson,
+        CancellationToken ct)
+    {
+        var reasons = RuntimeCheckpointRetainReasons.None;
+
+        if (ExecutionOperationalProjectionSync.HasDurableWaits(graphJson))
+            reasons |= RuntimeCheckpointRetainReasons.PendingWaits;
+
+        if (forkChildCoordinator is not null
+            && await forkChildCoordinator
+                .HasPendingPhysicalJoinBranchesAsync(executionId, ct)
+                .ConfigureAwait(false))
+        {
+            reasons |= RuntimeCheckpointRetainReasons.PendingPhysicalJoin;
+        }
+
+        return reasons;
+    }
+
+    /// <summary>
+    /// 内容破棄候補の checkpoint を削除するか、Worker 所有中なら runtime JSON のみ更新する。
+    /// </summary>
+    /// <remarks>
+    /// 所有（OwnedLease）は寿命表の保持理由ではない。Worker 都合で行を残し refresh する別層。
+    /// </remarks>
+    /// <returns>
+    /// 投影同期後に Engine を Unload してよいとき <see langword="true"/>。
+    /// 所有中の refresh や削除のみの場合は <see langword="false"/>。
+    /// </returns>
+    public async Task<bool> DiscardOrRefreshRuntimeCheckpointAsync(
+        ICoreUnitOfWork uow,
+        string engineExecutionId,
+        Guid executionId,
+        CancellationToken ct)
+    {
+        if (ownership.TryGet(executionId, out _, out _))
+        {
+            // Worker 所有中。寿命表上は破棄候補でも lease 行は残し runtime だけ更新する。
+            _ = await lifecycle.UpsertRuntimeCheckpointAsync(uow, engineExecutionId, executionId, ct)
+                .ConfigureAwait(false);
+            return false;
+        }
+
+        await checkpointStore.DeleteAsync(uow, executionId, ct).ConfigureAwait(false);
+        return false;
+    }
+
+    /// <summary>
+    /// Wait 登録直後: チェックポイントを保存して Unload する。
+    /// </summary>
+    /// <remarks>
+    /// Engine 辞書キーは <see cref="Guid.ToString()"/>（Start 時と同じ形式）を使う。
+    /// Export できない場合は Warning を出し、Unload しない（インメモリ再開を維持する）。
+    /// </remarks>
+    public Task PersistCheckpointAndUnloadAsync(Guid executionId, string nodeId, CancellationToken ct) =>
+        PersistCheckpointAndUnloadCoreAsync(executionId.ToString(), executionId, nodeId, ct);
+
+    /// <summary>
+    /// Engine 実行 ID 文字列を正としてチェックポイントを保存し Unload する。
+    /// </summary>
+    /// <param name="engineExecutionId">Engine に渡した実行 ID（辞書キー）。</param>
+    /// <param name="nodeId">Wait ノード ID（ログ用）。</param>
+    /// <param name="ct">キャンセル。</param>
+    public Task PersistCheckpointAndUnloadByEngineIdAsync(
+        string engineExecutionId,
+        string nodeId,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(engineExecutionId);
+        if (!Guid.TryParse(engineExecutionId, out var executionId))
+        {
+            logger.SkipCheckpointPersistInvalidExecutionId(engineExecutionId);
+            return Task.CompletedTask;
+        }
+
+        return PersistCheckpointAndUnloadCoreAsync(engineExecutionId, executionId, nodeId, ct);
+    }
+
+    /// <summary>チェックポイント upsert ののち Engine から Unload する共通実装。</summary>
+    private async Task PersistCheckpointAndUnloadCoreAsync(
+        string engineExecutionId,
+        Guid executionId,
+        string nodeId,
+        CancellationToken ct)
+    {
+        var gate = PersistUnloadGates.GetOrAdd(executionId, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await PersistCheckpointAndUnloadUnderGateAsync(engineExecutionId, executionId, nodeId, ct)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>ゲート取得後の Persist + Unload 本体。</summary>
+    private async Task PersistCheckpointAndUnloadUnderGateAsync(
+        string engineExecutionId,
+        Guid executionId,
+        string nodeId,
+        CancellationToken ct)
+    {
+        var checkpoint = engine.ExportCheckpoint(engineExecutionId);
+        if (checkpoint is null)
+        {
+            logger.ExportCheckpointNullSkipUnload(engineExecutionId, nodeId);
+            return;
+        }
+
+        // ForkExpansion は fire-and-forget のため ExpandFork 完了が Join→decide より遅れることがある。
+        // その遅延 Persist が空断面で Unload すると Wait 登録前／登録直後の decide を潰す（初回 Wait 到達不能）。
+        if (IsForkExpansionUnloadObsolete(checkpoint, nodeId))
+        {
+            logger.SkipForkExpansionUnloadAlreadyProgressed(
+                executionId,
+                nodeId,
+                checkpoint.ActiveStates.Count,
+                checkpoint.PendingWaits.Count);
+            return;
+        }
+
+        // Unload 前に投影へ反映する（Unload 後は GetSnapshot が null になり投影キューが空振りする）。
+        // snapshot 欠落時は Unknown/`{}` を書かず checkpoint のみ残す（マルチ Worker 競合で UI を壊さない）。
+        var snapshot = engine.GetSnapshot(engineExecutionId);
+        string? status = null;
+        bool? cancelRequested = null;
+        string? graphJson = null;
+        if (snapshot is not null)
+        {
+            status = ExecutionProjectionOrchestrator.MapStatus(snapshot);
+            cancelRequested = snapshot.IsCancelled;
+            graphJson = engine.ExportExecutionGraph(engineExecutionId);
+        }
+
+        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
+        var updatedAt = DateTime.UtcNow;
+        var (fenceLost, skippedStalePersist) = await PersistCheckpointDocumentUnderTransactionAsync(
+                new CheckpointDocumentPersistRequest(
+                    executionId,
+                    nodeId,
+                    checkpoint,
+                    json,
+                    updatedAt,
+                    status,
+                    cancelRequested,
+                    graphJson),
+                ct)
+            .ConfigureAwait(false);
+
+        if (skippedStalePersist)
+            return;
+
+        ownership.Clear(executionId);
+        engine.Unload(engineExecutionId);
+
+        if (fenceLost)
+        {
+            logger.UnloadAfterWaitFencingLost(nodeId, executionId);
+            return;
+        }
+
+        logger.CheckpointUnloadedAfterWait(executionId, nodeId);
+    }
+
+    /// <summary>Persist ゲート内の checkpoint 文書 Upsert 入力。</summary>
+    private readonly record struct CheckpointDocumentPersistRequest(
+        Guid ExecutionId,
+        string NodeId,
+        ExecutionRuntimeCheckpoint Checkpoint,
+        string CheckpointJson,
+        DateTime UpdatedAt,
+        string? Status,
+        bool? CancelRequested,
+        string? GraphJson);
+
+    /// <summary>
+    /// Persist ゲート内トランザクション: 投影更新・checkpoint Upsert・所有クリア。
+    /// </summary>
+    /// <returns>fencing 喪失と stale skip の有無。</returns>
+    private async Task<(bool FenceLost, bool SkippedStalePersist)> PersistCheckpointDocumentUnderTransactionAsync(
+        CheckpointDocumentPersistRequest request,
+        CancellationToken ct)
+    {
+        var skippedStalePersist = false;
+        var fenceLost = await executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                var existingCheckpoint = await checkpointStore
+                    .GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
+                    .ConfigureAwait(false);
+                if (existingCheckpoint is not null
+                    && ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(existingCheckpoint.CheckpointJson, out var stored, out _)
+                    && IsRuntimeCheckpointLessAdvanced(request.Checkpoint, stored))
+                {
+                    skippedStalePersist = true;
+                    logger.SkipStaleCheckpointPersist(
+                        request.ExecutionId,
+                        request.NodeId,
+                        stored.PendingWaits.Count,
+                        request.Checkpoint.PendingWaits.Count,
+                        stored.Graph.Nodes.Count,
+                        request.Checkpoint.Graph.Nodes.Count);
+                    return false;
+                }
+
+                var execution = await executions.GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
+                    .ConfigureAwait(false);
+                if (execution is not null && request.Status is not null && request.GraphJson is not null)
+                {
+                    await executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            request.ExecutionId,
+                            request.Status,
+                            request.CancelRequested,
+                            request.GraphJson,
+                            innerCt)
+                        .ConfigureAwait(false);
+                    await projection.SyncOperationalProjectionAsync(
+                            uow,
+                            request.ExecutionId,
+                            execution.TenantId,
+                            request.Status,
+                            request.GraphJson,
+                            nodeIdToClear: null,
+                            innerCt)
+                        .ConfigureAwait(false);
+                }
+
+                if (ownership.TryGet(request.ExecutionId, out _, out var generation))
+                {
+                    var upserted = await checkpointStore.TryUpsertRuntimeWithGenerationAsync(
+                            uow,
+                            new ExecutionCheckpointRuntimeUpsert(
+                                request.ExecutionId,
+                                generation,
+                                request.CheckpointJson,
+                                request.Checkpoint.SchemaVersion,
+                                request.UpdatedAt),
+                            innerCt)
+                        .ConfigureAwait(false);
+                    if (!upserted)
+                        return true;
+
+                    await checkpointStore.TryClearOwnershipAsync(uow, request.ExecutionId, generation, innerCt)
+                        .ConfigureAwait(false);
+                    return false;
+                }
+
+                await checkpointStore.UpsertAsync(
+                    uow,
+                    new ExecutionCheckpointDocument
+                    {
+                        ExecutionId = request.ExecutionId,
+                        CheckpointJson = request.CheckpointJson,
+                        SchemaVersion = request.Checkpoint.SchemaVersion,
+                        UpdatedAt = request.UpdatedAt
+                    },
+                    innerCt).ConfigureAwait(false);
+
+                var existing = await checkpointStore.GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
+                    .ConfigureAwait(false);
+                if (existing?.OwnerWorkerId is not null)
+                {
+                    await checkpointStore.TryClearOwnershipAsync(
+                            uow,
+                            request.ExecutionId,
+                            existing.OwnerGeneration,
+                            innerCt)
+                        .ConfigureAwait(false);
+                }
+
+                return false;
+            },
+            ct).ConfigureAwait(false);
+
+        return (fenceLost, skippedStalePersist);
+    }
+
+    /// <summary>
+    /// 永続済み断面より incoming が遅れているか（古い Fork Unload の上書き防止）。
+    /// </summary>
+    /// <remarks>単体テストから到達するため internal。</remarks>
+    internal static bool IsRuntimeCheckpointLessAdvanced(
+        ExecutionRuntimeCheckpoint incoming,
+        ExecutionRuntimeCheckpoint stored)
+    {
+        if (incoming.IsCompleted || incoming.IsCancelled || incoming.IsFailed)
+            return false;
+
+        if (incoming.Graph.Nodes.Count < stored.Graph.Nodes.Count)
+            return true;
+
+        // stored に durable Wait があり、incoming が Fork 待ち相当（active/wait 空）なら古い。
+        return stored.PendingWaits.Count > 0
+            && incoming.PendingWaits.Count == 0
+            && incoming.ActiveStates.Count == 0;
+    }
+
+    /// <summary>
+    /// Fork 展開後の Persist が、当該 Fork より先の Join / Wait 進行後に遅延したか。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Hosted では <c>NotifyForkExpansion</c> が非同期のため、子完了→Join→decide が
+    /// <c>ExpandFork</c> 完了より先に進みうる。その場合の Unload は decide Wait を失わせる。
+    /// </para>
+    /// <para>
+    /// <paramref name="nodeId"/> が Fork ノードでない呼び出し（Wait Suspend）は常に false。
+    /// </para>
+    /// <para>単体テストから到達するため internal。</para>
+    /// </remarks>
+    /// <param name="checkpoint">Export 直後の断面。</param>
+    /// <param name="nodeId">Persist 要求元のノード ID（Fork 展開時は Fork ノード）。</param>
+    /// <returns>Unload をスキップすべきなら true。</returns>
+    internal static bool IsForkExpansionUnloadObsolete(
+        ExecutionRuntimeCheckpoint checkpoint,
+        string nodeId)
+    {
+        var forkNode = checkpoint.Graph.Nodes
+            .FirstOrDefault(n =>
+                string.Equals(n.NodeId, nodeId, StringComparison.Ordinal)
+                && string.Equals(n.NodeType, "Fork", StringComparison.OrdinalIgnoreCase));
+        if (forkNode is null)
+            return false;
+
+        // Join 後の decide 実行中、または durable Wait 登録済みなら SuspendHandler に委ねる。
+        if (checkpoint.ActiveStates.Count > 0 || checkpoint.PendingWaits.Count > 0)
+            return true;
+
+        // この Fork 到達以降に Join が完了していれば、子待ち Unload の窓は閉じている。
+        return checkpoint.Graph.Nodes.Any(n =>
+            string.Equals(n.NodeType, "Join", StringComparison.OrdinalIgnoreCase)
+            && n.StartedAt >= forkNode.StartedAt
+            && (string.Equals(n.Fact, "Joined", StringComparison.OrdinalIgnoreCase)
+                || n.CompletedAt is not null));
+    }
+
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionEngineSession.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionEngineSession.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 実行 Engine の Load（checkpoint hydrate）共用ヘルパー。
+/// </summary>
+/// <remarks>
+/// <para>Cancel / Publish / Resume / Recover / Join など複数ドメインから共有する。</para>
+/// <para>Unload ゲートや Wait quiesce 待機はドメイン固有のためここに含めない（肥大化防止）。</para>
+/// </remarks>
+/// <param name="engine">実行エンジン。</param>
+/// <param name="compiler">定義コンパイル復元。</param>
+/// <param name="definitions">定義リポジトリ。</param>
+/// <param name="checkpointStore">runtime checkpoint 永続化。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="logger">構造化ログ。</param>
+internal sealed class ExecutionEngineSession(
+    IExecutionEngine engine,
+    IDefinitionCompilerService compiler,
+    IDefinitionRepository definitions,
+    IExecutionCheckpointStore checkpointStore,
+    ICoreTransactionExecutor executor,
+    ILogger<ExecutionEngineSession> logger)
+{
+    /// <summary>
+    /// ミューテーション前に Engine インスタンスを保証する（未ロードなら checkpoint から hydrate）。
+    /// </summary>
+    /// <remarks>
+    /// 終端投影かつメモリ未ロード、または checkpoint 欠落・不正時は例外。二重 hydrate は 422 相当へ写像する。
+    /// </remarks>
+    /// <param name="executionId">実行 UUID。</param>
+    /// <param name="execution">投影行（テナント・定義バージョン・status）。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <exception cref="ArgumentException">終端未ロード、checkpoint 欠落、または二重 hydrate。</exception>
+    /// <exception cref="InvalidOperationException">定義バージョン欠落または checkpoint 不正。</exception>
+    public async Task EnsureEngineRuntimeLoadedForMutationAsync(
+        Guid executionId,
+        ExecutionRow execution,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(execution);
+        if (engine.GetSnapshot(executionId.ToString()) is not null)
+            return;
+
+        if (ExecutionProjectionStatuses.IsTerminal(execution.Status))
+        {
+            throw new ArgumentException(
+                "The execution is already in a terminal state in the database projection, but there is no in-memory instance in this API process. Cancel or event delivery cannot be applied.");
+        }
+
+        var checkpointDocument = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => checkpointStore.GetByExecutionIdAsync(uow, executionId, innerCt),
+            ct).ConfigureAwait(false);
+        if (checkpointDocument is null)
+        {
+            throw new ArgumentException(
+                "The execution state is not loaded in this API process and no runtime checkpoint was found.");
+        }
+
+        var versionRow = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => definitions.GetVersionForExecutionByIdAsync(
+                uow,
+                execution.TenantId,
+                execution.DefinitionVersionId,
+                innerCt),
+            ct).ConfigureAwait(false);
+        if (versionRow is null)
+        {
+            throw new InvalidOperationException(
+                $"Definition version '{execution.DefinitionVersionId}' was not found for execution '{executionId}'.");
+        }
+
+        var compiled = RestoreCompiledDefinitionFromVersion(versionRow);
+        if (!TryParseRuntimeCheckpoint(checkpointDocument.CheckpointJson, out var checkpoint, out var parseError))
+        {
+            logger.RuntimeCheckpointInvalidForHydrate(
+                executionId,
+                checkpointDocument.CheckpointJson?.Length ?? 0);
+            if (parseError is not null)
+                logger.RuntimeCheckpointDeserializeFailed(parseError, executionId);
+
+            throw new InvalidOperationException(
+                $"Stored runtime checkpoint for execution '{executionId:D}' is empty or invalid and cannot be hydrated.");
+        }
+
+        try
+        {
+            engine.ImportCheckpoint(compiled, checkpoint);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // 二重 hydrate 等はクライアント向け 422（ArgumentException）へ写像する。
+            throw new ArgumentException(ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// 永続 checkpoint JSON を hydrate 用に検証・デシリアライズする。
+    /// </summary>
+    /// <remarks>
+    /// <c>BeginOwnedSessionAsync</c> の seed <c>{}</c> や必須欠落は不正とし、Import しない。
+    /// </remarks>
+    /// <param name="checkpointJson">永続化された checkpoint JSON。</param>
+    /// <param name="checkpoint">成功時のデシリアライズ結果。</param>
+    /// <param name="parseError">JSON 例外時のみ設定。形式不正（必須欠落）は null。</param>
+    /// <returns>hydrate 可能なとき true。</returns>
+    internal static bool TryParseRuntimeCheckpoint(
+        string? checkpointJson,
+        out ExecutionRuntimeCheckpoint checkpoint,
+        out Exception? parseError)
+    {
+        checkpoint = null!;
+        parseError = null;
+
+        if (string.IsNullOrWhiteSpace(checkpointJson))
+            return false;
+
+        var trimmed = checkpointJson.Trim();
+        if (trimmed is "{}" or "null")
+            return false;
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<ExecutionRuntimeCheckpoint>(
+                checkpointJson,
+                JsonSerializerProfiles.CamelCase);
+            if (parsed is null
+                || string.IsNullOrWhiteSpace(parsed.ExecutionId)
+                || string.IsNullOrWhiteSpace(parsed.DefinitionName)
+                || parsed.ActiveStates is null
+                || parsed.Graph is null
+                || parsed.Join is null
+                || parsed.Context is null
+                || parsed.PendingWaits is null)
+            {
+                return false;
+            }
+
+            // 物理 Join 待ち中は ActiveStates / PendingWaits が空の正規断面になり得る（Fork Unload 後）。
+            // 空配列だけでは破損とみなさない（seed "{}" は上で拒否済み）。
+
+            checkpoint = parsed;
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            parseError = ex;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 永続化された定義バージョンからコンパイル済み定義を復元する。
+    /// </summary>
+    private CompiledWorkflowDefinition RestoreCompiledDefinitionFromVersion(DefinitionVersionRow versionRow)
+    {
+        try
+        {
+            return compiler.RestoreFromStoredVersion(versionRow.SourceYaml, versionRow.CompiledJson);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InvalidOperationException("Stored definition version is invalid.", ex);
+        }
+    }
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionForkJoinCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionForkJoinCoordinator.cs
@@ -1,0 +1,528 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 親 Physical Join の完了/失敗と子完了 Resume による Join 再評価。
+/// </summary>
+/// <remarks>
+/// <para><see cref="ExecutionService"/> Facade / <see cref="ExecutionWaitEventService"/> から利用する。</para>
+/// <para>展開・子 Wait 配送・EvaluateJoin 自体は既存の <see cref="IForkChildExecutionCoordinator"/> を利用する。</para>
+/// </remarks>
+/// <param name="engine">実行エンジン。</param>
+/// <param name="executions">executions / snapshot 永続化。</param>
+/// <param name="checkpointStore">runtime checkpoint。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="lifecycle">Engine hydrate / checkpoint upsert。</param>
+/// <param name="projection">投影オーケストレータ。</param>
+/// <param name="checkpoints">checkpoint 寿命・破棄。</param>
+/// <param name="logger">構造化ログ。</param>
+/// <param name="forkChildCoordinator">Join 評価・展開協調（任意）。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
+internal sealed class ExecutionForkJoinCoordinator(
+    IExecutionEngine engine,
+    IExecutionRepository executions,
+    IExecutionCheckpointStore checkpointStore,
+    ICoreTransactionExecutor executor,
+    ExecutionLifecycleCommandService lifecycle,
+    ExecutionProjectionOrchestrator projection,
+    ExecutionCheckpointService checkpoints,
+    ILogger<ExecutionForkJoinCoordinator> logger,
+    IForkChildExecutionCoordinator? forkChildCoordinator = null)
+{
+    /// <summary>実行グラフ JSON のプロパティ名（Join 冪等判定用）。</summary>
+    private static class ExecutionGraphJsonProperties
+    {
+        internal const string Nodes = "nodes";
+        internal const string CompletedAt = "completedAt";
+        internal const string NodeId = "nodeId";
+        internal const string Fact = "fact";
+        internal const string Status = "status";
+    }
+
+    /// <summary>
+    /// 物理子終端の予約 Resume を受け、親の Join を再評価する（D2-B / D3）。
+    /// </summary>
+    /// <param name="parentExecutionId">親 execution。</param>
+    /// <param name="execution">親の投影行。</param>
+    /// <param name="forkNodeId">Resume payload の nodeId（Fork 到達インスタンス）。</param>
+    /// <param name="ct">キャンセル。</param>
+    public async Task HandleChildCompletedResumeAsync(
+        Guid parentExecutionId,
+        ExecutionRow execution,
+        string forkNodeId,
+        CancellationToken ct)
+    {
+        if (forkChildCoordinator is null)
+            return;
+
+        if (ExecutionLifecycleCommandService.IsTerminalExecutionProjectionStatus(execution.Status))
+            return;
+
+        var evaluation = await forkChildCoordinator
+            .EvaluateJoinAsync(parentExecutionId, forkNodeId, ct)
+            .ConfigureAwait(false);
+
+        switch (evaluation.Kind)
+        {
+            case ForkJoinEvaluationKind.Waiting:
+                return;
+
+            case ForkJoinEvaluationKind.Failed:
+                await FailParentFromJoinAsync(
+                        parentExecutionId,
+                        forkNodeId,
+                        evaluation.FailureStatus ?? ExecutionProjectionStatuses.Failed,
+                        ct)
+                    .ConfigureAwait(false);
+                return;
+
+            case ForkJoinEvaluationKind.Satisfied:
+                // 既に当該 Fork 訪問の Join が投影上 SUCCEEDED なら再実行しない（child.completed 再送の冪等）。
+                var snapshotRow = await executor.ExecuteReadOnlyAsync(
+                        (uow, innerCt) => executions.GetSnapshotByExecutionIdAsync(
+                            uow,
+                            parentExecutionId,
+                            innerCt),
+                        ct)
+                    .ConfigureAwait(false);
+                if (snapshotRow is not null
+                    && IsPhysicalJoinAlreadyCompleted(
+                        snapshotRow.GraphJson,
+                        forkNodeId,
+                        evaluation.JoinState))
+                {
+                    logger.ForkJoinAlreadyCompleted(parentExecutionId, forkNodeId, evaluation.JoinState);
+                    return;
+                }
+
+                await CompleteParentPhysicalJoinAsync(
+                        parentExecutionId,
+                        execution,
+                        forkNodeId,
+                        evaluation,
+                        ct)
+                    .ConfigureAwait(false);
+                return;
+
+            default:
+                throw new InvalidOperationException($"Unknown fork join evaluation kind '{evaluation.Kind}'.");
+        }
+    }
+
+    /// <summary>
+    /// Unload 後でも、Join が進んで Wait / 終端断面が checkpoint に残っているか。
+    /// </summary>
+    private async Task<bool> HasPhysicalJoinProgressAfterUnloadAsync(
+        Guid parentExecutionId,
+        CancellationToken ct)
+    {
+        var document = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => checkpointStore.GetByExecutionIdAsync(uow, parentExecutionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        if (document is null
+            || !ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(document.CheckpointJson, out var checkpoint, out _))
+        {
+            return false;
+        }
+
+        if (checkpoint.IsCompleted || checkpoint.IsCancelled || checkpoint.IsFailed)
+            return true;
+
+        if (checkpoint.PendingWaits.Count > 0)
+            return true;
+
+        return checkpoint.ActiveStates.Count > 0;
+    }
+
+    /// <summary>
+    /// 親グラフ上で、当該 Fork 訪問に対応する Join が既に SUCCEEDED か。
+    /// </summary>
+    /// <remarks>単体テストから到達するため internal。</remarks>
+    internal static bool IsPhysicalJoinAlreadyCompleted(
+        string parentGraphJson,
+        string forkNodeId,
+        string joinState)
+    {
+        var joinNodeId = PhysicalForkGraphComposer.ResolveJoinNodeId(
+            parentGraphJson,
+            forkNodeId,
+            joinState);
+        if (string.IsNullOrWhiteSpace(joinNodeId))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(parentGraphJson);
+            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
+                || nodes.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            // joinNodeId は Fork 訪問ごとに一意。一致ノードが無ければ未完了扱い。
+            var node = nodes.EnumerateArray().FirstOrDefault(candidate =>
+                candidate.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var idEl)
+                && string.Equals(idEl.GetString(), joinNodeId, StringComparison.Ordinal));
+            if (node.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            // 投影 JSON は UI 用 status ではなく fact / completedAt を持つ。
+            // 当該 Fork 訪問に紐づく Join が既に Joined なら冪等スキップ（循環の別訪問は別 Join nodeId）。
+            var fact = node.TryGetProperty(ExecutionGraphJsonProperties.Fact, out var factEl)
+                ? factEl.GetString()
+                : null;
+            if (string.Equals(fact, "Joined", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(fact, "Completed", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAtEl)
+                && completedAtEl.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(completedAtEl.GetString()))
+            {
+                return true;
+            }
+
+            var status = node.TryGetProperty(ExecutionGraphJsonProperties.Status, out var statusEl)
+                ? statusEl.GetString()
+                : null;
+            return string.Equals(status, "SUCCEEDED", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Join 失敗／キャンセルを親投影へ伝播する（残子 Cancel はタスク 6）。</summary>
+    private async Task FailParentFromJoinAsync(
+        Guid parentExecutionId,
+        string forkNodeId,
+        string failureStatus,
+        CancellationToken ct)
+    {
+        logger.ForkJoinFailedPropagated(parentExecutionId, forkNodeId, failureStatus);
+
+        var snapshot = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => executions.GetSnapshotByExecutionIdAsync(uow, parentExecutionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        var graphJson = snapshot?.GraphJson ?? """{"nodes":[],"edges":[]}""";
+        var cancelRequested = string.Equals(
+            failureStatus,
+            ExecutionProjectionStatuses.Cancelled,
+            StringComparison.Ordinal);
+
+        await executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    await executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            parentExecutionId,
+                            failureStatus,
+                            cancelRequested,
+                            graphJson,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    await checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
+                            uow,
+                            parentExecutionId.ToString(),
+                            parentExecutionId,
+                            innerCt)
+                        .ConfigureAwait(false);
+                },
+                ct)
+            .ConfigureAwait(false);
+
+        engine.Unload(parentExecutionId.ToString());
+    }
+
+    /// <summary>Join 充足時に親 Engine で物理 Join を完了し投影を更新する。</summary>
+    private async Task CompleteParentPhysicalJoinAsync(
+        Guid parentExecutionId,
+        ExecutionRow execution,
+        string forkNodeId,
+        ForkJoinEvaluation evaluation,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(evaluation.CandidateInputs);
+        logger.ForkJoinSatisfied(parentExecutionId, forkNodeId, evaluation.JoinState);
+
+        await lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(parentExecutionId, execution, ct).ConfigureAwait(false);
+
+        var engineId = parentExecutionId.ToString();
+        IReadOnlyList<PhysicalJoinContextFragment>? fragments = null;
+        if (evaluation.ContextMerges is { Count: > 0 })
+        {
+            fragments = evaluation.ContextMerges
+                .Select(m => new PhysicalJoinContextFragment(m.States, m.Vars))
+                .ToList();
+        }
+
+        engine.CompletePhysicalJoin(
+            engineId,
+            evaluation.JoinState,
+            evaluation.CandidateInputs,
+            fragments);
+        // Join は Schedule 非同期のため、ActiveStates==0 ですぐ戻ると decide Wait 前の断面を永続してしまう。
+        await WaitForPhysicalJoinSettlementAsync(
+            engineId,
+            forkNodeId,
+            evaluation.JoinState,
+            ct).ConfigureAwait(false);
+
+        // Join 直後に Wait へ進むと SuspendHandler が PersistCheckpointAndUnload する。
+        // Unload 後は GetSnapshot が null になり得る。checkpoint に Wait / 終端が進んでいれば冪等完了。
+        // Join が startedJoins 等で無動作のまま Unload された場合は再試行する。
+        var (status, cancelRequested, graphJson) = projection.BuildProjectionFromEngineForQueue(parentExecutionId);
+        if (status is null || graphJson is null)
+        {
+            if (!await HasPhysicalJoinProgressAfterUnloadAsync(parentExecutionId, ct).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException(
+                    $"Physical join for execution '{parentExecutionId:D}' unloaded before Join advanced; will retry.");
+            }
+
+            // SuspendHandler が checkpoint だけ進めて snapshot が遅れている場合の補正。
+            await TrySyncGraphSnapshotFromRuntimeCheckpointAsync(parentExecutionId, execution, ct)
+                .ConfigureAwait(false);
+
+            logger.ForkJoinProjectionSkippedAfterUnload(
+                parentExecutionId,
+                forkNodeId,
+                evaluation.JoinState);
+            return;
+        }
+
+        await executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    // Settlement 待機後〜tx 開始前に Wait Persist が進んでいることがあるので直前に再取得。
+                    var (freshStatus, freshCancel, freshGraph) = projection.BuildProjectionFromEngineForQueue(parentExecutionId);
+                    var writeStatus = freshStatus ?? status;
+                    var writeCancel = freshCancel ?? cancelRequested;
+                    var writeGraph = freshGraph ?? graphJson;
+
+                    await executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            parentExecutionId,
+                            writeStatus,
+                            writeCancel,
+                            writeGraph,
+                            innerCt)
+                        .ConfigureAwait(false);
+                    await projection.SyncOperationalProjectionAsync(
+                            uow,
+                            parentExecutionId,
+                            execution.TenantId,
+                            writeStatus,
+                            writeGraph,
+                            nodeIdToClear: null,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    if (await checkpoints.ShouldDiscardRuntimeCheckpointAsync(
+                                parentExecutionId,
+                                writeStatus,
+                                writeGraph,
+                                innerCt)
+                            .ConfigureAwait(false))
+                    {
+                        await checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
+                                uow,
+                                engineId,
+                                parentExecutionId,
+                                innerCt)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await lifecycle.UpsertRuntimeCheckpointAsync(uow, engineId, parentExecutionId, innerCt)
+                            .ConfigureAwait(false);
+                    }
+                },
+                ct)
+            .ConfigureAwait(false);
+
+        await projection.EnqueueAsync(parentExecutionId, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 物理 Join 完了後、Join ノード完了・decide Wait 登録・Unload・終端のいずれかまで待つ。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IExecutionEngine.CompletePhysicalJoin"/> は Join を非同期 Schedule するだけなので、
+    /// 直後は <c>ActiveStates</c> が空のままである。ここで
+    /// <see cref="ExecutionWaitEventService.WaitForEngineQuiescedAfterWaitAsync"/> を使うと Join 前断面を投影してしまう。
+    /// </para>
+    /// <para>
+    /// Join 直後に長い Action が続く場合でも、Join ノード完了で抜けて投影する。
+    /// durable Wait 登録・Unload・終端も同様に出口とする。
+    /// </para>
+    /// </remarks>
+    /// <param name="engineExecutionId">Engine 辞書キー。</param>
+    /// <param name="forkNodeId">充足した物理 Fork の graph nodeId。</param>
+    /// <param name="joinState">対応する Join 状態名。</param>
+    /// <param name="ct">キャンセル。</param>
+    private async Task WaitForPhysicalJoinSettlementAsync(
+        string engineExecutionId,
+        string forkNodeId,
+        string joinState,
+        CancellationToken ct)
+    {
+        const int maxAttempts = 200;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var snapshot = engine.GetSnapshot(engineExecutionId);
+            if (snapshot is null)
+                return;
+
+            if (snapshot.IsCompleted || snapshot.IsCancelled || snapshot.IsFailed)
+                return;
+
+            var graphJson = engine.ExportExecutionGraph(engineExecutionId);
+            if (IsPhysicalJoinAlreadyCompleted(graphJson, forkNodeId, joinState))
+                return;
+
+            var checkpoint = engine.ExportCheckpoint(engineExecutionId);
+            if (checkpoint is { PendingWaits.Count: > 0 })
+                return;
+
+            await Task.Delay(10, ct).ConfigureAwait(false);
+        }
+
+        logger.WaitResumeQuiesceTimedOut(engineExecutionId);
+    }
+
+    /// <summary>
+    /// Unload 後に runtime checkpoint が Wait 断面まで進んでいるとき、graph snapshot を追いつかせる。
+    /// </summary>
+    private async Task TrySyncGraphSnapshotFromRuntimeCheckpointAsync(
+        Guid executionId,
+        ExecutionRow execution,
+        CancellationToken ct)
+    {
+        await executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    var runtime = await checkpointStore
+                        .GetByExecutionIdAsync(uow, executionId, innerCt)
+                        .ConfigureAwait(false);
+                    if (runtime is null
+                        || !ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(runtime.CheckpointJson, out var checkpoint, out _)
+                        || checkpoint.PendingWaits.Count == 0)
+                    {
+                        return;
+                    }
+
+                    var graphJson = engine.ExportExecutionGraph(executionId.ToString());
+                    if (graphJson is "{}" || string.IsNullOrWhiteSpace(graphJson))
+                    {
+                        // Engine Unload 済みなら checkpoint 内グラフを投影 JSON へ写す。
+                        graphJson = JsonSerializer.Serialize(
+                            new
+                            {
+                                nodes = checkpoint.Graph.Nodes,
+                                edges = checkpoint.Graph.Edges
+                            },
+                            JsonSerializerProfiles.CamelCase);
+                    }
+
+                    var existingSnapshot = await executions
+                        .GetSnapshotByExecutionIdAsync(uow, executionId, innerCt)
+                        .ConfigureAwait(false);
+                    if (existingSnapshot?.GraphJson is not null
+                        && !IsGraphSnapshotBehindCheckpoint(existingSnapshot.GraphJson, checkpoint))
+                    {
+                        return;
+                    }
+
+                    var status = execution.Status;
+                    if (string.IsNullOrWhiteSpace(status))
+                        status = "Running";
+
+                    await executions
+                        .UpdateExecutionAndSnapshotAsync(
+                            uow,
+                            executionId,
+                            status,
+                            execution.CancelRequested,
+                            graphJson,
+                            innerCt)
+                        .ConfigureAwait(false);
+                    await projection.SyncOperationalProjectionAsync(
+                            uow,
+                            executionId,
+                            execution.TenantId,
+                            status,
+                            graphJson,
+                            nodeIdToClear: null,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    logger.SyncedGraphSnapshotFromRuntimeCheckpoint(
+                        executionId,
+                        checkpoint.PendingWaits.Count,
+                        checkpoint.Graph.Nodes.Count);
+                },
+                ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>永続 graph snapshot が runtime checkpoint より遅れているか。</summary>
+    private static bool IsGraphSnapshotBehindCheckpoint(
+        string snapshotGraphJson,
+        ExecutionRuntimeCheckpoint checkpoint)
+    {
+        if (!TryCountGraphNodes(snapshotGraphJson, out var snapshotNodeCount))
+            return true;
+
+        if (snapshotNodeCount < checkpoint.Graph.Nodes.Count)
+            return true;
+
+        return checkpoint.PendingWaits.Count > 0
+            && !ExecutionOperationalProjectionSync.HasDurableWaits(snapshotGraphJson);
+    }
+
+    /// <summary>グラフ JSON のノード数を数える。</summary>
+    private static bool TryCountGraphNodes(string graphJson, out int count)
+    {
+        count = 0;
+        if (string.IsNullOrWhiteSpace(graphJson))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(graphJson);
+            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
+                || nodes.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            count = nodes.GetArrayLength();
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionForkJoinCoordinator.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionForkJoinCoordinator.cs
@@ -16,7 +16,8 @@ namespace Statevia.Core.Application.Services;
 /// <param name="executions">executions / snapshot 永続化。</param>
 /// <param name="checkpointStore">runtime checkpoint。</param>
 /// <param name="executor">トランザクション実行。</param>
-/// <param name="lifecycle">Engine hydrate / checkpoint upsert。</param>
+/// <param name="lifecycle">checkpoint upsert。</param>
+/// <param name="engineSession">Engine Load / hydrate。</param>
 /// <param name="projection">投影オーケストレータ。</param>
 /// <param name="checkpoints">checkpoint 寿命・破棄。</param>
 /// <param name="logger">構造化ログ。</param>
@@ -31,6 +32,7 @@ internal sealed class ExecutionForkJoinCoordinator(
     IExecutionCheckpointStore checkpointStore,
     ICoreTransactionExecutor executor,
     ExecutionLifecycleCommandService lifecycle,
+    ExecutionEngineSession engineSession,
     ExecutionProjectionOrchestrator projection,
     ExecutionCheckpointService checkpoints,
     ILogger<ExecutionForkJoinCoordinator> logger,
@@ -128,7 +130,7 @@ internal sealed class ExecutionForkJoinCoordinator(
                 ct)
             .ConfigureAwait(false);
         if (document is null
-            || !ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(document.CheckpointJson, out var checkpoint, out _))
+            || !ExecutionEngineSession.TryParseRuntimeCheckpoint(document.CheckpointJson, out var checkpoint, out _))
         {
             return false;
         }
@@ -261,7 +263,7 @@ internal sealed class ExecutionForkJoinCoordinator(
         ArgumentNullException.ThrowIfNull(evaluation.CandidateInputs);
         logger.ForkJoinSatisfied(parentExecutionId, forkNodeId, evaluation.JoinState);
 
-        await lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(parentExecutionId, execution, ct).ConfigureAwait(false);
+        await engineSession.EnsureEngineRuntimeLoadedForMutationAsync(parentExecutionId, execution, ct).ConfigureAwait(false);
 
         var engineId = parentExecutionId.ToString();
         IReadOnlyList<PhysicalJoinContextFragment>? fragments = null;
@@ -425,7 +427,7 @@ internal sealed class ExecutionForkJoinCoordinator(
                         .GetByExecutionIdAsync(uow, executionId, innerCt)
                         .ConfigureAwait(false);
                     if (runtime is null
-                        || !ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(runtime.CheckpointJson, out var checkpoint, out _)
+                        || !ExecutionEngineSession.TryParseRuntimeCheckpoint(runtime.CheckpointJson, out var checkpoint, out _)
                         || checkpoint.PendingWaits.Count == 0)
                     {
                         return;

--- a/core/application/Statevia.Core.Application/Services/ExecutionIdempotencyService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionIdempotencyService.cs
@@ -1,0 +1,366 @@
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Statevia.Core.Application.Configuration;
+using Statevia.Core.Application.Infrastructure;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 実行コマンド / イベント配送の冪等判定と再送復元。
+/// </summary>
+/// <remarks>
+/// <para><c>command_dedup</c> のヒット復元・衝突検出と、<c>event_delivery_dedup</c> の RECEIVED 先行挿入を担う。</para>
+/// <para>dedup 行の APPLIED 更新や Save は呼び出し側のミューテーション tx に残す。</para>
+/// </remarks>
+/// <param name="dedupService">command dedup キー組み立て。</param>
+/// <param name="commandDedup">command_dedup 永続化。</param>
+/// <param name="eventDeliveryDedup">event_delivery_dedup 永続化。</param>
+/// <param name="tenantContext">テナント文脈。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="eventDeliveryRetryOptions">イベント配送挿入の再試行設定。</param>
+/// <param name="correlationIdAccessor">相関 ID。</param>
+/// <param name="logger">構造化ログ。</param>
+internal sealed class ExecutionIdempotencyService(
+    ICommandDedupService dedupService,
+    ICommandDedupRepository commandDedup,
+    IEventDeliveryDedupRepository eventDeliveryDedup,
+    ITenantContextAccessor tenantContext,
+    ICoreTransactionExecutor executor,
+    IOptions<EventDeliveryRetryOptions> eventDeliveryRetryOptions,
+    ICorrelationIdAccessor correlationIdAccessor,
+    ILogger<ExecutionIdempotencyService> logger)
+{
+    /// <summary><c>event_delivery_decision</c> 構造化ログの <c>decision</c> プロパティ値。</summary>
+    private static class EventDeliveryLogDecisions
+    {
+        internal const string Inserted = "inserted";
+        internal const string DuplicateKey = "duplicate_key";
+        internal const string AbortedTimeout = "aborted_timeout";
+        internal const string Retry = "retry";
+        internal const string BackoffBudgetExhausted = "backoff_budget_exhausted";
+        internal const string Failed = "failed";
+    }
+
+    /// <summary>
+    /// <c>event_delivery_decision</c> 構造化ログの <c>errorCode</c>、および dedup 行の既知 <c>error_code</c> 値。
+    /// </summary>
+    private static class EventDeliveryLogErrorCodes
+    {
+        internal const string None = "none";
+        internal const string UniqueViolation = "unique_violation";
+    }
+
+    /// <summary>command dedup キーを組み立てる（キー未指定時は <see langword="null"/>）。</summary>
+    /// <param name="tenantKey">テナントキー。</param>
+    /// <param name="idempotencyKey">冪等キー。</param>
+    /// <param name="method">HTTP メソッド相当。</param>
+    /// <param name="path">パス。</param>
+    /// <param name="requestHash">任意のリクエストハッシュ（Start 用）。</param>
+    /// <returns>dedup キー。未指定時は null。</returns>
+    public CommandDedupKey? CreateKey(
+        string tenantKey,
+        string? idempotencyKey,
+        string method,
+        string path,
+        string? requestHash = null) =>
+        dedupService.Create(tenantKey, idempotencyKey, method, path, requestHash);
+
+    /// <summary>
+    /// Start の command_dedup からキャッシュ応答を復元する。衝突ハッシュがあれば例外。
+    /// </summary>
+    /// <param name="dedupKey">command dedup キー。</param>
+    /// <param name="requestHash">今回のリクエストハッシュ。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>キャッシュされた Start 応答。無ければ null。</returns>
+    public async Task<ExecutionResponse?> TryGetIdempotentStartResponseAsync(
+        CommandDedupKey? dedupKey,
+        string requestHash,
+        CancellationToken ct)
+    {
+        if (dedupKey is not { } key)
+        {
+            return null;
+        }
+
+        var tenantKey = tenantContext.GetRequiredTenantKey();
+        var dedupCheckTime = DateTime.UtcNow;
+        var existing = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => commandDedup.FindValidAsync(uow, key.DedupKey, dedupCheckTime, innerCt),
+            ct).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            var cached = DeserializeCachedExecutionResponse(existing);
+            if (cached is not null)
+            {
+                return cached;
+            }
+        }
+
+        var conflicting = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => commandDedup.FindValidConflictingRequestHashAsync(
+                uow,
+                tenantKey,
+                key.Endpoint,
+                key.IdempotencyKey,
+                requestHash,
+                dedupCheckTime,
+                innerCt),
+            ct).ConfigureAwait(false);
+        if (conflicting is not null)
+        {
+            throw new IdempotencyConflictException(
+                "The same X-Idempotency-Key was used with a different request body.");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// 有効な command_dedup 行が存在するかどうか（Cancel / Publish / Resume の早期 return 用）。
+    /// </summary>
+    /// <param name="dedupKey">command dedup キー。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>有効行があれば true。</returns>
+    public async Task<bool> HasValidCommandDedupAsync(CommandDedupKey? dedupKey, CancellationToken ct)
+    {
+        if (dedupKey is not { } key)
+            return false;
+
+        var dedupCheckTime = DateTime.UtcNow;
+        var existing = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => commandDedup.FindValidAsync(uow, key.DedupKey, dedupCheckTime, innerCt),
+            ct).ConfigureAwait(false);
+        return existing is not null;
+    }
+
+    /// <summary>
+    /// <c>event_delivery_dedup</c> に RECEIVED を先行挿入する。一意制約違反時は既存行を読み、
+    /// 既に APPLIED なら true（呼び出し側は即 return）。それ以外は false（処理継続）。
+    /// DB 一時障害時は設定に従い段階的バックオフで再試行する（タイムアウト系は再試行しない）。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="clientEventId">クライアントイベント ID。</param>
+    /// <param name="cancellationToken">キャンセル。</param>
+    /// <returns>既に APPLIED なら true。</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Critical Code Smell",
+        "S3776:Cognitive Complexity of methods should not be too high",
+        Justification = "イベント配送 dedup の再試行・ログ分岐を一箇所に集約している。")]
+    public async Task<bool> TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(
+        Guid executionId,
+        Guid clientEventId,
+        CancellationToken cancellationToken)
+    {
+        var retryOptions = eventDeliveryRetryOptions.Value;
+        var traceId = correlationIdAccessor.GetCorrelationId();
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var acceptedAt = DateTime.UtcNow;
+        var row = new EventDeliveryDedupRow
+        {
+            TenantId = tenantId,
+            ExecutionId = executionId,
+            ClientEventId = clientEventId,
+            BatchId = null,
+            Status = EventDeliveryDedupStatuses.Received,
+            AcceptedAt = acceptedAt,
+            AppliedAt = null,
+            ErrorCode = null,
+            UpdatedAt = acceptedAt
+        };
+
+        var totalBackoffMs = 0;
+
+        for (var attempt = 1; attempt <= retryOptions.MaxAttempts; attempt++)
+        {
+            var attemptStopwatch = Stopwatch.StartNew();
+            try
+            {
+                await executor.ExecuteReadCommittedAsync(
+                    async (uow, innerCt) =>
+                    {
+                        await eventDeliveryDedup.AddReceivedAsync(uow, row, innerCt).ConfigureAwait(false);
+                    },
+                    cancellationToken).ConfigureAwait(false);
+                attemptStopwatch.Stop();
+                LogEventDeliveryDecision(new EventDeliveryDecisionDetails
+                {
+                    TraceId = traceId,
+                    TenantId = tenantId,
+                    ExecutionId = executionId,
+                    ClientEventId = clientEventId,
+                    Decision = EventDeliveryLogDecisions.Inserted,
+                    Attempt = attempt,
+                    ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
+                    ErrorCode = EventDeliveryLogErrorCodes.None,
+                });
+                return false;
+            }
+            catch (DbUpdateException dbUpdateException)
+                when (EventDeliveryRetryPolicy.IsUniqueConstraintViolation(dbUpdateException))
+            {
+                attemptStopwatch.Stop();
+                LogEventDeliveryDecision(new EventDeliveryDecisionDetails
+                {
+                    TraceId = traceId,
+                    TenantId = tenantId,
+                    ExecutionId = executionId,
+                    ClientEventId = clientEventId,
+                    Decision = EventDeliveryLogDecisions.DuplicateKey,
+                    Attempt = attempt,
+                    ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
+                    ErrorCode = EventDeliveryLogErrorCodes.UniqueViolation,
+                });
+
+                var existing = await executor.ExecuteReadOnlyAsync(
+                    (uow, innerCt) => eventDeliveryDedup.FindAsync(uow, tenantId, executionId, clientEventId, innerCt),
+                    cancellationToken).ConfigureAwait(false);
+                if (existing is { Status: EventDeliveryDedupStatuses.Applied })
+                    return true;
+
+                if (existing is null)
+                    throw;
+
+                return false;
+            }
+            catch (Exception exception)
+                when (EventDeliveryRetryPolicy.IsNonRetryableTimeoutOrCancellation(exception))
+            {
+                attemptStopwatch.Stop();
+                LogEventDeliveryDecision(
+                    new EventDeliveryDecisionDetails
+                    {
+                        TraceId = traceId,
+                        TenantId = tenantId,
+                        ExecutionId = executionId,
+                        ClientEventId = clientEventId,
+                        Decision = EventDeliveryLogDecisions.AbortedTimeout,
+                        Attempt = attempt,
+                        ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
+                        ErrorCode = MapErrorCode(exception),
+                    },
+                    exception);
+                throw;
+            }
+            catch (Exception exception) when (
+                EventDeliveryRetryPolicy.IsTransientInfrastructureFailure(exception)
+                && attempt < retryOptions.MaxAttempts)
+            {
+                attemptStopwatch.Stop();
+                LogEventDeliveryDecision(
+                    new EventDeliveryDecisionDetails
+                    {
+                        TraceId = traceId,
+                        TenantId = tenantId,
+                        ExecutionId = executionId,
+                        ClientEventId = clientEventId,
+                        Decision = EventDeliveryLogDecisions.Retry,
+                        Attempt = attempt,
+                        ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
+                        ErrorCode = MapErrorCode(exception),
+                    },
+                    exception);
+
+                var failureIndex = attempt - 1;
+                var delayMs = EventDeliveryRetryPolicy.ComputeBackoffDelayMs(
+                    failureIndex,
+                    retryOptions,
+                    Random.Shared);
+
+                if (retryOptions.MaxTotalBackoffMs > 0)
+                {
+                    var remainingBudgetMs = retryOptions.MaxTotalBackoffMs - totalBackoffMs;
+                    if (remainingBudgetMs <= 0)
+                    {
+                        attemptStopwatch.Stop();
+                        LogEventDeliveryDecision(
+                            new EventDeliveryDecisionDetails
+                            {
+                                TraceId = traceId,
+                                TenantId = tenantId,
+                                ExecutionId = executionId,
+                                ClientEventId = clientEventId,
+                                Decision = EventDeliveryLogDecisions.BackoffBudgetExhausted,
+                                Attempt = attempt,
+                                ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
+                                ErrorCode = EventDeliveryLogDecisions.BackoffBudgetExhausted,
+                            },
+                            exception);
+                        throw new InvalidOperationException(
+                            "Event delivery insert retry stopped: total backoff budget exhausted.",
+                            exception);
+                    }
+
+                    delayMs = Math.Min(delayMs, remainingBudgetMs);
+                }
+
+                totalBackoffMs += delayMs;
+                if (delayMs > 0)
+                    await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                attemptStopwatch.Stop();
+                LogEventDeliveryDecision(
+                    new EventDeliveryDecisionDetails
+                    {
+                        TraceId = traceId,
+                        TenantId = tenantId,
+                        ExecutionId = executionId,
+                        ClientEventId = clientEventId,
+                        Decision = EventDeliveryLogDecisions.Failed,
+                        Attempt = attempt,
+                        ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
+                        ErrorCode = MapErrorCode(exception),
+                    },
+                    exception);
+                throw;
+            }
+        }
+
+        throw new InvalidOperationException("Event delivery insert retry loop ended unexpectedly.");
+    }
+
+    private static ExecutionResponse? DeserializeCachedExecutionResponse(CommandDedupRow existing)
+    {
+        if (string.IsNullOrEmpty(existing.ResponseBody))
+            return null;
+        return JsonDeserialize.TryDeserialize<ExecutionResponse>(
+            existing.ResponseBody,
+            JsonSerializerProfiles.CaseInsensitive,
+            out var deserialized)
+            ? deserialized
+            : null;
+    }
+
+    private void LogEventDeliveryDecision(EventDeliveryDecisionDetails details, Exception? exception = null)
+    {
+        switch (details.Decision)
+        {
+            case EventDeliveryLogDecisions.Failed:
+            case EventDeliveryLogDecisions.BackoffBudgetExhausted:
+                logger.EventDeliveryDecisionError(exception!, details);
+                break;
+            case EventDeliveryLogDecisions.Retry:
+            case EventDeliveryLogDecisions.AbortedTimeout:
+                logger.EventDeliveryDecisionWarning(exception!, details);
+                break;
+            default:
+                logger.EventDeliveryDecisionInformation(details);
+                break;
+        }
+    }
+
+    /// <summary>ログ用のエラー分類コード（例外種別・SQLSTATE 等の短い識別子）。</summary>
+    private static string MapErrorCode(Exception exception) =>
+        exception switch
+        {
+            TaskCanceledException => nameof(TaskCanceledException),
+            OperationCanceledException => nameof(OperationCanceledException),
+            TimeoutException => nameof(TimeoutException),
+            DbUpdateException dbUpdateException =>
+                dbUpdateException.InnerException?.GetType().Name ?? nameof(DbUpdateException),
+            _ => exception.GetType().Name
+        };
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionIdempotencyService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionIdempotencyService.cs
@@ -22,6 +22,10 @@ namespace Statevia.Core.Application.Services;
 /// <param name="eventDeliveryRetryOptions">イベント配送挿入の再試行設定。</param>
 /// <param name="correlationIdAccessor">相関 ID。</param>
 /// <param name="logger">構造化ログ。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
 internal sealed class ExecutionIdempotencyService(
     ICommandDedupService dedupService,
     ICommandDedupRepository commandDedup,

--- a/core/application/Statevia.Core.Application/Services/ExecutionIdempotencyService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionIdempotencyService.cs
@@ -284,7 +284,7 @@ internal sealed class ExecutionIdempotencyService(
                                 Decision = EventDeliveryLogDecisions.BackoffBudgetExhausted,
                                 Attempt = attempt,
                                 ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
-                                ErrorCode = EventDeliveryLogDecisions.BackoffBudgetExhausted,
+                                ErrorCode = MapErrorCode(exception),
                             },
                             exception);
                         throw new InvalidOperationException(

--- a/core/application/Statevia.Core.Application/Services/ExecutionLifecycleCommandService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionLifecycleCommandService.cs
@@ -1,0 +1,1030 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 実行ライフサイクルコマンド（Start / Cancel / QueuedStart）。
+/// </summary>
+/// <remarks>
+/// <para><see cref="ExecutionService"/> Facade から委譲される。HTTP / Worker 契約は変更しない。</para>
+/// <para>冪等・投影は既存の <see cref="ExecutionIdempotencyService"/> / <see cref="ExecutionProjectionOrchestrator"/> を利用する。</para>
+/// </remarks>
+/// <param name="engine">実行エンジン。</param>
+/// <param name="displayIds">表示 ID 解決。</param>
+/// <param name="compiler">定義コンパイル復元。</param>
+/// <param name="idGenerator">ID 生成。</param>
+/// <param name="executions">executions 永続化。</param>
+/// <param name="definitions">定義リポジトリ。</param>
+/// <param name="projectAuth">プロジェクト認可。</param>
+/// <param name="runtimeAuth">Runtime 権限。</param>
+/// <param name="mutationAuth">実行ミューテーション認可。</param>
+/// <param name="snapshotFactory">セキュリティ snapshot。</param>
+/// <param name="tenantContext">テナント文脈。</param>
+/// <param name="dedup">command_dedup。</param>
+/// <param name="eventStore">event_store。</param>
+/// <param name="eventDeliveryDedup">event_delivery_dedup。</param>
+/// <param name="displayIdWrites">display ID 割当。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="mutationPersistence">Serializable 永続化。</param>
+/// <param name="logger">構造化ログ。</param>
+/// <param name="checkpointStore">runtime checkpoint。</param>
+/// <param name="ownership">Worker 所有トラッカー。</param>
+/// <param name="idempotency">冪等サービス。</param>
+/// <param name="projection">投影オーケストレータ。</param>
+/// <param name="workQueue">work queue（任意）。</param>
+/// <param name="forkChildCoordinator">Fork 協調（任意）。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
+internal sealed class ExecutionLifecycleCommandService(
+    IExecutionEngine engine,
+    IDisplayIdService displayIds,
+    IDefinitionCompilerService compiler,
+    IIdGenerator idGenerator,
+    IExecutionRepository executions,
+    IDefinitionRepository definitions,
+    IProjectAuthorizationService projectAuth,
+    IRuntimePermissionAuthorization runtimeAuth,
+    IExecutionMutationAuthorization mutationAuth,
+    IExecutionSecuritySnapshotFactory snapshotFactory,
+    ITenantContextAccessor tenantContext,
+    ICommandDedupRepository dedup,
+    IEventStoreRepository eventStore,
+    IEventDeliveryDedupRepository eventDeliveryDedup,
+    IDisplayIdWriteService displayIdWrites,
+    ICoreTransactionExecutor executor,
+    IExecutionMutationPersistence mutationPersistence,
+    ILogger<ExecutionLifecycleCommandService> logger,
+    IExecutionCheckpointStore checkpointStore,
+    ExecutionOwnershipTracker ownership,
+    ExecutionIdempotencyService idempotency,
+    ExecutionProjectionOrchestrator projection,
+    IExecutionWorkQueue? workQueue = null,
+    IForkChildExecutionCoordinator? forkChildCoordinator = null)
+{
+    /// <summary>HTTP 201 Created。</summary>
+    private const int HttpStatus201Created = 201;
+
+    /// <summary>HTTP 204 No Content。</summary>
+    private const int HttpStatus204NoContent = 204;
+
+    /// <summary>
+    /// 実行を開始する。HTTP 受理時は work queue へ enqueue、Worker / 同期経路は同一プロセスで Engine を起動する。
+    /// </summary>
+    /// <param name="request">開始リクエスト。</param>
+    /// <param name="idempotencyKey">冪等キー（任意）。</param>
+    /// <param name="requestContext">HTTP / Worker 文脈（Method / Path）。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>表示 ID 付きの実行応答。</returns>
+    /// <exception cref="NotFoundException">定義またはバージョンが見つからないとき。</exception>
+    public async Task<ExecutionResponse> StartAsync(
+        StartExecutionRequest request,
+        string? idempotencyKey,
+        CommandRequestContext requestContext,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(requestContext);
+        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
+
+        var tenantKey = tenantContext.GetRequiredTenantKey();
+        var requestHash = ComputeStartRequestHash(request);
+        var dedupKey = idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path, requestHash);
+
+        var cachedStart = await idempotency.TryGetIdempotentStartResponseAsync(dedupKey, requestHash, ct).ConfigureAwait(false);
+        if (cachedStart is not null)
+        {
+            return cachedStart;
+        }
+
+        var defUuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Definition, request.DefinitionId!, ct).ConfigureAwait(false);
+        if (defUuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
+
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var versionRow = await ResolveStartDefinitionVersionAsync(tenantId, defUuid.Value, request, ct).ConfigureAwait(false);
+        if (versionRow is null)
+            throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
+
+        await EnsureCanExecuteOnDefinitionAsync(tenantId, defUuid.Value, ct).ConfigureAwait(false);
+
+        // HTTP 受理経路: キューがある場合は Engine を回さず Start work item を投入する。
+        // Worker 文脈（またはテストでキュー未注入）は従来どおり同一プロセスで実行する。
+        if (workQueue is not null
+            && !string.Equals(requestContext.Method, "WORKER", StringComparison.Ordinal))
+        {
+            return await AcceptStartAndEnqueueAsync(
+                    request,
+                    requestHash,
+                    dedupKey,
+                    tenantId,
+                    defUuid.Value,
+                    versionRow,
+                    ct)
+                .ConfigureAwait(false);
+        }
+
+        return await ExecuteStartInProcessAsync(
+                new ExecuteStartInProcessArgs(
+                    request,
+                    requestHash,
+                    dedupKey,
+                    tenantId,
+                    defUuid.Value,
+                    versionRow,
+                    ExecutionId: null),
+                ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 実行行を受理し <see cref="ExecutionWorkItemKinds.Start"/> を enqueue する（Engine は回さない）。
+    /// </summary>
+    /// <param name="request">開始リクエスト。</param>
+    /// <param name="requestHash">冪等用リクエストハッシュ。</param>
+    /// <param name="dedupKey">command_dedup キー（任意）。</param>
+    /// <param name="tenantId">テナント ID。</param>
+    /// <param name="definitionId">定義 UUID。</param>
+    /// <param name="versionRow">採用する定義バージョン。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>受理直後の実行応答（Running）。</returns>
+    private async Task<ExecutionResponse> AcceptStartAndEnqueueAsync(
+        StartExecutionRequest request,
+        string requestHash,
+        CommandDedupKey? dedupKey,
+        Guid tenantId,
+        Guid definitionId,
+        DefinitionVersionRow versionRow,
+        CancellationToken ct)
+    {
+        var executionId = idGenerator.NewSequentialGuid();
+        var graphId = await displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Definition, definitionId.ToString("D"), ct).ConfigureAwait(false)
+            ?? definitionId.ToString("D");
+        const string emptyGraphJson = """{"nodes":[],"edges":[]}""";
+
+        var response = await executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                var createdAt = DateTime.UtcNow;
+                var securitySnapshot = await snapshotFactory
+                    .CaptureForStartAsync(tenantId, definitionId, createdAt, innerCt)
+                    .ConfigureAwait(false);
+                var securitySnapshotJson = ExecutionSecuritySnapshotJson.Serialize(securitySnapshot);
+                var displayId = await displayIdWrites
+                    .AllocateAsync(uow, DisplayIdResourceTypes.Execution, executionId, innerCt)
+                    .ConfigureAwait(false);
+
+                var executionRow = new ExecutionRow
+                {
+                    ExecutionId = executionId,
+                    TenantId = tenantId,
+                    DefinitionId = definitionId,
+                    DefinitionVersionId = versionRow.DefinitionVersionId,
+                    Status = ExecutionProjectionStatuses.Running,
+                    StartedAt = createdAt,
+                    UpdatedAt = createdAt,
+                    CancelRequested = false,
+                    RestartLost = false,
+                    SecuritySnapshotJson = securitySnapshotJson
+                };
+                var snapshotRow = new ExecutionGraphSnapshotRow
+                {
+                    ExecutionId = executionId,
+                    GraphJson = emptyGraphJson,
+                    UpdatedAt = createdAt
+                };
+                var accepted = new ExecutionResponse
+                {
+                    DisplayId = displayId,
+                    ResourceId = executionId,
+                    GraphId = graphId,
+                    Status = ExecutionProjectionStatuses.Running,
+                    StartedAt = createdAt
+                };
+
+                await executions.AddExecutionAndSnapshotAsync(uow, executionRow, snapshotRow, innerCt).ConfigureAwait(false);
+
+                var startedPayload = JsonSerializer.Serialize(
+                    new
+                    {
+                        definitionId = definitionId.ToString(),
+                        definitionVersionId = versionRow.DefinitionVersionId.ToString(),
+                        definitionVersion = versionRow.Version,
+                        tenantId,
+                        startedByPrincipalId = securitySnapshot.StartedByPrincipalId,
+                        permissionSetHash = securitySnapshot.PermissionSetHash,
+                        securityModelVersion = securitySnapshot.SecurityModelVersion,
+                        evaluationMode = securitySnapshot.EvaluationMode.ToString()
+                    },
+                    JsonSerializerProfiles.CamelCase);
+                await eventStore
+                    .AppendAsync(uow, executionId, EventStoreEventType.WorkflowStarted, startedPayload, innerCt)
+                    .ConfigureAwait(false);
+
+                if (dedupKey is { } saveKey)
+                {
+                    var responseJson = JsonSerializer.Serialize(accepted, JsonSerializerProfiles.CamelCase);
+                    await dedup.SaveAsync(
+                        uow,
+                        new CommandDedupRow
+                        {
+                            DedupKey = saveKey.DedupKey,
+                            Endpoint = saveKey.Endpoint,
+                            IdempotencyKey = saveKey.IdempotencyKey,
+                            RequestHash = requestHash,
+                            StatusCode = HttpStatus201Created,
+                            ResponseBody = responseJson,
+                            CreatedAt = createdAt,
+                            ExpiresAt = createdAt.AddHours(24)
+                        },
+                        innerCt).ConfigureAwait(false);
+                }
+
+                await workQueue!.EnqueueAsync(
+                    uow,
+                    new ExecutionWorkItemRow
+                    {
+                        WorkItemId = idGenerator.NewSequentialGuid(),
+                        ExecutionId = executionId,
+                        Kind = ExecutionWorkItemKinds.Start,
+                        Payload = JsonSerializer.Serialize(
+                            new ExecutionStartWorkItemPayload(executionId, request),
+                            ExecutionWorkItemPayloadJson.Options),
+                        AvailableAt = createdAt,
+                        Attempts = 0,
+                        CreatedAt = createdAt
+                    },
+                    innerCt).ConfigureAwait(false);
+
+                return accepted;
+            },
+            ct).ConfigureAwait(false);
+
+        return response;
+    }
+
+    /// <summary>
+    /// 同一プロセス内で Engine を起動し投影する（Worker / テスト互換）。
+    /// </summary>
+    /// <remarks>
+    /// <para><paramref name="args"/>.ExecutionId がある場合は受理済み行の QueuedStart。無い場合は新規 Start。</para>
+    /// <para>同期経路で durable Wait があるときは checkpoint 保存後に Unload する。</para>
+    /// </remarks>
+    /// <param name="args">Start 入力束。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>投影反映後の実行応答。</returns>
+    private async Task<ExecutionResponse> ExecuteStartInProcessAsync(
+        ExecuteStartInProcessArgs args,
+        CancellationToken ct)
+    {
+        var compiled = RestoreCompiledDefinitionFromVersion(args.VersionRow);
+        var resolvedExecutionId = args.ExecutionId ?? idGenerator.NewSequentialGuid();
+        var engineId = resolvedExecutionId.ToString();
+        engine.Start(compiled, engineId, args.Request.Input, args.Request.InitialState);
+
+        var graphId = await displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Definition, args.DefinitionId.ToString("D"), ct).ConfigureAwait(false)
+            ?? args.DefinitionId.ToString("D");
+
+        try
+        {
+            var startResult = await executor.ExecuteReadCommittedAsync(
+                async (uow, innerCt) =>
+                {
+                    var createdAt = DateTime.UtcNow;
+                    var startSnapshot = engine.GetSnapshot(engineId)
+                        ?? throw new InvalidOperationException(
+                            $"Cannot project execution '{resolvedExecutionId}': engine snapshot is missing after Start.");
+                    var status = ExecutionProjectionOrchestrator.MapStatus(startSnapshot);
+                    var graphJson = engine.ExportExecutionGraph(engineId);
+
+                    ExecutionResponse response;
+                    if (args.ExecutionId is null)
+                    {
+                        // 同一プロセス受理: セキュリティ snapshot と WorkflowStarted をここで確定する。
+                        var securitySnapshot = await snapshotFactory
+                            .CaptureForStartAsync(args.TenantId, args.DefinitionId, createdAt, innerCt)
+                            .ConfigureAwait(false);
+                        var securitySnapshotJson = ExecutionSecuritySnapshotJson.Serialize(securitySnapshot);
+
+                        var startedPayload = JsonSerializer.Serialize(
+                            new
+                            {
+                                definitionId = args.DefinitionId.ToString(),
+                                definitionVersionId = args.VersionRow.DefinitionVersionId.ToString(),
+                                definitionVersion = args.VersionRow.Version,
+                                tenantId = args.TenantId,
+                                startedByPrincipalId = securitySnapshot.StartedByPrincipalId,
+                                permissionSetHash = securitySnapshot.PermissionSetHash,
+                                securityModelVersion = securitySnapshot.SecurityModelVersion,
+                                evaluationMode = securitySnapshot.EvaluationMode.ToString()
+                            },
+                            JsonSerializerProfiles.CamelCase);
+
+                        var displayId = await displayIdWrites
+                            .AllocateAsync(uow, DisplayIdResourceTypes.Execution, resolvedExecutionId, innerCt)
+                            .ConfigureAwait(false);
+
+                        var executionRow = new ExecutionRow
+                        {
+                            ExecutionId = resolvedExecutionId,
+                            TenantId = args.TenantId,
+                            DefinitionId = args.DefinitionId,
+                            DefinitionVersionId = args.VersionRow.DefinitionVersionId,
+                            Status = status,
+                            StartedAt = createdAt,
+                            UpdatedAt = createdAt,
+                            CancelRequested = false,
+                            RestartLost = false,
+                            SecuritySnapshotJson = securitySnapshotJson
+                        };
+                        var snapshotRow = new ExecutionGraphSnapshotRow
+                        {
+                            ExecutionId = resolvedExecutionId,
+                            GraphJson = graphJson,
+                            UpdatedAt = createdAt
+                        };
+                        response = new ExecutionResponse
+                        {
+                            DisplayId = displayId,
+                            ResourceId = resolvedExecutionId,
+                            GraphId = graphId,
+                            Status = status,
+                            StartedAt = createdAt
+                        };
+
+                        await executions.AddExecutionAndSnapshotAsync(uow, executionRow, snapshotRow, innerCt).ConfigureAwait(false);
+                        await eventStore
+                            .AppendAsync(uow, resolvedExecutionId, EventStoreEventType.WorkflowStarted, startedPayload, innerCt)
+                            .ConfigureAwait(false);
+
+                        if (args.DedupKey is { } saveKey)
+                        {
+                            var responseJson = JsonSerializer.Serialize(response, JsonSerializerProfiles.CamelCase);
+                            await dedup.SaveAsync(
+                                uow,
+                                new CommandDedupRow
+                                {
+                                    DedupKey = saveKey.DedupKey,
+                                    Endpoint = saveKey.Endpoint,
+                                    IdempotencyKey = saveKey.IdempotencyKey,
+                                    RequestHash = args.RequestHash,
+                                    StatusCode = HttpStatus201Created,
+                                    ResponseBody = responseJson,
+                                    CreatedAt = createdAt,
+                                    ExpiresAt = createdAt.AddHours(24)
+                                },
+                                innerCt).ConfigureAwait(false);
+                        }
+                    }
+                    else
+                    {
+                        // Worker: HTTP 受理時に snapshot / WorkflowStarted 済み。投影のみ更新する。
+                        var existing = await executions.GetByIdAsync(uow, args.TenantId, resolvedExecutionId, innerCt).ConfigureAwait(false)
+                            ?? throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+                        var displayId = await displayIds.GetDisplayIdAsync(
+                                DisplayIdResourceTypes.Execution,
+                                resolvedExecutionId.ToString("D"),
+                                innerCt)
+                            .ConfigureAwait(false)
+                            ?? resolvedExecutionId.ToString("D");
+                        response = new ExecutionResponse
+                        {
+                            DisplayId = displayId,
+                            ResourceId = resolvedExecutionId,
+                            GraphId = graphId,
+                            Status = status,
+                            StartedAt = existing.StartedAt
+                        };
+                        await executions
+                            .UpdateExecutionAndSnapshotAsync(
+                                uow,
+                                resolvedExecutionId,
+                                status,
+                                cancelRequested: existing.CancelRequested,
+                                graphJson,
+                                innerCt)
+                            .ConfigureAwait(false);
+                    }
+
+                    await projection.SyncOperationalProjectionAsync(
+                            uow,
+                            resolvedExecutionId,
+                            args.TenantId,
+                            status,
+                            graphJson,
+                            nodeIdToClear: null,
+                            innerCt)
+                        .ConfigureAwait(false);
+
+                    var checkpointSaved = false;
+                    if (string.Equals(status, ExecutionProjectionStatuses.Running, StringComparison.Ordinal)
+                        && ExecutionOperationalProjectionSync.HasDurableWaits(graphJson))
+                    {
+                        checkpointSaved = await UpsertRuntimeCheckpointAsync(uow, engineId, resolvedExecutionId, innerCt)
+                            .ConfigureAwait(false);
+                    }
+
+                    return (Response: response, UnloadAfterCommit: checkpointSaved);
+                },
+                ct).ConfigureAwait(false);
+
+            if (startResult.UnloadAfterCommit)
+            {
+                engine.Unload(engineId);
+                logger.CheckpointUnloadedAfterStartSync(resolvedExecutionId);
+            }
+
+            return startResult.Response;
+        }
+        catch
+        {
+            // DB 反映前に失敗した場合、再試行で二重 Load しないようローカル Engine を捨てる。
+            engine.Unload(engineId);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// 受理済み実行の Start work item を同一プロセスで実行する（Worker 用）。
+    /// </summary>
+    /// <param name="executionId">受理済み実行 ID。</param>
+    /// <param name="request">開始時の入力（定義解決済み行と整合）。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>投影反映後の実行応答。</returns>
+    /// <exception cref="NotFoundException">実行または定義バージョンが見つからないとき。</exception>
+    public async Task<ExecutionResponse> ExecuteQueuedStartAsync(
+        Guid executionId,
+        StartExecutionRequest request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
+
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var execution = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => executions.GetByIdAsync(uow, tenantId, executionId, innerCt),
+            ct).ConfigureAwait(false);
+        if (execution is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        var versionRow = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => definitions.GetVersionForExecutionByIdAsync(
+                uow,
+                tenantId,
+                execution.DefinitionVersionId,
+                innerCt),
+            ct).ConfigureAwait(false);
+        if (versionRow is null)
+            throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
+
+        return await ExecuteStartInProcessAsync(
+                new ExecuteStartInProcessArgs(
+                    request,
+                    RequestHash: string.Empty,
+                    DedupKey: null,
+                    tenantId,
+                    execution.DefinitionId,
+                    versionRow,
+                    executionId),
+                ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Engine から runtime checkpoint を export し永続化する。
+    /// </summary>
+    /// <remarks>
+    /// Worker 所有中は世代付き upsert。所有外は通常 upsert。export が null のときは false。
+    /// </remarks>
+    /// <param name="uow">単位作業（UoW）。</param>
+    /// <param name="engineExecutionId">Engine 上の実行 ID 文字列。</param>
+    /// <param name="executionId">永続化側の実行 UUID。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>保存できたとき true。export 失敗または世代衝突時は false。</returns>
+    public async Task<bool> UpsertRuntimeCheckpointAsync(
+        ICoreUnitOfWork uow,
+        string engineExecutionId,
+        Guid executionId,
+        CancellationToken ct)
+    {
+        var checkpoint = engine.ExportCheckpoint(engineExecutionId);
+        if (checkpoint is null)
+        {
+            logger.ExportCheckpointNullWithDurableWaits(engineExecutionId);
+            return false;
+        }
+
+        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
+        var updatedAt = DateTime.UtcNow;
+        if (ownership.TryGet(executionId, out _, out var generation))
+        {
+            return await checkpointStore.TryUpsertRuntimeWithGenerationAsync(
+                    uow,
+                    new ExecutionCheckpointRuntimeUpsert(
+                        executionId,
+                        generation,
+                        json,
+                        checkpoint.SchemaVersion,
+                        updatedAt),
+                    ct)
+                .ConfigureAwait(false);
+        }
+
+        await checkpointStore.UpsertAsync(
+            uow,
+            new ExecutionCheckpointDocument
+            {
+                ExecutionId = executionId,
+                CheckpointJson = json,
+                SchemaVersion = checkpoint.SchemaVersion,
+                UpdatedAt = updatedAt
+            },
+            ct).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// 実行をキャンセルする。HTTP 受理時は work queue、Worker / 同期経路は Engine Cancel と投影更新を行う。
+    /// </summary>
+    /// <param name="idOrUuid">表示 ID または UUID。</param>
+    /// <param name="idempotencyKey">冪等キー（任意）。</param>
+    /// <param name="requestContext">HTTP / Worker 文脈。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <exception cref="NotFoundException">実行が見つからないとき。</exception>
+    public async Task CancelAsync(
+        string idOrUuid,
+        string? idempotencyKey,
+        CommandRequestContext requestContext,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(requestContext);
+
+        var tenantKey = tenantContext.GetRequiredTenantKey();
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var dedupKey = idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
+
+        if (await idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
+            return;
+
+        var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
+        if (uuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        var execution = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt),
+            ct).ConfigureAwait(false);
+        if (execution is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
+
+        // HTTP 受理経路: キューがある場合は Engine を回さず Cancel work item を投入する。
+        if (workQueue is not null
+            && !string.Equals(requestContext.Method, "WORKER", StringComparison.Ordinal))
+        {
+            await AcceptCancelAndEnqueueAsync(uuid.Value, dedupKey, ct).ConfigureAwait(false);
+            return;
+        }
+
+        // WORKER / 同期 Cancel: 未終端子へ Cancel をカスケード（ネストは各層で再帰）。
+        if (forkChildCoordinator is not null)
+        {
+            await forkChildCoordinator
+                .CascadeCancelToRunningChildrenAsync(uuid.Value, ct)
+                .ConfigureAwait(false);
+        }
+
+        await projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
+
+        var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, idGenerator);
+
+        if (await idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
+            return;
+
+        await EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
+
+        var cancelApply = await engine.CancelAsync(uuid.Value.ToString(), clientEventId).ConfigureAwait(false);
+        var skipCancelEventAppend = cancelApply.IsAlreadyApplied;
+
+        var (projStatus, projCancel, projGraphJson) = projection.BuildProjectionFromEngine(uuid.Value);
+        var cancelPayload = JsonSerializer.Serialize(
+            new { tenantId },
+            JsonSerializerProfiles.CamelCase);
+
+        await mutationPersistence.ExecuteSerializableWithRetryAsync(
+            tenantId,
+            uuid.Value,
+            clientEventId,
+            async (uow, ctInner) =>
+            {
+                await executions
+                    .UpdateExecutionAndSnapshotAsync(uow, uuid.Value, projStatus, projCancel, projGraphJson, ctInner)
+                    .ConfigureAwait(false);
+                await projection.SyncOperationalProjectionAsync(
+                        uow,
+                        uuid.Value,
+                        tenantId,
+                        projStatus,
+                        projGraphJson,
+                        nodeIdToClear: null,
+                        ctInner)
+                    .ConfigureAwait(false);
+                if (!skipCancelEventAppend)
+                {
+                    await eventStore
+                        .AppendAsync(uow, uuid.Value, EventStoreEventType.WorkflowCancelled, cancelPayload, ctInner)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await eventStore.TryAppendIfAbsentByClientEventAsync(
+                        uow,
+                        uuid.Value,
+                        clientEventId,
+                        EventStoreEventType.WorkflowCancelled,
+                        cancelPayload,
+                        ctInner).ConfigureAwait(false);
+                }
+
+                if (dedupKey is { } saveKey)
+                {
+                    var now = DateTime.UtcNow;
+                    await dedup.SaveAsync(
+                        uow,
+                        new CommandDedupRow
+                        {
+                            DedupKey = saveKey.DedupKey,
+                            Endpoint = saveKey.Endpoint,
+                            IdempotencyKey = saveKey.IdempotencyKey,
+                            RequestHash = null,
+                            StatusCode = HttpStatus204NoContent,
+                            ResponseBody = null,
+                            CreatedAt = now,
+                            ExpiresAt = now.AddHours(24)
+                        },
+                        ctInner).ConfigureAwait(false);
+                }
+
+                var nowUtc = DateTime.UtcNow;
+                await eventDeliveryDedup.TryUpdateStatusAsync(
+                    uow,
+                    tenantId,
+                    uuid.Value,
+                    clientEventId,
+                    new EventDeliveryDedupStatusUpdate(
+                        EventDeliveryDedupStatuses.Applied,
+                        nowUtc,
+                        AppliedAt: nowUtc,
+                        ErrorCode: null),
+                    ctInner).ConfigureAwait(false);
+            },
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Cancel work item を enqueue し、任意で command_dedup を保存する。
+    /// </summary>
+    /// <param name="executionId">対象実行 ID。</param>
+    /// <param name="dedupKey">command_dedup キー（任意）。</param>
+    /// <param name="ct">キャンセル。</param>
+    private async Task AcceptCancelAndEnqueueAsync(
+        Guid executionId,
+        CommandDedupKey? dedupKey,
+        CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        await executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                if (dedupKey is { } saveKey)
+                {
+                    await dedup.SaveAsync(
+                        uow,
+                        new CommandDedupRow
+                        {
+                            DedupKey = saveKey.DedupKey,
+                            Endpoint = saveKey.Endpoint,
+                            IdempotencyKey = saveKey.IdempotencyKey,
+                            RequestHash = null,
+                            StatusCode = HttpStatus204NoContent,
+                            ResponseBody = null,
+                            CreatedAt = now,
+                            ExpiresAt = now.AddHours(24)
+                        },
+                        innerCt).ConfigureAwait(false);
+                }
+
+                await workQueue!.EnqueueAsync(
+                    uow,
+                    new ExecutionWorkItemRow
+                    {
+                        WorkItemId = idGenerator.NewSequentialGuid(),
+                        ExecutionId = executionId,
+                        Kind = ExecutionWorkItemKinds.Cancel,
+                        Payload = "{}",
+                        AvailableAt = now,
+                        Attempts = 0,
+                        CreatedAt = now
+                    },
+                    innerCt).ConfigureAwait(false);
+            },
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Start 用の定義バージョン行を解決する（versionId / version 番号 / latest）。</summary>
+    private Task<DefinitionVersionRow?> ResolveStartDefinitionVersionAsync(
+        Guid tenantId,
+        Guid definitionId,
+        StartExecutionRequest request,
+        CancellationToken ct) =>
+        executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => ResolveStartDefinitionVersionInUowAsync(uow, tenantId, definitionId, request, innerCt),
+            ct);
+
+    /// <summary>UoW 内で Start 用定義バージョンを解決する。</summary>
+    private async Task<DefinitionVersionRow?> ResolveStartDefinitionVersionInUowAsync(
+        ICoreUnitOfWork uow,
+        Guid tenantId,
+        Guid definitionId,
+        StartExecutionRequest request,
+        CancellationToken ct)
+    {
+        if (request.DefinitionVersionId is { } versionId)
+            return await ResolveVersionByIdForAdmissionAsync(uow, tenantId, definitionId, versionId, ct)
+                .ConfigureAwait(false);
+
+        if (request.DefinitionVersion is { } versionNumber)
+            return await ResolveVersionByNumberForAdmissionAsync(uow, tenantId, definitionId, versionNumber, ct)
+                .ConfigureAwait(false);
+
+        var latest = await definitions
+            .GetLatestForApiAsync(uow, tenantId, definitionId, ct)
+            .ConfigureAwait(false);
+        return latest?.Version;
+    }
+
+    /// <summary>versionId 指定の受理。親定義が Active であることと定義所属を検証する。</summary>
+    private async Task<DefinitionVersionRow?> ResolveVersionByIdForAdmissionAsync(
+        ICoreUnitOfWork uow,
+        Guid tenantId,
+        Guid definitionId,
+        Guid versionId,
+        CancellationToken ct)
+    {
+        var byId = await definitions
+            .GetVersionForExecutionByIdAsync(uow, tenantId, versionId, ct)
+            .ConfigureAwait(false);
+        if (byId is null || byId.DefinitionId != definitionId)
+            return null;
+
+        return await EnsureActiveParentForAdmissionAsync(uow, tenantId, definitionId, ct).ConfigureAwait(false)
+            ? byId
+            : null;
+    }
+
+    /// <summary>version 番号指定の受理。親定義が Active であることを検証する。</summary>
+    private async Task<DefinitionVersionRow?> ResolveVersionByNumberForAdmissionAsync(
+        ICoreUnitOfWork uow,
+        Guid tenantId,
+        Guid definitionId,
+        int versionNumber,
+        CancellationToken ct)
+    {
+        var byNumber = await definitions
+            .GetVersionForExecutionAsync(uow, tenantId, definitionId, versionNumber, ct)
+            .ConfigureAwait(false);
+        if (byNumber is null)
+            return null;
+
+        return await EnsureActiveParentForAdmissionAsync(uow, tenantId, definitionId, ct).ConfigureAwait(false)
+            ? byNumber
+            : null;
+    }
+
+    /// <summary>親定義が API 向け Active（latest）として存在するか。</summary>
+    private async Task<bool> EnsureActiveParentForAdmissionAsync(
+        ICoreUnitOfWork uow,
+        Guid tenantId,
+        Guid definitionId,
+        CancellationToken ct)
+    {
+        var active = await definitions
+            .GetLatestForApiAsync(uow, tenantId, definitionId, ct)
+            .ConfigureAwait(false);
+        return active is not null;
+    }
+
+    /// <summary>定義が属するプロジェクトで Execute 権限を要求する。</summary>
+    private Task EnsureCanExecuteOnDefinitionAsync(
+        Guid tenantId,
+        Guid definitionId,
+        CancellationToken ct) =>
+        executor.ExecuteReadOnlyAsync(
+            async (uow, innerCt) =>
+            {
+                var projectId = await definitions
+                    .ResolveProjectIdAsync(uow, tenantId, definitionId, innerCt)
+                    .ConfigureAwait(false);
+                if (projectId is null)
+                    throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
+
+                await projectAuth
+                    .EnsureCanExecuteAsync(uow, tenantId, projectId.Value, innerCt)
+                    .ConfigureAwait(false);
+            },
+            ct);
+
+    /// <summary>
+    /// 永続化された定義バージョンからコンパイル済み定義を復元する。
+    /// </summary>
+    /// <param name="versionRow">定義バージョン行。</param>
+    /// <returns>コンパイル済みワークフロー定義。</returns>
+    /// <exception cref="InvalidOperationException">格納 YAML / JSON が不正なとき。</exception>
+    public CompiledWorkflowDefinition RestoreCompiledDefinitionFromVersion(DefinitionVersionRow versionRow)
+    {
+        try
+        {
+            return compiler.RestoreFromStoredVersion(versionRow.SourceYaml, versionRow.CompiledJson);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InvalidOperationException("Stored definition version is invalid.", ex);
+        }
+    }
+
+    /// <summary>Start リクエスト本文の正規化 SHA-256（hex）を返す。</summary>
+    private static string ComputeStartRequestHash(StartExecutionRequest request)
+    {
+        var normalized = JsonSerializer.Serialize(
+            new
+            {
+                definitionId = request.DefinitionId,
+                definitionVersion = request.DefinitionVersion,
+                definitionVersionId = request.DefinitionVersionId,
+                input = request.Input
+            },
+            JsonSerializerProfiles.CamelCase);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
+    }
+
+    /// <summary>投影ステータスが終端（Succeeded / Failed / Cancelled 等）かどうか。</summary>
+    /// <param name="status">投影 status 文字列。</param>
+    /// <returns>終端なら true。</returns>
+    internal static bool IsTerminalExecutionProjectionStatus(string status) =>
+        ExecutionProjectionStatuses.IsTerminal(status);
+
+    /// <summary>Runtime の executions:write を要求する。</summary>
+    private Task EnsureExecutionsWriteAsync(CancellationToken ct) =>
+        runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsWrite, ct);
+
+    /// <summary>実行行の security snapshot に基づきミューテーション権限を要求する。</summary>
+    private Task EnsureExecutionMutationWriteAsync(ExecutionRow execution, CancellationToken ct)
+    {
+        var snapshot = ExecutionSecuritySnapshotJson.TryDeserialize(execution.SecuritySnapshotJson);
+        return mutationAuth.EnsureMutationPermissionAsync(
+            snapshot,
+            RuntimePermissionRequirements.ExecutionsWrite,
+            ct);
+    }
+
+    /// <summary>
+    /// ミューテーション前に Engine インスタンスを保証する（未ロードなら checkpoint から hydrate）。
+    /// </summary>
+    /// <remarks>
+    /// 終端投影かつメモリ未ロード、または checkpoint 欠落・不正時は例外。二重 hydrate は 422 相当へ写像する。
+    /// </remarks>
+    /// <param name="executionId">実行 UUID。</param>
+    /// <param name="execution">投影行（テナント・定義バージョン・status）。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <exception cref="ArgumentException">終端未ロード、checkpoint 欠落、または二重 hydrate。</exception>
+    /// <exception cref="InvalidOperationException">定義バージョン欠落または checkpoint 不正。</exception>
+    public async Task EnsureEngineRuntimeLoadedForMutationAsync(
+        Guid executionId,
+        ExecutionRow execution,
+        CancellationToken ct)
+    {
+        if (engine.GetSnapshot(executionId.ToString()) is not null)
+            return;
+
+        if (IsTerminalExecutionProjectionStatus(execution.Status))
+        {
+            throw new ArgumentException(
+                "The execution is already in a terminal state in the database projection, but there is no in-memory instance in this API process. Cancel or event delivery cannot be applied.");
+        }
+
+        var checkpointDocument = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => checkpointStore.GetByExecutionIdAsync(uow, executionId, innerCt),
+            ct).ConfigureAwait(false);
+        if (checkpointDocument is null)
+        {
+            throw new ArgumentException(
+                "The execution state is not loaded in this API process and no runtime checkpoint was found.");
+        }
+
+        var versionRow = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => definitions.GetVersionForExecutionByIdAsync(
+                uow,
+                execution.TenantId,
+                execution.DefinitionVersionId,
+                innerCt),
+            ct).ConfigureAwait(false);
+        if (versionRow is null)
+        {
+            throw new InvalidOperationException(
+                $"Definition version '{execution.DefinitionVersionId}' was not found for execution '{executionId}'.");
+        }
+
+        var compiled = RestoreCompiledDefinitionFromVersion(versionRow);
+        if (!TryParseRuntimeCheckpoint(checkpointDocument.CheckpointJson, out var checkpoint, out var parseError))
+        {
+            logger.RuntimeCheckpointInvalidForHydrate(
+                executionId,
+                checkpointDocument.CheckpointJson?.Length ?? 0);
+            if (parseError is not null)
+                logger.RuntimeCheckpointDeserializeFailed(parseError, executionId);
+
+            throw new InvalidOperationException(
+                $"Stored runtime checkpoint for execution '{executionId:D}' is empty or invalid and cannot be hydrated.");
+        }
+
+        try
+        {
+            engine.ImportCheckpoint(compiled, checkpoint);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // 二重 hydrate 等はクライアント向け 422（ArgumentException）へ写像する。
+            throw new ArgumentException(ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// 永続 checkpoint JSON を hydrate 用に検証・デシリアライズする。
+    /// </summary>
+    /// <remarks>
+    /// <c>BeginOwnedSessionAsync</c> の seed <c>{}</c> や必須欠落は不正とし、Import しない。
+    /// </remarks>
+    /// <param name="checkpointJson">永続化された checkpoint JSON。</param>
+    /// <param name="checkpoint">成功時のデシリアライズ結果。</param>
+    /// <param name="parseError">JSON 例外時のみ設定。形式不正（必須欠落）は null。</param>
+    /// <returns>hydrate 可能なとき true。</returns>
+    internal static bool TryParseRuntimeCheckpoint(
+        string? checkpointJson,
+        out ExecutionRuntimeCheckpoint checkpoint,
+        out Exception? parseError)
+    {
+        checkpoint = null!;
+        parseError = null;
+
+        if (string.IsNullOrWhiteSpace(checkpointJson))
+            return false;
+
+        var trimmed = checkpointJson.Trim();
+        if (trimmed is "{}" or "null")
+            return false;
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<ExecutionRuntimeCheckpoint>(
+                checkpointJson,
+                JsonSerializerProfiles.CamelCase);
+            if (parsed is null
+                || string.IsNullOrWhiteSpace(parsed.ExecutionId)
+                || string.IsNullOrWhiteSpace(parsed.DefinitionName)
+                || parsed.ActiveStates is null
+                || parsed.Graph is null
+                || parsed.Join is null
+                || parsed.Context is null
+                || parsed.PendingWaits is null)
+            {
+                return false;
+            }
+
+            // 物理 Join 待ち中は ActiveStates / PendingWaits が空の正規断面になり得る（Fork Unload 後）。
+            // 空配列だけでは破損とみなさない（seed "{}" は上で拒否済み）。
+
+            checkpoint = parsed;
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            parseError = ex;
+            return false;
+        }
+    }
+
+    /// <summary>同一プロセス Start の入力束。</summary>
+    private sealed record ExecuteStartInProcessArgs(
+        StartExecutionRequest Request,
+        string RequestHash,
+        CommandDedupKey? DedupKey,
+        Guid TenantId,
+        Guid DefinitionId,
+        DefinitionVersionRow VersionRow,
+        Guid? ExecutionId);
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionLifecycleCommandService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionLifecycleCommandService.cs
@@ -13,6 +13,7 @@ namespace Statevia.Core.Application.Services;
 /// <remarks>
 /// <para><see cref="ExecutionService"/> Facade から委譲される。HTTP / Worker 契約は変更しない。</para>
 /// <para>冪等・投影は既存の <see cref="ExecutionIdempotencyService"/> / <see cref="ExecutionProjectionOrchestrator"/> を利用する。</para>
+/// <para>認可は <see cref="ExecutionAuthorizationGuard"/>、Engine hydrate は <see cref="ExecutionEngineSession"/> に委譲する。</para>
 /// </remarks>
 /// <param name="engine">実行エンジン。</param>
 /// <param name="displayIds">表示 ID 解決。</param>
@@ -20,9 +21,8 @@ namespace Statevia.Core.Application.Services;
 /// <param name="idGenerator">ID 生成。</param>
 /// <param name="executions">executions 永続化。</param>
 /// <param name="definitions">定義リポジトリ。</param>
-/// <param name="projectAuth">プロジェクト認可。</param>
-/// <param name="runtimeAuth">Runtime 権限。</param>
-/// <param name="mutationAuth">実行ミューテーション認可。</param>
+/// <param name="authorization">横断認可。</param>
+/// <param name="engineSession">Engine Load / hydrate。</param>
 /// <param name="snapshotFactory">セキュリティ snapshot。</param>
 /// <param name="tenantContext">テナント文脈。</param>
 /// <param name="dedup">command_dedup。</param>
@@ -49,9 +49,8 @@ internal sealed class ExecutionLifecycleCommandService(
     IIdGenerator idGenerator,
     IExecutionRepository executions,
     IDefinitionRepository definitions,
-    IProjectAuthorizationService projectAuth,
-    IRuntimePermissionAuthorization runtimeAuth,
-    IExecutionMutationAuthorization mutationAuth,
+    ExecutionAuthorizationGuard authorization,
+    ExecutionEngineSession engineSession,
     IExecutionSecuritySnapshotFactory snapshotFactory,
     ITenantContextAccessor tenantContext,
     ICommandDedupRepository dedup,
@@ -90,7 +89,7 @@ internal sealed class ExecutionLifecycleCommandService(
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(requestContext);
-        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
 
         var tenantKey = tenantContext.GetRequiredTenantKey();
         var requestHash = ComputeStartRequestHash(request);
@@ -111,7 +110,7 @@ internal sealed class ExecutionLifecycleCommandService(
         if (versionRow is null)
             throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
 
-        await EnsureCanExecuteOnDefinitionAsync(tenantId, defUuid.Value, ct).ConfigureAwait(false);
+        await authorization.EnsureCanExecuteOnDefinitionAsync(tenantId, defUuid.Value, ct).ConfigureAwait(false);
 
         // HTTP 受理経路: キューがある場合は Engine を回さず Start work item を投入する。
         // Worker 文脈（またはテストでキュー未注入）は従来どおり同一プロセスで実行する。
@@ -463,7 +462,7 @@ internal sealed class ExecutionLifecycleCommandService(
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(request);
-        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
 
         var tenantId = tenantContext.GetRequiredTenantId();
         var execution = await executor.ExecuteReadOnlyAsync(
@@ -581,7 +580,7 @@ internal sealed class ExecutionLifecycleCommandService(
         if (execution is null)
             throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
 
-        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
         // HTTP 受理経路: キューがある場合は Engine を回さず Cancel work item を投入する。
         if (workQueue is not null
@@ -606,7 +605,7 @@ internal sealed class ExecutionLifecycleCommandService(
         if (await idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
             return;
 
-        await EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
+        await engineSession.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
 
         var cancelApply = await engine.CancelAsync(uuid.Value.ToString(), clientEventId).ConfigureAwait(false);
         var skipCancelEventAppend = cancelApply.IsAlreadyApplied;
@@ -819,26 +818,6 @@ internal sealed class ExecutionLifecycleCommandService(
         return active is not null;
     }
 
-    /// <summary>定義が属するプロジェクトで Execute 権限を要求する。</summary>
-    private Task EnsureCanExecuteOnDefinitionAsync(
-        Guid tenantId,
-        Guid definitionId,
-        CancellationToken ct) =>
-        executor.ExecuteReadOnlyAsync(
-            async (uow, innerCt) =>
-            {
-                var projectId = await definitions
-                    .ResolveProjectIdAsync(uow, tenantId, definitionId, innerCt)
-                    .ConfigureAwait(false);
-                if (projectId is null)
-                    throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
-
-                await projectAuth
-                    .EnsureCanExecuteAsync(uow, tenantId, projectId.Value, innerCt)
-                    .ConfigureAwait(false);
-            },
-            ct);
-
     /// <summary>
     /// 永続化された定義バージョンからコンパイル済み定義を復元する。
     /// </summary>
@@ -877,146 +856,6 @@ internal sealed class ExecutionLifecycleCommandService(
     /// <returns>終端なら true。</returns>
     internal static bool IsTerminalExecutionProjectionStatus(string status) =>
         ExecutionProjectionStatuses.IsTerminal(status);
-
-    /// <summary>Runtime の executions:write を要求する。</summary>
-    private Task EnsureExecutionsWriteAsync(CancellationToken ct) =>
-        runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsWrite, ct);
-
-    /// <summary>実行行の security snapshot に基づきミューテーション権限を要求する。</summary>
-    private Task EnsureExecutionMutationWriteAsync(ExecutionRow execution, CancellationToken ct)
-    {
-        var snapshot = ExecutionSecuritySnapshotJson.TryDeserialize(execution.SecuritySnapshotJson);
-        return mutationAuth.EnsureMutationPermissionAsync(
-            snapshot,
-            RuntimePermissionRequirements.ExecutionsWrite,
-            ct);
-    }
-
-    /// <summary>
-    /// ミューテーション前に Engine インスタンスを保証する（未ロードなら checkpoint から hydrate）。
-    /// </summary>
-    /// <remarks>
-    /// 終端投影かつメモリ未ロード、または checkpoint 欠落・不正時は例外。二重 hydrate は 422 相当へ写像する。
-    /// </remarks>
-    /// <param name="executionId">実行 UUID。</param>
-    /// <param name="execution">投影行（テナント・定義バージョン・status）。</param>
-    /// <param name="ct">キャンセル。</param>
-    /// <exception cref="ArgumentException">終端未ロード、checkpoint 欠落、または二重 hydrate。</exception>
-    /// <exception cref="InvalidOperationException">定義バージョン欠落または checkpoint 不正。</exception>
-    public async Task EnsureEngineRuntimeLoadedForMutationAsync(
-        Guid executionId,
-        ExecutionRow execution,
-        CancellationToken ct)
-    {
-        if (engine.GetSnapshot(executionId.ToString()) is not null)
-            return;
-
-        if (IsTerminalExecutionProjectionStatus(execution.Status))
-        {
-            throw new ArgumentException(
-                "The execution is already in a terminal state in the database projection, but there is no in-memory instance in this API process. Cancel or event delivery cannot be applied.");
-        }
-
-        var checkpointDocument = await executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => checkpointStore.GetByExecutionIdAsync(uow, executionId, innerCt),
-            ct).ConfigureAwait(false);
-        if (checkpointDocument is null)
-        {
-            throw new ArgumentException(
-                "The execution state is not loaded in this API process and no runtime checkpoint was found.");
-        }
-
-        var versionRow = await executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => definitions.GetVersionForExecutionByIdAsync(
-                uow,
-                execution.TenantId,
-                execution.DefinitionVersionId,
-                innerCt),
-            ct).ConfigureAwait(false);
-        if (versionRow is null)
-        {
-            throw new InvalidOperationException(
-                $"Definition version '{execution.DefinitionVersionId}' was not found for execution '{executionId}'.");
-        }
-
-        var compiled = RestoreCompiledDefinitionFromVersion(versionRow);
-        if (!TryParseRuntimeCheckpoint(checkpointDocument.CheckpointJson, out var checkpoint, out var parseError))
-        {
-            logger.RuntimeCheckpointInvalidForHydrate(
-                executionId,
-                checkpointDocument.CheckpointJson?.Length ?? 0);
-            if (parseError is not null)
-                logger.RuntimeCheckpointDeserializeFailed(parseError, executionId);
-
-            throw new InvalidOperationException(
-                $"Stored runtime checkpoint for execution '{executionId:D}' is empty or invalid and cannot be hydrated.");
-        }
-
-        try
-        {
-            engine.ImportCheckpoint(compiled, checkpoint);
-        }
-        catch (InvalidOperationException ex)
-        {
-            // 二重 hydrate 等はクライアント向け 422（ArgumentException）へ写像する。
-            throw new ArgumentException(ex.Message, ex);
-        }
-    }
-
-    /// <summary>
-    /// 永続 checkpoint JSON を hydrate 用に検証・デシリアライズする。
-    /// </summary>
-    /// <remarks>
-    /// <c>BeginOwnedSessionAsync</c> の seed <c>{}</c> や必須欠落は不正とし、Import しない。
-    /// </remarks>
-    /// <param name="checkpointJson">永続化された checkpoint JSON。</param>
-    /// <param name="checkpoint">成功時のデシリアライズ結果。</param>
-    /// <param name="parseError">JSON 例外時のみ設定。形式不正（必須欠落）は null。</param>
-    /// <returns>hydrate 可能なとき true。</returns>
-    internal static bool TryParseRuntimeCheckpoint(
-        string? checkpointJson,
-        out ExecutionRuntimeCheckpoint checkpoint,
-        out Exception? parseError)
-    {
-        checkpoint = null!;
-        parseError = null;
-
-        if (string.IsNullOrWhiteSpace(checkpointJson))
-            return false;
-
-        var trimmed = checkpointJson.Trim();
-        if (trimmed is "{}" or "null")
-            return false;
-
-        try
-        {
-            var parsed = JsonSerializer.Deserialize<ExecutionRuntimeCheckpoint>(
-                checkpointJson,
-                JsonSerializerProfiles.CamelCase);
-            if (parsed is null
-                || string.IsNullOrWhiteSpace(parsed.ExecutionId)
-                || string.IsNullOrWhiteSpace(parsed.DefinitionName)
-                || parsed.ActiveStates is null
-                || parsed.Graph is null
-                || parsed.Join is null
-                || parsed.Context is null
-                || parsed.PendingWaits is null)
-            {
-                return false;
-            }
-
-            // 物理 Join 待ち中は ActiveStates / PendingWaits が空の正規断面になり得る（Fork Unload 後）。
-            // 空配列だけでは破損とみなさない（seed "{}" は上で拒否済み）。
-
-            checkpoint = parsed;
-            return true;
-        }
-        catch (JsonException ex)
-        {
-            parseError = ex;
-            return false;
-        }
-    }
 
     /// <summary>同一プロセス Start の入力束。</summary>
     private sealed record ExecuteStartInProcessArgs(

--- a/core/application/Statevia.Core.Application/Services/ExecutionOwnershipService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionOwnershipService.cs
@@ -1,0 +1,253 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// Worker 所有セッションとローカル Engine Load 待機。
+/// </summary>
+/// <remarks>
+/// <para><see cref="ExecutionService"/> Facade から委譲される。lease 獲得・更新・解放と AwaitLocal を担う。</para>
+/// <para>AwaitLocal の終端時投影は <see cref="ExecutionProjectionOrchestrator"/> と checkpoint 寿命フックを利用する。</para>
+/// </remarks>
+/// <param name="engine">実行エンジン。</param>
+/// <param name="checkpointStore">runtime checkpoint / ownership 永続化。</param>
+/// <param name="ownership">プロセス内所有トラッカー。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="projection">投影オーケストレータ。</param>
+/// <param name="checkpoints">checkpoint 寿命・Persist+Unload。</param>
+/// <param name="lifecycle">checkpoint upsert。</param>
+/// <param name="logger">構造化ログ。</param>
+internal sealed class ExecutionOwnershipService(
+    IExecutionEngine engine,
+    IExecutionCheckpointStore checkpointStore,
+    ExecutionOwnershipTracker ownership,
+    ICoreTransactionExecutor executor,
+    ExecutionProjectionOrchestrator projection,
+    ExecutionCheckpointService checkpoints,
+    ExecutionLifecycleCommandService lifecycle,
+    ILogger<ExecutionOwnershipService> logger)
+{
+    /// <summary>Worker が 1 Load を待つときのポーリング間隔。</summary>
+    private static readonly TimeSpan LocalExecutionLoadPollInterval = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>実行グラフ JSON のプロパティ名（AwaitLocal の実行中ノード判定用）。</summary>
+    private static class ExecutionGraphJsonProperties
+    {
+        internal const string Nodes = "nodes";
+        internal const string CompletedAt = "completedAt";
+        internal const string StartedAt = "startedAt";
+        internal const string NodeType = "nodeType";
+    }
+
+    /// <summary>
+    /// Worker セッションの所有を獲得しトラッカーへ登録する。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="workerId">Worker 識別子。</param>
+    /// <param name="leaseDuration">lease 期間。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>獲得後の世代。失敗時は null。</returns>
+    public async Task<long?> BeginOwnedSessionAsync(
+        Guid executionId,
+        string workerId,
+        TimeSpan leaseDuration,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workerId);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(leaseDuration, TimeSpan.Zero);
+
+        var leaseUntil = DateTime.UtcNow.Add(leaseDuration);
+        var generation = await executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                var seed = new ExecutionCheckpointDocument
+                {
+                    ExecutionId = executionId,
+                    CheckpointJson = "{}",
+                    SchemaVersion = ExecutionRuntimeCheckpoint.CurrentSchemaVersion,
+                    UpdatedAt = DateTime.UtcNow
+                };
+                return await checkpointStore.TryAcquireOwnershipAsync(
+                        uow,
+                        executionId,
+                        workerId,
+                        leaseUntil,
+                        seed,
+                        innerCt)
+                    .ConfigureAwait(false);
+            },
+            ct).ConfigureAwait(false);
+
+        if (generation is long gen)
+            ownership.Set(executionId, workerId, gen);
+
+        return generation;
+    }
+
+    /// <summary>
+    /// 所有 lease を延長する。トラッカー空（Unload 済み）なら成功扱いで no-op。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="leaseDuration">延長期間。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>延長成功またはトラッカー空のとき true。</returns>
+    public async Task<bool> RenewOwnedSessionLeaseAsync(
+        Guid executionId,
+        TimeSpan leaseDuration,
+        CancellationToken ct)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(leaseDuration, TimeSpan.Zero);
+        // Wait Unload 済みでトラッカーが空なら延長不要（失敗扱いにすると heartbeat が誤キャンセルする）。
+        if (!ownership.TryGet(executionId, out _, out var generation))
+            return true;
+
+        var leaseUntil = DateTime.UtcNow.Add(leaseDuration);
+        return await executor.ExecuteReadCommittedAsync(
+            (uow, innerCt) => checkpointStore.TryRenewOwnershipLeaseAsync(
+                uow,
+                executionId,
+                generation,
+                leaseUntil,
+                innerCt),
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 所有を解放しトラッカーから除去する。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="ct">キャンセル。</param>
+    public async Task EndOwnedSessionAsync(Guid executionId, CancellationToken ct)
+    {
+        if (!ownership.TryGet(executionId, out _, out var generation))
+            return;
+
+        try
+        {
+            await executor.ExecuteReadCommittedAsync(
+                (uow, innerCt) => checkpointStore.TryClearOwnershipAsync(
+                    uow,
+                    executionId,
+                    generation,
+                    innerCt),
+                ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            ownership.Clear(executionId);
+        }
+    }
+
+    /// <summary>
+    /// ローカル所有をベストエフォートで放棄し Engine を Unload する。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    public Task AbandonLocalOwnedSessionAsync(Guid executionId)
+    {
+        ownership.Clear(executionId);
+        var engineId = executionId.ToString();
+        try
+        {
+            engine.Unload(engineId);
+        }
+#pragma warning disable CA1031 // ローカル放棄はベストエフォート。Unload 失敗で Worker を止めない。
+        catch (Exception exception)
+#pragma warning restore CA1031
+        {
+            logger.UnloadDuringAbandon(exception, executionId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// ローカル Engine が終端または durable Wait まで進むのを待ち、必要なら投影・Unload する。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="ct">キャンセル。</param>
+    public async Task AwaitLocalExecutionLoadAsync(Guid executionId, CancellationToken ct)
+    {
+        var engineId = executionId.ToString();
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var snapshot = engine.GetSnapshot(engineId);
+            if (snapshot is null)
+                return;
+
+            if (snapshot.IsCompleted || snapshot.IsCancelled || snapshot.IsFailed)
+            {
+                // 終端後に Unload すると投影キューが engine 不在でスキップし、
+                // Start 直後の不完全 graph のまま Completed だけ残る。最終投影を先に確定する。
+                await projection.DrainAsync(executionId, ct).ConfigureAwait(false);
+                await projection.UpdateProjectionFromEngineAsync(
+                        executionId,
+                        checkpoints.ShouldDiscardRuntimeCheckpointAsync,
+                        checkpoints.DiscardOrRefreshRuntimeCheckpointAsync,
+                        lifecycle.UpsertRuntimeCheckpointAsync,
+                        ct)
+                    .ConfigureAwait(false);
+                engine.Unload(engineId);
+                return;
+            }
+
+            var checkpoint = engine.ExportCheckpoint(engineId);
+            // recovery hydrate 後など、PendingWaits があるのに Unload されていない場合がある。
+            if (checkpoint is { PendingWaits.Count: > 0 }
+                && !HasRunningNonWaitNodes(engine.ExportExecutionGraph(engineId)))
+            {
+                var waitNodeId = checkpoint.PendingWaits[0].NodeId;
+                await checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineId, waitNodeId, ct)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            await Task.Delay(LocalExecutionLoadPollInterval, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Wait 以外で未完了の実行中ノードがあるか。</summary>
+    /// <param name="graphJson">Engine export グラフ JSON。</param>
+    /// <returns>実行中の非 Wait ノードがあれば true。</returns>
+    internal static bool HasRunningNonWaitNodes(string graphJson)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(graphJson);
+            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
+                || nodes.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            return nodes.EnumerateArray().Any(node =>
+            {
+                var nodeType = node.TryGetProperty(ExecutionGraphJsonProperties.NodeType, out var typeEl)
+                    ? typeEl.GetString()
+                    : null;
+                if (string.Equals(nodeType, "Wait", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(nodeType, "EventWait", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
+                    && completedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+                {
+                    return false;
+                }
+
+                // startedAt があり未完了なら実行中とみなす。
+                return node.TryGetProperty(ExecutionGraphJsonProperties.StartedAt, out var startedAt)
+                    && startedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined;
+            });
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionOwnershipService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionOwnershipService.cs
@@ -20,6 +20,10 @@ namespace Statevia.Core.Application.Services;
 /// <param name="checkpoints">checkpoint 寿命・Persist+Unload。</param>
 /// <param name="lifecycle">checkpoint upsert。</param>
 /// <param name="logger">構造化ログ。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
 internal sealed class ExecutionOwnershipService(
     IExecutionEngine engine,
     IExecutionCheckpointStore checkpointStore,

--- a/core/application/Statevia.Core.Application/Services/ExecutionProjectionOrchestrator.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionProjectionOrchestrator.cs
@@ -22,6 +22,10 @@ namespace Statevia.Core.Application.Services;
 /// <param name="ownership">Worker 所有トラッカー（投影後 Unload 判定）。</param>
 /// <param name="projectionUpdateQueue">投影更新キュー。未注入時は no-op。</param>
 /// <param name="forkChildCoordinator">子終端通知（任意）。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
 internal sealed class ExecutionProjectionOrchestrator(
     IExecutionEngine engine,
     IExecutionRepository executions,

--- a/core/application/Statevia.Core.Application/Services/ExecutionProjectionOrchestrator.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionProjectionOrchestrator.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 実行投影の更新窓口（Engine → executions / operational / queue）。
+/// </summary>
+/// <remarks>
+/// <para><see cref="IExecutionService.UpdateProjectionFromEngineAsync"/> と operational sync・queue Drain/Enqueue を集約する。</para>
+/// <para>checkpoint 寿命の破棄判定自体は呼び出し側（Facade）に残し、投影 tx 内でフックとして受け取る。</para>
+/// </remarks>
+/// <param name="engine">実行エンジン。</param>
+/// <param name="executions">executions / snapshot 永続化。</param>
+/// <param name="executionCursors">cursor 投影。</param>
+/// <param name="executionWaits">wait 投影。</param>
+/// <param name="idGenerator">ID 生成。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="logger">構造化ログ。</param>
+/// <param name="ownership">Worker 所有トラッカー（投影後 Unload 判定）。</param>
+/// <param name="projectionUpdateQueue">投影更新キュー。未注入時は no-op。</param>
+/// <param name="forkChildCoordinator">子終端通知（任意）。</param>
+internal sealed class ExecutionProjectionOrchestrator(
+    IExecutionEngine engine,
+    IExecutionRepository executions,
+    IExecutionCursorRepository executionCursors,
+    IExecutionWaitRepository executionWaits,
+    IIdGenerator idGenerator,
+    ICoreTransactionExecutor executor,
+    ILogger<ExecutionProjectionOrchestrator> logger,
+    ExecutionOwnershipTracker ownership,
+    IExecutionProjectionUpdateQueue? projectionUpdateQueue = null,
+    IForkChildExecutionCoordinator? forkChildCoordinator = null)
+{
+    private readonly IExecutionProjectionUpdateQueue _projectionUpdateQueue =
+        projectionUpdateQueue ?? NoopExecutionProjectionUpdateQueue.Instance;
+
+    /// <summary>投影キューを drain する。</summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="ct">キャンセル。</param>
+    public Task DrainAsync(Guid executionId, CancellationToken ct) =>
+        _projectionUpdateQueue.DrainAsync(executionId, ct);
+
+    /// <summary>投影キューへ enqueue する。</summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="ct">キャンセル。</param>
+    public Task EnqueueAsync(Guid executionId, CancellationToken ct) =>
+        _projectionUpdateQueue.EnqueueAsync(executionId, ct);
+
+    /// <summary>
+    /// Engine スナップショットから status を写像する。
+    /// </summary>
+    /// <param name="snapshot">Engine スナップショット。</param>
+    /// <returns>投影 status 文字列。</returns>
+    public static string MapStatus(ExecutionSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (snapshot.IsCompleted) return ExecutionProjectionStatuses.Completed;
+        if (snapshot.IsCancelled) return ExecutionProjectionStatuses.Cancelled;
+        if (snapshot.IsFailed) return ExecutionProjectionStatuses.Failed;
+        return ExecutionProjectionStatuses.Running;
+    }
+
+    /// <summary>
+    /// Engine から投影用の status / cancel / graph を組み立てる。欠落時は例外。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <returns>投影タプル。</returns>
+    public (string Status, bool? CancelRequested, string GraphJson) BuildProjectionFromEngine(Guid executionId)
+    {
+        var engineId = executionId.ToString();
+        var snapshot = engine.GetSnapshot(engineId);
+        if (snapshot is null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot project execution '{executionId}': engine snapshot is missing.");
+        }
+
+        var graphJson = engine.ExportExecutionGraph(engineId);
+        var status = MapStatus(snapshot);
+        return (status, snapshot.IsCancelled, graphJson);
+    }
+
+    /// <summary>
+    /// キュー更新向け。スナップショット欠落時は null を返しスキップする。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <returns>投影タプル。欠落時は各要素 null。</returns>
+    public (string? Status, bool? CancelRequested, string? GraphJson) BuildProjectionFromEngineForQueue(Guid executionId)
+    {
+        var engineId = executionId.ToString();
+        var snapshot = engine.GetSnapshot(engineId);
+        if (snapshot is null)
+        {
+            logger.SkipProjectionQueueUpdateDebug(executionId);
+            return (null, null, null);
+        }
+
+        var graphJson = engine.ExportExecutionGraph(engineId);
+        var status = MapStatus(snapshot);
+        return (status, snapshot.IsCancelled, graphJson);
+    }
+
+    /// <summary>
+    /// cursor / wait の operational 投影を同期する。
+    /// </summary>
+    /// <param name="uow">同一 tx の UoW。</param>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="tenantId">テナント ID。</param>
+    /// <param name="status">投影 status。</param>
+    /// <param name="graphJson">グラフ JSON。</param>
+    /// <param name="nodeIdToClear">クリア対象 Wait nodeId。</param>
+    /// <param name="ct">キャンセル。</param>
+    public Task SyncOperationalProjectionAsync(
+        ICoreUnitOfWork uow,
+        Guid executionId,
+        Guid tenantId,
+        string status,
+        string graphJson,
+        string? nodeIdToClear,
+        CancellationToken ct)
+    {
+        var snapshot = engine.GetSnapshot(executionId.ToString());
+        var request = new ExecutionOperationalProjectionSyncRequest(
+            executionId,
+            tenantId,
+            status,
+            snapshot,
+            graphJson,
+            nodeIdToClear);
+        return ExecutionOperationalProjectionSync.SyncAsync(
+            uow,
+            executionCursors,
+            executionWaits,
+            request,
+            idGenerator,
+            ct);
+    }
+
+    /// <summary>
+    /// Engine 状態を executions / operational へ投影し、必要なら Unload と子終端通知を行う。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="shouldDiscardRuntimeCheckpointAsync">checkpoint 破棄候補判定。</param>
+    /// <param name="discardOrRefreshRuntimeCheckpointAsync">破棄または所有中 refresh。</param>
+    /// <param name="upsertRuntimeCheckpointAsync">runtime checkpoint upsert。</param>
+    /// <param name="ct">キャンセル。</param>
+    public async Task UpdateProjectionFromEngineAsync(
+        Guid executionId,
+        Func<Guid, string, string, CancellationToken, Task<bool>> shouldDiscardRuntimeCheckpointAsync,
+        Func<ICoreUnitOfWork, string, Guid, CancellationToken, Task<bool>> discardOrRefreshRuntimeCheckpointAsync,
+        Func<ICoreUnitOfWork, string, Guid, CancellationToken, Task<bool>> upsertRuntimeCheckpointAsync,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(shouldDiscardRuntimeCheckpointAsync);
+        ArgumentNullException.ThrowIfNull(discardOrRefreshRuntimeCheckpointAsync);
+        ArgumentNullException.ThrowIfNull(upsertRuntimeCheckpointAsync);
+
+        var (status, cancelRequested, graphJson) = BuildProjectionFromEngineForQueue(executionId);
+        if (status is null || graphJson is null)
+            return;
+
+        var engineExecutionId = executionId.ToString();
+        var shouldUnloadAfterProjection = await executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                var execution = await executions.GetByExecutionIdAsync(uow, executionId, innerCt).ConfigureAwait(false);
+                if (execution is null)
+                    return false;
+
+                await executions
+                    .UpdateExecutionAndSnapshotAsync(uow, executionId, status, cancelRequested, graphJson, innerCt)
+                    .ConfigureAwait(false);
+                await SyncOperationalProjectionAsync(
+                        uow,
+                        executionId,
+                        execution.TenantId,
+                        status,
+                        graphJson,
+                        nodeIdToClear: null,
+                        innerCt)
+                    .ConfigureAwait(false);
+
+                // durable Wait / 物理 Join 待ちが無い／終端なら checkpoint を削除する。
+                // ただし Worker 所有中は lease / fencing 行を消さない（Heartbeat が世代不一致で落ちる）。
+                if (await shouldDiscardRuntimeCheckpointAsync(executionId, status, graphJson, innerCt)
+                        .ConfigureAwait(false))
+                {
+                    return await discardOrRefreshRuntimeCheckpointAsync(
+                            uow,
+                            engineExecutionId,
+                            executionId,
+                            innerCt)
+                        .ConfigureAwait(false);
+                }
+
+                var upserted = await upsertRuntimeCheckpointAsync(uow, engineExecutionId, executionId, innerCt)
+                    .ConfigureAwait(false);
+                // 所有セッション中の Unload 境界は Worker（Await / EndOwnedSession）。投影からは落とさない。
+                return upserted && !ownership.TryGet(executionId, out _, out _);
+            },
+            ct).ConfigureAwait(false);
+
+        string? childTerminalOutputJson = null;
+        string? childTerminalStatesJson = null;
+        string? childTerminalVarsJson = null;
+        if (ExecutionProjectionStatuses.IsTerminal(status))
+        {
+            (childTerminalOutputJson, childTerminalStatesJson, childTerminalVarsJson) =
+                TryGetChildTerminalContextJson(engineExecutionId);
+        }
+
+        if (shouldUnloadAfterProjection)
+        {
+            engine.Unload(engineExecutionId);
+            logger.CheckpointUnloadedAfterProjectionSync(executionId);
+        }
+
+        if (ExecutionProjectionStatuses.IsTerminal(status) && forkChildCoordinator is not null)
+        {
+            await forkChildCoordinator
+                .NotifyChildTerminalAsync(
+                    executionId,
+                    status,
+                    childTerminalOutputJson,
+                    childTerminalStatesJson,
+                    childTerminalVarsJson,
+                    ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>ロード中 Engine から終端 Context（output / states / vars）を JSON 文字列として取り出す。</summary>
+    private (string? OutputJson, string? StatesJson, string? VarsJson) TryGetChildTerminalContextJson(
+        string engineExecutionId)
+    {
+        var checkpoint = engine.ExportCheckpoint(engineExecutionId);
+        if (checkpoint is null)
+            return (null, null, null);
+
+        var output = checkpoint.Context.WorkflowOutput;
+        string? outputJson = null;
+        if (output is not null
+            && output.Value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+        {
+            outputJson = output.Value.GetRawText();
+        }
+
+        string? statesJson = null;
+        if (checkpoint.Context.States is { Count: > 0 })
+        {
+            statesJson = JsonSerializer.Serialize(
+                checkpoint.Context.States.ToDictionary(
+                    kv => kv.Key,
+                    kv => kv.Value,
+                    StringComparer.OrdinalIgnoreCase),
+                JsonSerializerProfiles.CamelCase);
+        }
+
+        string? varsJson = null;
+        var vars = checkpoint.Context.Vars;
+        if (vars is not null
+            && vars.Value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+        {
+            varsJson = vars.Value.GetRawText();
+        }
+
+        return (outputJson, statesJson, varsJson);
+    }
+
+    private sealed class NoopExecutionProjectionUpdateQueue : IExecutionProjectionUpdateQueue
+    {
+        internal static readonly NoopExecutionProjectionUpdateQueue Instance = new();
+
+        public Task EnqueueAsync(Guid executionId, CancellationToken ct) => Task.CompletedTask;
+
+        public Task DrainAsync(Guid executionId, CancellationToken ct) => Task.CompletedTask;
+    }
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionQueryService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionQueryService.cs
@@ -1,0 +1,326 @@
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 実行の read-model（一覧・単体・graph・view・events）取得。
+/// </summary>
+/// <remarks>
+/// <para><see cref="ExecutionService"/> Facade から委譲される。HTTP 契約は変更しない。</para>
+/// <para>Hosted Fork の親 graph / イベント合成は <see cref="IForkChildExecutionCoordinator"/> 経由。</para>
+/// </remarks>
+/// <param name="displayIds">表示 ID 解決。</param>
+/// <param name="executions">executions / snapshot 永続化。</param>
+/// <param name="runtimeAuth">Runtime 権限（read）。</param>
+/// <param name="tenantContext">テナント文脈。</param>
+/// <param name="eventStore">event_store 読み取り。</param>
+/// <param name="executor">読み取りトランザクション実行。</param>
+/// <param name="forkChildCoordinator">Fork 合成（未登録時は生 snapshot）。</param>
+internal sealed class ExecutionQueryService(
+    IDisplayIdService displayIds,
+    IExecutionRepository executions,
+    IRuntimePermissionAuthorization runtimeAuth,
+    ITenantContextAccessor tenantContext,
+    IEventStoreRepository eventStore,
+    ICoreTransactionExecutor executor,
+    IForkChildExecutionCoordinator? forkChildCoordinator = null)
+{
+    /// <summary>ページング一覧を返す。</summary>
+    /// <param name="query">一覧クエリ。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>ページ結果。</returns>
+    public async Task<PagedResult<ExecutionResponse>> ListPagedAsync(
+        ExecutionListPageQuery query,
+        CancellationToken ct)
+    {
+        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+
+        var tenantId = tenantContext.GetRequiredTenantId();
+        ArgumentNullException.ThrowIfNull(query);
+
+        var (total, pairs) = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => executions.ListWithDisplayIdsPageAsync(uow, tenantId, query, innerCt),
+            ct).ConfigureAwait(false);
+        var items = pairs.Select(p => new ExecutionResponse
+        {
+            DisplayId = p.DisplayId ?? p.Execution.ExecutionId.ToString(),
+            ResourceId = p.Execution.ExecutionId,
+            GraphId = p.Execution.DefinitionId.ToString("D"),
+            Status = p.Execution.Status,
+            StartedAt = p.Execution.StartedAt,
+            UpdatedAt = p.Execution.UpdatedAt,
+            CancelRequested = p.Execution.CancelRequested,
+            RestartLost = p.Execution.RestartLost
+        }).ToList();
+
+        return new PagedResult<ExecutionResponse>
+        {
+            Items = items,
+            TotalCount = total,
+            Offset = query.Page.Offset,
+            Limit = query.Page.Limit,
+            HasMore = query.Page.Offset + items.Count < total
+        };
+    }
+
+    /// <summary>単一取得（一覧と同形）。</summary>
+    /// <param name="idOrUuid">表示 ID または UUID。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>実行応答。</returns>
+    public async Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct)
+    {
+        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
+        if (uuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        return await executor.ExecuteReadOnlyAsync(
+            async (uow, innerCt) =>
+            {
+                var execution = await executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt).ConfigureAwait(false);
+                if (execution is null)
+                    throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+                var displayId = await displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Execution, idOrUuid, innerCt)
+                    .ConfigureAwait(false) ?? execution.ExecutionId.ToString("D");
+                var graphId = await displayIds
+                    .GetDisplayIdAsync(DisplayIdResourceTypes.Definition, execution.DefinitionId.ToString("D"), innerCt)
+                    .ConfigureAwait(false) ?? execution.DefinitionId.ToString("D");
+
+                return new ExecutionResponse
+                {
+                    DisplayId = displayId,
+                    ResourceId = execution.ExecutionId,
+                    GraphId = graphId,
+                    Status = execution.Status,
+                    StartedAt = execution.StartedAt,
+                    UpdatedAt = execution.UpdatedAt,
+                    CancelRequested = execution.CancelRequested,
+                    RestartLost = execution.RestartLost
+                };
+            },
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>投影済み実行グラフ JSON を返す（Fork 合成込み）。</summary>
+    /// <param name="idOrUuid">表示 ID または UUID。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>グラフ JSON。</returns>
+    public async Task<string> GetGraphJsonAsync(string idOrUuid, CancellationToken ct)
+    {
+        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+
+        var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
+        if (uuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+        await EnsureExecutionExistsAsync(uuid.Value, ct).ConfigureAwait(false);
+        var row = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => executions.GetSnapshotByExecutionIdAsync(uow, uuid.Value, innerCt),
+            ct).ConfigureAwait(false);
+        if (row is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        if (forkChildCoordinator is null)
+            return row.GraphJson;
+
+        return await forkChildCoordinator
+            .ComposeReadModelGraphJsonAsync(uuid.Value, row.GraphJson, ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>指定 execution がテナントに存在することを検証する。</summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="ct">キャンセル。</param>
+    public Task EnsureExecutionExistsAsync(Guid executionId, CancellationToken ct) =>
+        executor.ExecuteReadOnlyAsync(
+            async (uow, innerCt) =>
+            {
+                var tenantId = tenantContext.GetRequiredTenantId();
+                var execution = await executions.GetByIdAsync(uow, tenantId, executionId, innerCt).ConfigureAwait(false);
+                if (execution is null)
+                    throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+            },
+            ct);
+
+    /// <summary>スナップショット行からグラフ JSON を取得する。無ければ <see langword="null"/>。</summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>グラフ JSON または null。</returns>
+    public Task<string?> TryGetSnapshotGraphJsonByExecutionIdAsync(Guid executionId, CancellationToken ct) =>
+        executor.ExecuteReadOnlyAsync(
+            async (uow, innerCt) =>
+            {
+                var row = await executions.GetSnapshotByExecutionIdAsync(uow, executionId, innerCt).ConfigureAwait(false);
+                return row?.GraphJson;
+            },
+            ct);
+
+    /// <summary>現在の実行ビューを返す。</summary>
+    /// <param name="idOrUuid">表示 ID または UUID。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>実行ビュー。</returns>
+    public async Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct)
+    {
+        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+
+        var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
+        if (uuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        return await BuildExecutionViewInternalAsync(uuid.Value, idOrUuid, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>指定シーケンス時点に近い実行ビューを返す（リプレイ近似）。</summary>
+    /// <param name="idOrUuid">表示 ID または UUID。</param>
+    /// <param name="atSeq">対象シーケンス。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>実行ビュー。</returns>
+    public async Task<ExecutionViewDto> GetExecutionViewAtSeqAsync(string idOrUuid, long atSeq, CancellationToken ct)
+    {
+        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+
+        var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
+        if (uuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        var maxSeq = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => eventStore.GetMaxSeqAsync(uow, uuid.Value, innerCt),
+            ct).ConfigureAwait(false);
+        if (maxSeq == 0)
+            return await BuildExecutionViewInternalAsync(uuid.Value, idOrUuid, ct).ConfigureAwait(false);
+
+        if (atSeq > maxSeq)
+            throw new NotFoundException("atSeq out of range");
+
+        return await BuildExecutionViewInternalAsync(uuid.Value, idOrUuid, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>event_store 由来のタイムラインイベントを返す。</summary>
+    /// <param name="idOrUuid">表示 ID または UUID。</param>
+    /// <param name="afterSeq">この seq より後を返す。</param>
+    /// <param name="limit">最大件数。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <returns>イベント一覧。</returns>
+    public async Task<ExecutionEventsResponseDto> ListEventsAsync(
+        string idOrUuid,
+        long afterSeq,
+        int limit,
+        CancellationToken ct)
+    {
+        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
+        if (uuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        var execution = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt),
+            ct).ConfigureAwait(false);
+        if (execution is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        var displayId = await displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false)
+            ?? execution.ExecutionId.ToString("D");
+        // D6 / D6.1: GraphUpdated patch は合成グラフ由来。
+        var graphJson = await GetGraphJsonAsync(idOrUuid, ct).ConfigureAwait(false);
+        var patchNodes = ExecutionViewMapper.MapGraphPatchNodes(graphJson);
+
+        var sourceRows = await LoadEventStoreRowsForTimelineAsync(uuid.Value, ct).ConfigureAwait(false);
+        var (events, hasMore) = PhysicalForkEventTimelineComposer.ComposePage(
+            sourceRows,
+            displayId,
+            patchNodes,
+            afterSeq,
+            limit);
+
+        return new ExecutionEventsResponseDto { Events = events, HasMore = hasMore };
+    }
+
+    /// <summary>
+    /// 親＋再帰子孫の event_store 行を読み取り合成用に集める（D6.1）。
+    /// </summary>
+    private async Task<IReadOnlyList<PhysicalForkEventTimelineComposer.SourceRow>> LoadEventStoreRowsForTimelineAsync(
+        Guid rootExecutionId,
+        CancellationToken ct)
+    {
+        var executionIds = new List<Guid> { rootExecutionId };
+        if (forkChildCoordinator is not null)
+        {
+            var descendants = await forkChildCoordinator
+                .ListDescendantExecutionIdsAsync(rootExecutionId, ct)
+                .ConfigureAwait(false);
+            executionIds.AddRange(descendants);
+        }
+
+        var rows = new List<PhysicalForkEventTimelineComposer.SourceRow>();
+        foreach (var executionId in executionIds)
+        {
+            var isRoot = executionId == rootExecutionId;
+            long pageAfterSeq = 0;
+            while (true)
+            {
+                var pageAfter = pageAfterSeq;
+                var (items, hasMore) = await executor.ExecuteReadOnlyAsync(
+                        (uow, innerCt) => eventStore.ListAfterSeqAsync(
+                            uow,
+                            executionId,
+                            pageAfter,
+                            limit: 500,
+                            innerCt),
+                        ct)
+                    .ConfigureAwait(false);
+
+                foreach (var item in items)
+                    rows.Add(new PhysicalForkEventTimelineComposer.SourceRow(item, isRoot));
+
+                if (!hasMore || items.Count == 0)
+                    break;
+
+                pageAfterSeq = items[^1].Seq;
+                // 暴走防止（異常に長い event_store）。
+                if (rows.Count >= 50_000)
+                    break;
+            }
+        }
+
+        return rows;
+    }
+
+    private async Task<ExecutionViewDto> BuildExecutionViewInternalAsync(Guid uuid, string idOrUuidForDisplay, CancellationToken ct)
+    {
+        var tenantId = tenantContext.GetRequiredTenantId();
+        return await executor.ExecuteReadOnlyAsync(
+            async (uow, innerCt) =>
+            {
+                var execution = await executions.GetByIdAsync(uow, tenantId, uuid, innerCt).ConfigureAwait(false);
+                if (execution is null)
+                    throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+                var snapshot = await executions.GetSnapshotByExecutionIdAsync(uow, uuid, innerCt).ConfigureAwait(false);
+                if (snapshot is null)
+                    throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+                var displayId = await displayIds
+                    .GetDisplayIdAsync(DisplayIdResourceTypes.Execution, idOrUuidForDisplay, innerCt)
+                    .ConfigureAwait(false) ?? execution.ExecutionId.ToString("D");
+                var graphId = await displayIds
+                    .GetDisplayIdAsync(DisplayIdResourceTypes.Definition, execution.DefinitionId.ToString("D"), innerCt)
+                    .ConfigureAwait(false) ?? execution.DefinitionId.ToString("D");
+
+                var graphJson = snapshot.GraphJson;
+                if (forkChildCoordinator is not null)
+                {
+                    graphJson = await forkChildCoordinator
+                        .ComposeReadModelGraphJsonAsync(uuid, snapshot.GraphJson, innerCt)
+                        .ConfigureAwait(false);
+                }
+
+                return ExecutionViewMapper.BuildExecutionView(execution, graphJson, displayId, graphId);
+            },
+            ct).ConfigureAwait(false);
+    }
+
+    private Task EnsureExecutionsReadAsync(CancellationToken ct) =>
+        runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsRead, ct);
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionQueryService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionQueryService.cs
@@ -9,7 +9,7 @@ namespace Statevia.Core.Application.Services;
 /// </remarks>
 /// <param name="displayIds">表示 ID 解決。</param>
 /// <param name="executions">executions / snapshot 永続化。</param>
-/// <param name="runtimeAuth">Runtime 権限（read）。</param>
+/// <param name="authorization">横断認可（read）。</param>
 /// <param name="tenantContext">テナント文脈。</param>
 /// <param name="eventStore">event_store 読み取り。</param>
 /// <param name="executor">読み取りトランザクション実行。</param>
@@ -17,7 +17,7 @@ namespace Statevia.Core.Application.Services;
 internal sealed class ExecutionQueryService(
     IDisplayIdService displayIds,
     IExecutionRepository executions,
-    IRuntimePermissionAuthorization runtimeAuth,
+    ExecutionAuthorizationGuard authorization,
     ITenantContextAccessor tenantContext,
     IEventStoreRepository eventStore,
     ICoreTransactionExecutor executor,
@@ -31,7 +31,7 @@ internal sealed class ExecutionQueryService(
         ExecutionListPageQuery query,
         CancellationToken ct)
     {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
 
         var tenantId = tenantContext.GetRequiredTenantId();
         ArgumentNullException.ThrowIfNull(query);
@@ -67,7 +67,7 @@ internal sealed class ExecutionQueryService(
     /// <returns>実行応答。</returns>
     public async Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct)
     {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
 
         var tenantId = tenantContext.GetRequiredTenantId();
         var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
@@ -108,7 +108,7 @@ internal sealed class ExecutionQueryService(
     /// <returns>グラフ JSON。</returns>
     public async Task<string> GetGraphJsonAsync(string idOrUuid, CancellationToken ct)
     {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
 
         var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
         if (uuid is null)
@@ -161,7 +161,7 @@ internal sealed class ExecutionQueryService(
     /// <returns>実行ビュー。</returns>
     public async Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct)
     {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
 
         var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
         if (uuid is null)
@@ -177,7 +177,7 @@ internal sealed class ExecutionQueryService(
     /// <returns>実行ビュー。</returns>
     public async Task<ExecutionViewDto> GetExecutionViewAtSeqAsync(string idOrUuid, long atSeq, CancellationToken ct)
     {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
 
         var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
         if (uuid is null)
@@ -207,7 +207,7 @@ internal sealed class ExecutionQueryService(
         int limit,
         CancellationToken ct)
     {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
 
         var tenantId = tenantContext.GetRequiredTenantId();
         var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
@@ -320,7 +320,4 @@ internal sealed class ExecutionQueryService(
             },
             ct).ConfigureAwait(false);
     }
-
-    private Task EnsureExecutionsReadAsync(CancellationToken ct) =>
-        runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsRead, ct);
 }

--- a/core/application/Statevia.Core.Application/Services/ExecutionRecoveryService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionRecoveryService.cs
@@ -21,6 +21,10 @@ namespace Statevia.Core.Application.Services;
 /// <param name="waitEvents">Wait quiesce 待機。</param>
 /// <param name="projection">投影オーケストレータ。</param>
 /// <param name="checkpoints">checkpoint 寿命・Persist+Unload。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
 internal sealed class ExecutionRecoveryService(
     IExecutionEngine engine,
     IExecutionRepository executions,

--- a/core/application/Statevia.Core.Application/Services/ExecutionRecoveryService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionRecoveryService.cs
@@ -13,22 +13,22 @@ namespace Statevia.Core.Application.Services;
 /// </remarks>
 /// <param name="engine">実行エンジン。</param>
 /// <param name="executions">executions 永続化。</param>
-/// <param name="runtimeAuth">Runtime 権限。</param>
-/// <param name="mutationAuth">実行ミューテーション認可。</param>
+/// <param name="authorization">横断認可。</param>
 /// <param name="tenantContext">テナント文脈。</param>
 /// <param name="executor">トランザクション実行。</param>
-/// <param name="lifecycle">Engine hydrate / checkpoint upsert。</param>
+/// <param name="lifecycle">checkpoint upsert。</param>
+/// <param name="engineSession">Engine Load / hydrate。</param>
 /// <param name="waitEvents">Wait quiesce 待機。</param>
 /// <param name="projection">投影オーケストレータ。</param>
 /// <param name="checkpoints">checkpoint 寿命・Persist+Unload。</param>
 internal sealed class ExecutionRecoveryService(
     IExecutionEngine engine,
     IExecutionRepository executions,
-    IRuntimePermissionAuthorization runtimeAuth,
-    IExecutionMutationAuthorization mutationAuth,
+    ExecutionAuthorizationGuard authorization,
     ITenantContextAccessor tenantContext,
     ICoreTransactionExecutor executor,
     ExecutionLifecycleCommandService lifecycle,
+    ExecutionEngineSession engineSession,
     ExecutionWaitEventService waitEvents,
     ExecutionProjectionOrchestrator projection,
     ExecutionCheckpointService checkpoints)
@@ -46,7 +46,7 @@ internal sealed class ExecutionRecoveryService(
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(requestContext);
-        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
 
         var tenantId = tenantContext.GetRequiredTenantId();
         var execution = await executor.ExecuteReadOnlyAsync(
@@ -55,13 +55,13 @@ internal sealed class ExecutionRecoveryService(
         if (execution is null)
             throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
 
-        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
         if (ExecutionLifecycleCommandService.IsTerminalExecutionProjectionStatus(execution.Status))
             return;
 
         // Worker が BeginOwnedSession 済み前提。hydrate 後、完了フロンティア／PendingWaits から継続する。
-        await lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(executionId, execution, ct).ConfigureAwait(false);
+        await engineSession.EnsureEngineRuntimeLoadedForMutationAsync(executionId, execution, ct).ConfigureAwait(false);
 
         var engineId = executionId.ToString();
         // ImportCheckpoint が起動した継続（Wait 復元または完了フロンティア遷移）が落ち着くのを待つ。
@@ -110,17 +110,5 @@ internal sealed class ExecutionRecoveryService(
             await checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineId, restored.PendingWaits[0].NodeId, ct)
                 .ConfigureAwait(false);
         }
-    }
-
-    private Task EnsureExecutionsWriteAsync(CancellationToken ct) =>
-        runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsWrite, ct);
-
-    private Task EnsureExecutionMutationWriteAsync(ExecutionRow execution, CancellationToken ct)
-    {
-        var snapshot = ExecutionSecuritySnapshotJson.TryDeserialize(execution.SecuritySnapshotJson);
-        return mutationAuth.EnsureMutationPermissionAsync(
-            snapshot,
-            RuntimePermissionRequirements.ExecutionsWrite,
-            ct);
     }
 }

--- a/core/application/Statevia.Core.Application/Services/ExecutionRecoveryService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionRecoveryService.cs
@@ -1,0 +1,126 @@
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// 所有喪失後の hydrate 再開（Wait 非消費）。
+/// </summary>
+/// <remarks>
+/// <para><see cref="ExecutionService"/> Facade から委譲される。Recover は Engine を hydrate し投影を同期する。</para>
+/// <para>durable Wait のみ残る場合は Persist+Unload して Worker Await を解放する。</para>
+/// </remarks>
+/// <param name="engine">実行エンジン。</param>
+/// <param name="executions">executions 永続化。</param>
+/// <param name="runtimeAuth">Runtime 権限。</param>
+/// <param name="mutationAuth">実行ミューテーション認可。</param>
+/// <param name="tenantContext">テナント文脈。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="lifecycle">Engine hydrate / checkpoint upsert。</param>
+/// <param name="waitEvents">Wait quiesce 待機。</param>
+/// <param name="projection">投影オーケストレータ。</param>
+/// <param name="checkpoints">checkpoint 寿命・Persist+Unload。</param>
+internal sealed class ExecutionRecoveryService(
+    IExecutionEngine engine,
+    IExecutionRepository executions,
+    IRuntimePermissionAuthorization runtimeAuth,
+    IExecutionMutationAuthorization mutationAuth,
+    ITenantContextAccessor tenantContext,
+    ICoreTransactionExecutor executor,
+    ExecutionLifecycleCommandService lifecycle,
+    ExecutionWaitEventService waitEvents,
+    ExecutionProjectionOrchestrator projection,
+    ExecutionCheckpointService checkpoints)
+{
+    /// <summary>
+    /// 所有喪失後に checkpoint から Engine を hydrate し、投影を同期する（Wait は消費しない）。
+    /// </summary>
+    /// <param name="executionId">実行 ID。</param>
+    /// <param name="requestContext">HTTP / Worker 文脈。</param>
+    /// <param name="ct">キャンセル。</param>
+    /// <exception cref="NotFoundException">実行が見つからないとき。</exception>
+    public async Task RecoverExecutionAsync(
+        Guid executionId,
+        CommandRequestContext requestContext,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(requestContext);
+        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
+
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var execution = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => executions.GetByIdAsync(uow, tenantId, executionId, innerCt),
+            ct).ConfigureAwait(false);
+        if (execution is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
+
+        if (ExecutionLifecycleCommandService.IsTerminalExecutionProjectionStatus(execution.Status))
+            return;
+
+        // Worker が BeginOwnedSession 済み前提。hydrate 後、完了フロンティア／PendingWaits から継続する。
+        await lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(executionId, execution, ct).ConfigureAwait(false);
+
+        var engineId = executionId.ToString();
+        // ImportCheckpoint が起動した継続（Wait 復元または完了フロンティア遷移）が落ち着くのを待つ。
+        await waitEvents.WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
+
+        var (status, cancelRequested, graphJson) = projection.BuildProjectionFromEngine(executionId);
+        await executor.ExecuteReadCommittedAsync(
+            async (uow, innerCt) =>
+            {
+                await executions
+                    .UpdateExecutionAndSnapshotAsync(uow, executionId, status, cancelRequested, graphJson, innerCt)
+                    .ConfigureAwait(false);
+                await projection.SyncOperationalProjectionAsync(
+                        uow,
+                        executionId,
+                        tenantId,
+                        status,
+                        graphJson,
+                        nodeIdToClear: null,
+                        innerCt)
+                    .ConfigureAwait(false);
+
+                if (await checkpoints.ShouldDiscardRuntimeCheckpointAsync(executionId, status, graphJson, innerCt)
+                        .ConfigureAwait(false))
+                {
+                    await checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
+                            uow,
+                            engineId,
+                            executionId,
+                            innerCt)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await lifecycle.UpsertRuntimeCheckpointAsync(uow, engineId, executionId, innerCt)
+                        .ConfigureAwait(false);
+                }
+            },
+            ct).ConfigureAwait(false);
+
+        // Wait 復元のみで継続が無い場合、ここで Unload しないと Worker Await が解放されない。
+        var restored = engine.ExportCheckpoint(engineId);
+        if (restored is { PendingWaits.Count: > 0 }
+            && !ExecutionOwnershipService.HasRunningNonWaitNodes(engine.ExportExecutionGraph(engineId)))
+        {
+            await checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineId, restored.PendingWaits[0].NodeId, ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private Task EnsureExecutionsWriteAsync(CancellationToken ct) =>
+        runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsWrite, ct);
+
+    private Task EnsureExecutionMutationWriteAsync(ExecutionRow execution, CancellationToken ct)
+    {
+        var snapshot = ExecutionSecuritySnapshotJson.TryDeserialize(execution.SecuritySnapshotJson);
+        return mutationAuth.EnsureMutationPermissionAsync(
+            snapshot,
+            RuntimePermissionRequirements.ExecutionsWrite,
+            ct);
+    }
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -1,6 +1,3 @@
-using System.Collections.Concurrent;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Statevia.Core.Application.Infrastructure;
@@ -12,15 +9,6 @@ internal sealed class ExecutionService : IExecutionService
 {
     /// <summary>Worker が 1 Load を待つときのポーリング間隔。</summary>
     private static readonly TimeSpan LocalExecutionLoadPollInterval = TimeSpan.FromMilliseconds(250);
-
-    /// <summary>
-    /// 同一実行の <see cref="PersistCheckpointAndUnloadCoreAsync"/> を直列化し、
-    /// 古い Fork Unload が新しい Wait 断面を上書きしないようにする。
-    /// </summary>
-    private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> PersistUnloadGates = new();
-
-    /// <summary>HTTP 204 No Content。</summary>
-    private const int HttpStatus204NoContent = 204;
 
     /// <summary>実行グラフ JSON のプロパティ名（投影・Engine export 共通）。</summary>
     private static class ExecutionGraphJsonProperties
@@ -62,6 +50,7 @@ internal sealed class ExecutionService : IExecutionService
     private readonly ExecutionProjectionOrchestrator _projection;
     private readonly ExecutionLifecycleCommandService _lifecycle;
     private readonly ExecutionWaitEventService _waitEvents;
+    private readonly ExecutionCheckpointService _checkpoints;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
@@ -93,6 +82,7 @@ internal sealed class ExecutionService : IExecutionService
         ExecutionProjectionOrchestrator projection,
         ExecutionLifecycleCommandService lifecycle,
         ExecutionWaitEventService waitEvents,
+        ExecutionCheckpointService checkpoints,
         IExecutionWorkQueue? workQueue = null,
         ExecutionOwnershipTracker? ownershipTracker = null,
         IForkChildExecutionCoordinator? forkChildCoordinator = null)
@@ -124,6 +114,7 @@ internal sealed class ExecutionService : IExecutionService
         _projection = projection;
         _lifecycle = lifecycle;
         _waitEvents = waitEvents;
+        _checkpoints = checkpoints;
         _forkChildCoordinator = forkChildCoordinator;
     }
 
@@ -166,61 +157,10 @@ internal sealed class ExecutionService : IExecutionService
         CommandRequestContext requestContext,
         CancellationToken ct) =>
         _lifecycle.CancelAsync(idOrUuid, idempotencyKey, requestContext, ct);
-
     /// <inheritdoc />
-    public async Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(engineExecutionId);
-        if (!Guid.TryParse(engineExecutionId, out var executionId))
-        {
-            _logger.SkipKeepLoadedCheckpointInvalidExecutionId(engineExecutionId);
-            return;
-        }
+    public Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct) =>
+        _checkpoints.PersistCheckpointKeepLoadedAsync(engineExecutionId, ct);
 
-        var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
-        if (checkpoint is null)
-            return;
-
-        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
-        var updatedAt = DateTime.UtcNow;
-
-        await _executor.ExecuteReadCommittedAsync(
-            async (uow, innerCt) =>
-            {
-                if (_ownership.TryGet(executionId, out _, out var generation))
-                {
-                    var ok = await _checkpointStore.TryUpsertRuntimeWithGenerationAsync(
-                            uow,
-                            new ExecutionCheckpointRuntimeUpsert(
-                                executionId,
-                                generation,
-                                json,
-                                checkpoint.SchemaVersion,
-                                updatedAt),
-                            innerCt)
-                        .ConfigureAwait(false);
-                    if (!ok)
-                    {
-                        _logger.KeepLoadedCheckpointRejectedByFencing(executionId);
-                    }
-
-                    return;
-                }
-
-                await _checkpointStore.UpsertAsync(
-                        uow,
-                        new ExecutionCheckpointDocument
-                        {
-                            ExecutionId = executionId,
-                            CheckpointJson = json,
-                            SchemaVersion = checkpoint.SchemaVersion,
-                            UpdatedAt = updatedAt
-                        },
-                        innerCt)
-                    .ConfigureAwait(false);
-            },
-            ct).ConfigureAwait(false);
-    }
 
     /// <inheritdoc />
     public async Task<long?> BeginOwnedSessionAsync(
@@ -350,7 +290,7 @@ internal sealed class ExecutionService : IExecutionService
                 && !HasRunningNonWaitNodes(_engine.ExportExecutionGraph(engineId)))
             {
                 var waitNodeId = checkpoint.PendingWaits[0].NodeId;
-                await PersistCheckpointAndUnloadByEngineIdAsync(engineId, waitNodeId, ct)
+                await _checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineId, waitNodeId, ct)
                     .ConfigureAwait(false);
                 return;
             }
@@ -434,8 +374,8 @@ internal sealed class ExecutionService : IExecutionService
             idempotencyKey,
             requestContext,
             HandleChildCompletedResumeAsync,
-            ShouldDiscardRuntimeCheckpointAsync,
-            DiscardOrRefreshRuntimeCheckpointAsync,
+            _checkpoints.ShouldDiscardRuntimeCheckpointAsync,
+            _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync,
             ct);
 
     /// <summary>
@@ -629,7 +569,7 @@ internal sealed class ExecutionService : IExecutionService
                             innerCt)
                         .ConfigureAwait(false);
 
-                    await DiscardOrRefreshRuntimeCheckpointAsync(
+                    await _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
                             uow,
                             parentExecutionId.ToString(),
                             parentExecutionId,
@@ -727,14 +667,14 @@ internal sealed class ExecutionService : IExecutionService
                             innerCt)
                         .ConfigureAwait(false);
 
-                    if (await ShouldDiscardRuntimeCheckpointAsync(
+                    if (await _checkpoints.ShouldDiscardRuntimeCheckpointAsync(
                                 parentExecutionId,
                                 writeStatus,
                                 writeGraph,
                                 innerCt)
                             .ConfigureAwait(false))
                     {
-                        await DiscardOrRefreshRuntimeCheckpointAsync(
+                        await _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
                                 uow,
                                 engineId,
                                 parentExecutionId,
@@ -798,10 +738,10 @@ internal sealed class ExecutionService : IExecutionService
                         innerCt)
                     .ConfigureAwait(false);
 
-                if (await ShouldDiscardRuntimeCheckpointAsync(executionId, status, graphJson, innerCt)
+                if (await _checkpoints.ShouldDiscardRuntimeCheckpointAsync(executionId, status, graphJson, innerCt)
                         .ConfigureAwait(false))
                 {
-                    await DiscardOrRefreshRuntimeCheckpointAsync(
+                    await _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
                             uow,
                             engineId,
                             executionId,
@@ -821,7 +761,7 @@ internal sealed class ExecutionService : IExecutionService
         if (restored is { PendingWaits.Count: > 0 }
             && !HasRunningNonWaitNodes(_engine.ExportExecutionGraph(engineId)))
         {
-            await PersistCheckpointAndUnloadByEngineIdAsync(engineId, restored.PendingWaits[0].NodeId, ct)
+            await _checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineId, restored.PendingWaits[0].NodeId, ct)
                 .ConfigureAwait(false);
         }
     }
@@ -990,81 +930,6 @@ internal sealed class ExecutionService : IExecutionService
         }
     }
 
-    /// <summary>
-    /// 寿命表に従い checkpoint <b>内容</b>の破棄候補か。
-    /// </summary>
-    /// <remarks>
-    /// 保持理由は <see cref="RuntimeCheckpointRetainReasons"/> のみ
-    ///（PendingWaits / PendingPhysicalJoin）。
-    /// Worker 所有 lease は同列にせず、破棄候補でも
-    /// <see cref="DiscardOrRefreshRuntimeCheckpointAsync"/> が Delete を抑止する。
-    /// </remarks>
-    private async Task<bool> ShouldDiscardRuntimeCheckpointAsync(
-        Guid executionId,
-        string status,
-        string graphJson,
-        CancellationToken ct)
-    {
-        var retainReasons = await EvaluateRuntimeCheckpointRetainReasonsAsync(
-                executionId,
-                graphJson,
-                ct)
-            .ConfigureAwait(false);
-        return RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(status, retainReasons);
-    }
-
-    /// <summary>
-    /// 寿命表の内容保持理由を評価する（OwnedLease は含めない）。
-    /// </summary>
-    private async Task<RuntimeCheckpointRetainReasons> EvaluateRuntimeCheckpointRetainReasonsAsync(
-        Guid executionId,
-        string graphJson,
-        CancellationToken ct)
-    {
-        var reasons = RuntimeCheckpointRetainReasons.None;
-
-        if (ExecutionOperationalProjectionSync.HasDurableWaits(graphJson))
-            reasons |= RuntimeCheckpointRetainReasons.PendingWaits;
-
-        if (_forkChildCoordinator is not null
-            && await _forkChildCoordinator
-                .HasPendingPhysicalJoinBranchesAsync(executionId, ct)
-                .ConfigureAwait(false))
-        {
-            reasons |= RuntimeCheckpointRetainReasons.PendingPhysicalJoin;
-        }
-
-        return reasons;
-    }
-
-    /// <summary>
-    /// 内容破棄候補の checkpoint を削除するか、Worker 所有中なら runtime JSON のみ更新する。
-    /// </summary>
-    /// <remarks>
-    /// 所有（OwnedLease）は寿命表の保持理由ではない。Worker 都合で行を残し refresh する別層。
-    /// </remarks>
-    /// <returns>
-    /// 投影同期後に Engine を Unload してよいとき <see langword="true"/>。
-    /// 所有中の refresh や削除のみの場合は <see langword="false"/>。
-    /// </returns>
-    private async Task<bool> DiscardOrRefreshRuntimeCheckpointAsync(
-        ICoreUnitOfWork uow,
-        string engineExecutionId,
-        Guid executionId,
-        CancellationToken ct)
-    {
-        if (_ownership.TryGet(executionId, out _, out _))
-        {
-            // Worker 所有中。寿命表上は破棄候補でも lease 行は残し runtime だけ更新する。
-            _ = await _lifecycle.UpsertRuntimeCheckpointAsync(uow, engineExecutionId, executionId, ct)
-                .ConfigureAwait(false);
-            return false;
-        }
-
-        await _checkpointStore.DeleteAsync(uow, executionId, ct).ConfigureAwait(false);
-        return false;
-    }
-
     private Task EnsureExecutionsWriteAsync(CancellationToken ct) =>
         _runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsWrite, ct);
 
@@ -1076,306 +941,21 @@ internal sealed class ExecutionService : IExecutionService
             RuntimePermissionRequirements.ExecutionsWrite,
             ct);
     }
-
-    /// <summary>
-    /// Wait 登録直後: チェックポイントを保存して Unload する。
-    /// </summary>
-    /// <remarks>
-    /// Engine 辞書キーは <see cref="Guid.ToString()"/>（Start 時と同じ形式）を使う。
-    /// Export できない場合は Warning を出し、Unload しない（インメモリ再開を維持する）。
-    /// </remarks>
+    /// <inheritdoc />
     public Task PersistCheckpointAndUnloadAsync(Guid executionId, string nodeId, CancellationToken ct) =>
-        PersistCheckpointAndUnloadCoreAsync(executionId.ToString(), executionId, nodeId, ct);
-
-    /// <summary>
-    /// Engine 実行 ID 文字列を正としてチェックポイントを保存し Unload する。
-    /// </summary>
-    /// <param name="engineExecutionId">Engine に渡した実行 ID（辞書キー）。</param>
-    /// <param name="nodeId">Wait ノード ID（ログ用）。</param>
-    /// <param name="ct">キャンセル。</param>
+        _checkpoints.PersistCheckpointAndUnloadAsync(executionId, nodeId, ct);
+    /// <inheritdoc />
     public Task PersistCheckpointAndUnloadByEngineIdAsync(
         string engineExecutionId,
         string nodeId,
-        CancellationToken ct)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(engineExecutionId);
-        if (!Guid.TryParse(engineExecutionId, out var executionId))
-        {
-            _logger.SkipCheckpointPersistInvalidExecutionId(engineExecutionId);
-            return Task.CompletedTask;
-        }
-
-        return PersistCheckpointAndUnloadCoreAsync(engineExecutionId, executionId, nodeId, ct);
-    }
-
-    /// <summary>チェックポイント upsert ののち Engine から Unload する共通実装。</summary>
-    private async Task PersistCheckpointAndUnloadCoreAsync(
-        string engineExecutionId,
-        Guid executionId,
-        string nodeId,
-        CancellationToken ct)
-    {
-        var gate = PersistUnloadGates.GetOrAdd(executionId, static _ => new SemaphoreSlim(1, 1));
-        await gate.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            await PersistCheckpointAndUnloadUnderGateAsync(engineExecutionId, executionId, nodeId, ct)
-                .ConfigureAwait(false);
-        }
-        finally
-        {
-            gate.Release();
-        }
-    }
-
-    /// <summary>ゲート取得後の Persist + Unload 本体。</summary>
-    private async Task PersistCheckpointAndUnloadUnderGateAsync(
-        string engineExecutionId,
-        Guid executionId,
-        string nodeId,
-        CancellationToken ct)
-    {
-        var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
-        if (checkpoint is null)
-        {
-            _logger.ExportCheckpointNullSkipUnload(engineExecutionId, nodeId);
-            return;
-        }
-
-        // ForkExpansion は fire-and-forget のため ExpandFork 完了が Join→decide より遅れることがある。
-        // その遅延 Persist が空断面で Unload すると Wait 登録前／登録直後の decide を潰す（初回 Wait 到達不能）。
-        if (IsForkExpansionUnloadObsolete(checkpoint, nodeId))
-        {
-            _logger.SkipForkExpansionUnloadAlreadyProgressed(
-                executionId,
-                nodeId,
-                checkpoint.ActiveStates.Count,
-                checkpoint.PendingWaits.Count);
-            return;
-        }
-
-        // Unload 前に投影へ反映する（Unload 後は GetSnapshot が null になり投影キューが空振りする）。
-        // snapshot 欠落時は Unknown/`{}` を書かず checkpoint のみ残す（マルチ Worker 競合で UI を壊さない）。
-        var snapshot = _engine.GetSnapshot(engineExecutionId);
-        string? status = null;
-        bool? cancelRequested = null;
-        string? graphJson = null;
-        if (snapshot is not null)
-        {
-            status = ExecutionProjectionOrchestrator.MapStatus(snapshot);
-            cancelRequested = snapshot.IsCancelled;
-            graphJson = _engine.ExportExecutionGraph(engineExecutionId);
-        }
-
-        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
-        var updatedAt = DateTime.UtcNow;
-        var (fenceLost, skippedStalePersist) = await PersistCheckpointDocumentUnderTransactionAsync(
-                new CheckpointDocumentPersistRequest(
-                    executionId,
-                    nodeId,
-                    checkpoint,
-                    json,
-                    updatedAt,
-                    status,
-                    cancelRequested,
-                    graphJson),
-                ct)
-            .ConfigureAwait(false);
-
-        if (skippedStalePersist)
-            return;
-
-        _ownership.Clear(executionId);
-        _engine.Unload(engineExecutionId);
-
-        if (fenceLost)
-        {
-            _logger.UnloadAfterWaitFencingLost(nodeId, executionId);
-            return;
-        }
-
-        _logger.CheckpointUnloadedAfterWait(executionId, nodeId);
-    }
-
-    /// <summary>Persist ゲート内の checkpoint 文書 Upsert 入力。</summary>
-    private readonly record struct CheckpointDocumentPersistRequest(
-        Guid ExecutionId,
-        string NodeId,
-        ExecutionRuntimeCheckpoint Checkpoint,
-        string CheckpointJson,
-        DateTime UpdatedAt,
-        string? Status,
-        bool? CancelRequested,
-        string? GraphJson);
-
-    /// <summary>
-    /// Persist ゲート内トランザクション: 投影更新・checkpoint Upsert・所有クリア。
-    /// </summary>
-    /// <returns>fencing 喪失と stale skip の有無。</returns>
-    private async Task<(bool FenceLost, bool SkippedStalePersist)> PersistCheckpointDocumentUnderTransactionAsync(
-        CheckpointDocumentPersistRequest request,
-        CancellationToken ct)
-    {
-        var skippedStalePersist = false;
-        var fenceLost = await _executor.ExecuteReadCommittedAsync(
-            async (uow, innerCt) =>
-            {
-                var existingCheckpoint = await _checkpointStore
-                    .GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
-                    .ConfigureAwait(false);
-                if (existingCheckpoint is not null
-                    && ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(existingCheckpoint.CheckpointJson, out var stored, out _)
-                    && IsRuntimeCheckpointLessAdvanced(request.Checkpoint, stored))
-                {
-                    skippedStalePersist = true;
-                    _logger.SkipStaleCheckpointPersist(
-                        request.ExecutionId,
-                        request.NodeId,
-                        stored.PendingWaits.Count,
-                        request.Checkpoint.PendingWaits.Count,
-                        stored.Graph.Nodes.Count,
-                        request.Checkpoint.Graph.Nodes.Count);
-                    return false;
-                }
-
-                var execution = await _executions.GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
-                    .ConfigureAwait(false);
-                if (execution is not null && request.Status is not null && request.GraphJson is not null)
-                {
-                    await _executions
-                        .UpdateExecutionAndSnapshotAsync(
-                            uow,
-                            request.ExecutionId,
-                            request.Status,
-                            request.CancelRequested,
-                            request.GraphJson,
-                            innerCt)
-                        .ConfigureAwait(false);
-                    await _projection.SyncOperationalProjectionAsync(
-                            uow,
-                            request.ExecutionId,
-                            execution.TenantId,
-                            request.Status,
-                            request.GraphJson,
-                            nodeIdToClear: null,
-                            innerCt)
-                        .ConfigureAwait(false);
-                }
-
-                if (_ownership.TryGet(request.ExecutionId, out _, out var generation))
-                {
-                    var upserted = await _checkpointStore.TryUpsertRuntimeWithGenerationAsync(
-                            uow,
-                            new ExecutionCheckpointRuntimeUpsert(
-                                request.ExecutionId,
-                                generation,
-                                request.CheckpointJson,
-                                request.Checkpoint.SchemaVersion,
-                                request.UpdatedAt),
-                            innerCt)
-                        .ConfigureAwait(false);
-                    if (!upserted)
-                        return true;
-
-                    await _checkpointStore.TryClearOwnershipAsync(uow, request.ExecutionId, generation, innerCt)
-                        .ConfigureAwait(false);
-                    return false;
-                }
-
-                await _checkpointStore.UpsertAsync(
-                    uow,
-                    new ExecutionCheckpointDocument
-                    {
-                        ExecutionId = request.ExecutionId,
-                        CheckpointJson = request.CheckpointJson,
-                        SchemaVersion = request.Checkpoint.SchemaVersion,
-                        UpdatedAt = request.UpdatedAt
-                    },
-                    innerCt).ConfigureAwait(false);
-
-                var existing = await _checkpointStore.GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
-                    .ConfigureAwait(false);
-                if (existing?.OwnerWorkerId is not null)
-                {
-                    await _checkpointStore.TryClearOwnershipAsync(
-                            uow,
-                            request.ExecutionId,
-                            existing.OwnerGeneration,
-                            innerCt)
-                        .ConfigureAwait(false);
-                }
-
-                return false;
-            },
-            ct).ConfigureAwait(false);
-
-        return (fenceLost, skippedStalePersist);
-    }
-
-    /// <summary>
-    /// 永続済み断面より incoming が遅れているか（古い Fork Unload の上書き防止）。
-    /// </summary>
-    /// <remarks>単体テストから到達するため internal。</remarks>
-    internal static bool IsRuntimeCheckpointLessAdvanced(
-        ExecutionRuntimeCheckpoint incoming,
-        ExecutionRuntimeCheckpoint stored)
-    {
-        if (incoming.IsCompleted || incoming.IsCancelled || incoming.IsFailed)
-            return false;
-
-        if (incoming.Graph.Nodes.Count < stored.Graph.Nodes.Count)
-            return true;
-
-        // stored に durable Wait があり、incoming が Fork 待ち相当（active/wait 空）なら古い。
-        return stored.PendingWaits.Count > 0
-            && incoming.PendingWaits.Count == 0
-            && incoming.ActiveStates.Count == 0;
-    }
-
-    /// <summary>
-    /// Fork 展開後の Persist が、当該 Fork より先の Join / Wait 進行後に遅延したか。
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Hosted では <c>NotifyForkExpansion</c> が非同期のため、子完了→Join→decide が
-    /// <c>ExpandFork</c> 完了より先に進みうる。その場合の Unload は decide Wait を失わせる。
-    /// </para>
-    /// <para>
-    /// <paramref name="nodeId"/> が Fork ノードでない呼び出し（Wait Suspend）は常に false。
-    /// </para>
-    /// <para>単体テストから到達するため internal。</para>
-    /// </remarks>
-    /// <param name="checkpoint">Export 直後の断面。</param>
-    /// <param name="nodeId">Persist 要求元のノード ID（Fork 展開時は Fork ノード）。</param>
-    /// <returns>Unload をスキップすべきなら true。</returns>
-    internal static bool IsForkExpansionUnloadObsolete(
-        ExecutionRuntimeCheckpoint checkpoint,
-        string nodeId)
-    {
-        var forkNode = checkpoint.Graph.Nodes
-            .FirstOrDefault(n =>
-                string.Equals(n.NodeId, nodeId, StringComparison.Ordinal)
-                && string.Equals(n.NodeType, "Fork", StringComparison.OrdinalIgnoreCase));
-        if (forkNode is null)
-            return false;
-
-        // Join 後の decide 実行中、または durable Wait 登録済みなら SuspendHandler に委ねる。
-        if (checkpoint.ActiveStates.Count > 0 || checkpoint.PendingWaits.Count > 0)
-            return true;
-
-        // この Fork 到達以降に Join が完了していれば、子待ち Unload の窓は閉じている。
-        return checkpoint.Graph.Nodes.Any(n =>
-            string.Equals(n.NodeType, "Join", StringComparison.OrdinalIgnoreCase)
-            && n.StartedAt >= forkNode.StartedAt
-            && (string.Equals(n.Fact, "Joined", StringComparison.OrdinalIgnoreCase)
-                || n.CompletedAt is not null));
-    }
+        CancellationToken ct) =>
+        _checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineExecutionId, nodeId, ct);
 
     public Task UpdateProjectionFromEngineAsync(Guid executionId, CancellationToken ct) =>
         _projection.UpdateProjectionFromEngineAsync(
             executionId,
-            ShouldDiscardRuntimeCheckpointAsync,
-            DiscardOrRefreshRuntimeCheckpointAsync,
+            _checkpoints.ShouldDiscardRuntimeCheckpointAsync,
+            _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync,
             _lifecycle.UpsertRuntimeCheckpointAsync,
             ct);
 

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -1,145 +1,64 @@
-using System.Text.Json;
-using Microsoft.Extensions.Logging;
-using Statevia.Core.Application.Infrastructure;
-using Statevia.Core.Engine.Abstractions;
-
 namespace Statevia.Core.Application.Services;
 
-internal sealed class ExecutionService : IExecutionService
+/// <summary>
+/// <see cref="IExecutionService"/> の薄いファサード。ドメインサービスへ委譲する。
+/// </summary>
+/// <remarks>
+/// <para>HTTP / Worker 契約の入口。ビジネス分岐は持たず、各ドメインサービスに委譲する。</para>
+/// <para>Repository / Auth / Engine への直接依存は持たない（最終形）。</para>
+/// </remarks>
+/// <param name="query">Read-model 取得。</param>
+/// <param name="projection">投影オーケストレータ。</param>
+/// <param name="lifecycle">Start / Cancel / QueuedStart。</param>
+/// <param name="waitEvents">Publish / Resume。</param>
+/// <param name="checkpoints">checkpoint Persist / Unload。</param>
+/// <param name="ownershipSessions">Worker 所有セッション。</param>
+/// <param name="recovery">Recover。</param>
+internal sealed class ExecutionService(
+    ExecutionQueryService query,
+    ExecutionProjectionOrchestrator projection,
+    ExecutionLifecycleCommandService lifecycle,
+    ExecutionWaitEventService waitEvents,
+    ExecutionCheckpointService checkpoints,
+    ExecutionOwnershipService ownershipSessions,
+    ExecutionRecoveryService recovery) : IExecutionService
 {
-    private readonly IExecutionEngine _engine;
-    private readonly IDisplayIdService _displayIds;
-    private readonly IDefinitionCompilerService _compiler;
-    private readonly IIdGenerator _idGenerator;
-    private readonly IExecutionRepository _executions;
-    private readonly IExecutionWaitRepository _executionWaits;
-    private readonly IExecutionCheckpointStore _checkpointStore;
-    private readonly IExecutionWorkQueue? _workQueue;
-    private readonly ExecutionOwnershipTracker _ownership;
-    private readonly IDefinitionRepository _definitions;
-    private readonly IProjectAuthorizationService _projectAuth;
-    private readonly IRuntimePermissionAuthorization _runtimeAuth;
-    private readonly IExecutionMutationAuthorization _mutationAuth;
-    private readonly IExecutionSecuritySnapshotFactory _snapshotFactory;
-    private readonly ITenantContextAccessor _tenantContext;
-    private readonly ICommandDedupRepository _dedup;
-    private readonly IEventStoreRepository _eventStore;
-    private readonly IEventDeliveryDedupRepository _eventDeliveryDedup;
-    private readonly IDisplayIdWriteService _displayIdWrites;
-    private readonly ICoreTransactionExecutor _executor;
-    private readonly IExecutionMutationPersistence _mutationPersistence;
-    private readonly ILogger<ExecutionService> _logger;
-    private readonly IForkChildExecutionCoordinator? _forkChildCoordinator;
-    private readonly ExecutionQueryService _query;
-    private readonly ExecutionIdempotencyService _idempotency;
-    private readonly ExecutionProjectionOrchestrator _projection;
-    private readonly ExecutionLifecycleCommandService _lifecycle;
-    private readonly ExecutionWaitEventService _waitEvents;
-    private readonly ExecutionCheckpointService _checkpoints;
-    private readonly ExecutionOwnershipService _ownershipSessions;
-    private readonly ExecutionRecoveryService _recovery;
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S107:Methods should not have too many parameters",
-        Justification = "DI による明示的コンストラクタ注入。")]
-    public ExecutionService(
-        IExecutionEngine engine,
-        IDisplayIdService displayIds,
-        IDefinitionCompilerService compiler,
-        IIdGenerator idGenerator,
-        IExecutionRepository executions,
-        IExecutionWaitRepository executionWaits,
-        IDefinitionRepository definitions,
-        IProjectAuthorizationService projectAuth,
-        IRuntimePermissionAuthorization runtimeAuth,
-        IExecutionMutationAuthorization mutationAuth,
-        IExecutionSecuritySnapshotFactory snapshotFactory,
-        ITenantContextAccessor tenantContext,
-        ICommandDedupRepository dedup,
-        IEventStoreRepository eventStore,
-        IEventDeliveryDedupRepository eventDeliveryDedup,
-        IDisplayIdWriteService displayIdWrites,
-        ICoreTransactionExecutor executor,
-        IExecutionMutationPersistence mutationPersistence,
-        ILogger<ExecutionService> logger,
-        IExecutionCheckpointStore checkpointStore,
-        ExecutionQueryService query,
-        ExecutionIdempotencyService idempotency,
-        ExecutionProjectionOrchestrator projection,
-        ExecutionLifecycleCommandService lifecycle,
-        ExecutionWaitEventService waitEvents,
-        ExecutionCheckpointService checkpoints,
-        ExecutionOwnershipService ownershipSessions,
-        ExecutionRecoveryService recovery,
-        IExecutionWorkQueue? workQueue = null,
-        ExecutionOwnershipTracker? ownershipTracker = null,
-        IForkChildExecutionCoordinator? forkChildCoordinator = null)
-    {
-        _engine = engine;
-        _displayIds = displayIds;
-        _compiler = compiler;
-        _idGenerator = idGenerator;
-        _executions = executions;
-        _executionWaits = executionWaits;
-        _checkpointStore = checkpointStore;
-        _workQueue = workQueue;
-        _ownership = ownershipTracker ?? new ExecutionOwnershipTracker();
-        _definitions = definitions;
-        _projectAuth = projectAuth;
-        _runtimeAuth = runtimeAuth;
-        _mutationAuth = mutationAuth;
-        _snapshotFactory = snapshotFactory;
-        _tenantContext = tenantContext;
-        _dedup = dedup;
-        _eventStore = eventStore;
-        _eventDeliveryDedup = eventDeliveryDedup;
-        _displayIdWrites = displayIdWrites;
-        _executor = executor;
-        _mutationPersistence = mutationPersistence;
-        _logger = logger;
-        _query = query;
-        _idempotency = idempotency;
-        _projection = projection;
-        _lifecycle = lifecycle;
-        _waitEvents = waitEvents;
-        _checkpoints = checkpoints;
-        _ownershipSessions = ownershipSessions;
-        _recovery = recovery;
-        _forkChildCoordinator = forkChildCoordinator;
-    }
-
     /// <inheritdoc />
     public Task<ExecutionResponse> StartAsync(
         StartExecutionRequest request,
         string? idempotencyKey,
         CommandRequestContext requestContext,
         CancellationToken ct) =>
-        _lifecycle.StartAsync(request, idempotencyKey, requestContext, ct);
+        lifecycle.StartAsync(request, idempotencyKey, requestContext, ct);
 
     /// <inheritdoc />
     public Task<ExecutionResponse> ExecuteQueuedStartAsync(
         Guid executionId,
         StartExecutionRequest request,
         CancellationToken ct) =>
-        _lifecycle.ExecuteQueuedStartAsync(executionId, request, ct);
+        lifecycle.ExecuteQueuedStartAsync(executionId, request, ct);
 
+    /// <inheritdoc />
     public Task<PagedResult<ExecutionResponse>> ListPagedAsync(
-        ExecutionListPageQuery query,
+        ExecutionListPageQuery listQuery,
         CancellationToken ct) =>
-        _query.ListPagedAsync(query, ct);
+        query.ListPagedAsync(listQuery, ct);
 
+    /// <inheritdoc />
     public Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct) =>
-        _query.GetExecutionResponseAsync(idOrUuid, ct);
+        query.GetExecutionResponseAsync(idOrUuid, ct);
 
+    /// <inheritdoc />
     public Task<string> GetGraphJsonAsync(string idOrUuid, CancellationToken ct) =>
-        _query.GetGraphJsonAsync(idOrUuid, ct);
+        query.GetGraphJsonAsync(idOrUuid, ct);
 
+    /// <inheritdoc />
     public Task EnsureExecutionExistsAsync(Guid executionId, CancellationToken ct) =>
-        _query.EnsureExecutionExistsAsync(executionId, ct);
+        query.EnsureExecutionExistsAsync(executionId, ct);
 
+    /// <inheritdoc />
     public Task<string?> TryGetSnapshotGraphJsonByExecutionIdAsync(Guid executionId, CancellationToken ct) =>
-        _query.TryGetSnapshotGraphJsonByExecutionIdAsync(executionId, ct);
+        query.TryGetSnapshotGraphJsonByExecutionIdAsync(executionId, ct);
 
     /// <inheritdoc />
     public Task CancelAsync(
@@ -147,11 +66,11 @@ internal sealed class ExecutionService : IExecutionService
         string? idempotencyKey,
         CommandRequestContext requestContext,
         CancellationToken ct) =>
-        _lifecycle.CancelAsync(idOrUuid, idempotencyKey, requestContext, ct);
-        
+        lifecycle.CancelAsync(idOrUuid, idempotencyKey, requestContext, ct);
+
     /// <inheritdoc />
     public Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct) =>
-        _checkpoints.PersistCheckpointKeepLoadedAsync(engineExecutionId, ct);
+        checkpoints.PersistCheckpointKeepLoadedAsync(engineExecutionId, ct);
 
     /// <inheritdoc />
     public Task<long?> BeginOwnedSessionAsync(
@@ -159,26 +78,26 @@ internal sealed class ExecutionService : IExecutionService
         string workerId,
         TimeSpan leaseDuration,
         CancellationToken ct) =>
-        _ownershipSessions.BeginOwnedSessionAsync(executionId, workerId, leaseDuration, ct);
+        ownershipSessions.BeginOwnedSessionAsync(executionId, workerId, leaseDuration, ct);
 
     /// <inheritdoc />
     public Task<bool> RenewOwnedSessionLeaseAsync(
         Guid executionId,
         TimeSpan leaseDuration,
         CancellationToken ct) =>
-        _ownershipSessions.RenewOwnedSessionLeaseAsync(executionId, leaseDuration, ct);
+        ownershipSessions.RenewOwnedSessionLeaseAsync(executionId, leaseDuration, ct);
 
     /// <inheritdoc />
     public Task EndOwnedSessionAsync(Guid executionId, CancellationToken ct) =>
-        _ownershipSessions.EndOwnedSessionAsync(executionId, ct);
+        ownershipSessions.EndOwnedSessionAsync(executionId, ct);
 
     /// <inheritdoc />
     public Task AbandonLocalOwnedSessionAsync(Guid executionId) =>
-        _ownershipSessions.AbandonLocalOwnedSessionAsync(executionId);
+        ownershipSessions.AbandonLocalOwnedSessionAsync(executionId);
 
     /// <inheritdoc />
     public Task AwaitLocalExecutionLoadAsync(Guid executionId, CancellationToken ct) =>
-        _ownershipSessions.AwaitLocalExecutionLoadAsync(executionId, ct);
+        ownershipSessions.AwaitLocalExecutionLoadAsync(executionId, ct);
 
     /// <inheritdoc />
     public Task PublishEventAsync(
@@ -187,20 +106,23 @@ internal sealed class ExecutionService : IExecutionService
         string? idempotencyKey,
         CommandRequestContext requestContext,
         CancellationToken ct) =>
-        _waitEvents.PublishEventAsync(idOrUuid, eventName, idempotencyKey, requestContext, ct);
+        waitEvents.PublishEventAsync(idOrUuid, eventName, idempotencyKey, requestContext, ct);
 
+    /// <inheritdoc />
     public Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct) =>
-        _query.GetExecutionViewAsync(idOrUuid, ct);
+        query.GetExecutionViewAsync(idOrUuid, ct);
 
+    /// <inheritdoc />
     public Task<ExecutionViewDto> GetExecutionViewAtSeqAsync(string idOrUuid, long atSeq, CancellationToken ct) =>
-        _query.GetExecutionViewAtSeqAsync(idOrUuid, atSeq, ct);
+        query.GetExecutionViewAtSeqAsync(idOrUuid, atSeq, ct);
 
+    /// <inheritdoc />
     public Task<ExecutionEventsResponseDto> ListEventsAsync(
         string idOrUuid,
         long afterSeq,
         int limit,
         CancellationToken ct) =>
-        _query.ListEventsAsync(idOrUuid, afterSeq, limit, ct);
+        query.ListEventsAsync(idOrUuid, afterSeq, limit, ct);
 
     /// <inheritdoc />
     public Task ResumeNodeAsync(
@@ -210,7 +132,7 @@ internal sealed class ExecutionService : IExecutionService
         string? idempotencyKey,
         CommandRequestContext requestContext,
         CancellationToken ct) =>
-        _waitEvents.ResumeNodeAsync(
+        waitEvents.ResumeNodeAsync(
             idOrUuid,
             nodeId,
             resumeKey,
@@ -223,25 +145,25 @@ internal sealed class ExecutionService : IExecutionService
         Guid executionId,
         CommandRequestContext requestContext,
         CancellationToken ct) =>
-        _recovery.RecoverExecutionAsync(executionId, requestContext, ct);
+        recovery.RecoverExecutionAsync(executionId, requestContext, ct);
 
     /// <inheritdoc />
     public Task PersistCheckpointAndUnloadAsync(Guid executionId, string nodeId, CancellationToken ct) =>
-        _checkpoints.PersistCheckpointAndUnloadAsync(executionId, nodeId, ct);
+        checkpoints.PersistCheckpointAndUnloadAsync(executionId, nodeId, ct);
 
     /// <inheritdoc />
     public Task PersistCheckpointAndUnloadByEngineIdAsync(
         string engineExecutionId,
         string nodeId,
         CancellationToken ct) =>
-        _checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineExecutionId, nodeId, ct);
+        checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineExecutionId, nodeId, ct);
 
+    /// <inheritdoc />
     public Task UpdateProjectionFromEngineAsync(Guid executionId, CancellationToken ct) =>
-        _projection.UpdateProjectionFromEngineAsync(
+        projection.UpdateProjectionFromEngineAsync(
             executionId,
-            _checkpoints.ShouldDiscardRuntimeCheckpointAsync,
-            _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync,
-            _lifecycle.UpsertRuntimeCheckpointAsync,
+            checkpoints.ShouldDiscardRuntimeCheckpointAsync,
+            checkpoints.DiscardOrRefreshRuntimeCheckpointAsync,
+            lifecycle.UpsertRuntimeCheckpointAsync,
             ct);
-
 }

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -7,7 +7,7 @@ namespace Statevia.Core.Application.Services;
 /// <para>HTTP / Worker 契約の入口。ビジネス分岐は持たず、各ドメインサービスに委譲する。</para>
 /// <para>Repository / Auth / Engine への直接依存は持たない（最終形）。</para>
 /// </remarks>
-/// <param name="query">Read-model 取得。</param>
+/// <param name="queryService">Read-model 取得。</param>
 /// <param name="projection">投影オーケストレータ。</param>
 /// <param name="lifecycle">Start / Cancel / QueuedStart。</param>
 /// <param name="waitEvents">Publish / Resume。</param>
@@ -15,7 +15,7 @@ namespace Statevia.Core.Application.Services;
 /// <param name="ownershipSessions">Worker 所有セッション。</param>
 /// <param name="recovery">Recover。</param>
 internal sealed class ExecutionService(
-    ExecutionQueryService query,
+    ExecutionQueryService queryService,
     ExecutionProjectionOrchestrator projection,
     ExecutionLifecycleCommandService lifecycle,
     ExecutionWaitEventService waitEvents,
@@ -40,25 +40,25 @@ internal sealed class ExecutionService(
 
     /// <inheritdoc />
     public Task<PagedResult<ExecutionResponse>> ListPagedAsync(
-        ExecutionListPageQuery listQuery,
+        ExecutionListPageQuery query,
         CancellationToken ct) =>
-        query.ListPagedAsync(listQuery, ct);
+        queryService.ListPagedAsync(query, ct);
 
     /// <inheritdoc />
     public Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct) =>
-        query.GetExecutionResponseAsync(idOrUuid, ct);
+        queryService.GetExecutionResponseAsync(idOrUuid, ct);
 
     /// <inheritdoc />
     public Task<string> GetGraphJsonAsync(string idOrUuid, CancellationToken ct) =>
-        query.GetGraphJsonAsync(idOrUuid, ct);
+        queryService.GetGraphJsonAsync(idOrUuid, ct);
 
     /// <inheritdoc />
     public Task EnsureExecutionExistsAsync(Guid executionId, CancellationToken ct) =>
-        query.EnsureExecutionExistsAsync(executionId, ct);
+        queryService.EnsureExecutionExistsAsync(executionId, ct);
 
     /// <inheritdoc />
     public Task<string?> TryGetSnapshotGraphJsonByExecutionIdAsync(Guid executionId, CancellationToken ct) =>
-        query.TryGetSnapshotGraphJsonByExecutionIdAsync(executionId, ct);
+        queryService.TryGetSnapshotGraphJsonByExecutionIdAsync(executionId, ct);
 
     /// <inheritdoc />
     public Task CancelAsync(
@@ -110,11 +110,11 @@ internal sealed class ExecutionService(
 
     /// <inheritdoc />
     public Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct) =>
-        query.GetExecutionViewAsync(idOrUuid, ct);
+        queryService.GetExecutionViewAsync(idOrUuid, ct);
 
     /// <inheritdoc />
     public Task<ExecutionViewDto> GetExecutionViewAtSeqAsync(string idOrUuid, long atSeq, CancellationToken ct) =>
-        query.GetExecutionViewAtSeqAsync(idOrUuid, atSeq, ct);
+        queryService.GetExecutionViewAtSeqAsync(idOrUuid, atSeq, ct);
 
     /// <inheritdoc />
     public Task<ExecutionEventsResponseDto> ListEventsAsync(
@@ -122,7 +122,7 @@ internal sealed class ExecutionService(
         long afterSeq,
         int limit,
         CancellationToken ct) =>
-        query.ListEventsAsync(idOrUuid, afterSeq, limit, ct);
+        queryService.ListEventsAsync(idOrUuid, afterSeq, limit, ct);
 
     /// <inheritdoc />
     public Task ResumeNodeAsync(

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -61,6 +61,7 @@ internal sealed class ExecutionService : IExecutionService
     private readonly ExecutionIdempotencyService _idempotency;
     private readonly ExecutionProjectionOrchestrator _projection;
     private readonly ExecutionLifecycleCommandService _lifecycle;
+    private readonly ExecutionWaitEventService _waitEvents;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
@@ -91,6 +92,7 @@ internal sealed class ExecutionService : IExecutionService
         ExecutionIdempotencyService idempotency,
         ExecutionProjectionOrchestrator projection,
         ExecutionLifecycleCommandService lifecycle,
+        ExecutionWaitEventService waitEvents,
         IExecutionWorkQueue? workQueue = null,
         ExecutionOwnershipTracker? ownershipTracker = null,
         IForkChildExecutionCoordinator? forkChildCoordinator = null)
@@ -121,6 +123,7 @@ internal sealed class ExecutionService : IExecutionService
         _idempotency = idempotency;
         _projection = projection;
         _lifecycle = lifecycle;
+        _waitEvents = waitEvents;
         _forkChildCoordinator = forkChildCoordinator;
     }
 
@@ -395,214 +398,14 @@ internal sealed class ExecutionService : IExecutionService
             return false;
         }
     }
-
-    public async Task PublishEventAsync(
+    /// <inheritdoc />
+    public Task PublishEventAsync(
         string idOrUuid,
         string eventName,
         string? idempotencyKey,
         CommandRequestContext requestContext,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(requestContext);
-
-        var tenantKey = _tenantContext.GetRequiredTenantKey();
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var dedupKey = _idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
-
-        if (await _idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
-            return;
-
-        var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
-        if (uuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        var execution = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt),
-            ct).ConfigureAwait(false);
-        if (execution is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        // 親 ID への PublishEvent も子 Wait へ振り替える（要件4）。
-        if (await TryRedirectPublishEventToChildWaitAsync(
-                uuid.Value,
-                eventName,
-                idempotencyKey,
-                requestContext,
-                ct).ConfigureAwait(false))
-        {
-            return;
-        }
-
-        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
-
-        await _projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
-
-        var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
-
-        if (await _idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
-            return;
-
-        await _lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
-
-        // PublishEvent 復帰時点ではグラフ上の Wait 完了が未反映になり得るため、発行前の nodeId で先行削除する。
-        // グラフ解析失敗時は永続化済み wait 行からフォールバック解決する（Applied 時のみ）。
-        var engineId = uuid.Value.ToString();
-        var prePublishGraphJson = _engine.ExportExecutionGraph(engineId);
-
-        // PublishEvent シム条件外（複数 Wait / 複数 events 等）は設計どおり 422。
-        var publishApply = InvokeEngineWaitMutation(
-            () => _engine.PublishEvent(engineId, eventName, clientEventId));
-        var skipEventAppend = publishApply.IsAlreadyApplied;
-        var nodeIdToClearFromGraph = publishApply.IsApplied
-            ? TryResolveSoleActiveWaitNodeId(prePublishGraphJson)
-            : null;
-        await AwaitEngineReadyAfterWaitClearAsync(
-                engineId,
-                publishApply.IsApplied ? nodeIdToClearFromGraph : null,
-                ct)
-            .ConfigureAwait(false);
-
-        var (pubStatus, pubCancel, pubGraphJson) = _projection.BuildProjectionFromEngine(uuid.Value);
-        var publishedPayload = JsonSerializer.Serialize(
-            new { tenantId, name = eventName },
-            JsonSerializerProfiles.CamelCase);
-
-        await _mutationPersistence.ExecuteSerializableWithRetryAsync(
-            tenantId,
-            uuid.Value,
-            clientEventId,
-            async (uow, ctInner) =>
-            {
-                var nodeIdToClear = await ResolvePublishNodeIdToClearAsync(
-                        uow,
-                        uuid.Value,
-                        publishApply.IsApplied,
-                        nodeIdToClearFromGraph,
-                        eventName,
-                        ctInner)
-                    .ConfigureAwait(false);
-
-                await _executions
-                    .UpdateExecutionAndSnapshotAsync(uow, uuid.Value, pubStatus, pubCancel, pubGraphJson, ctInner)
-                    .ConfigureAwait(false);
-                await _projection.SyncOperationalProjectionAsync(
-                        uow,
-                        uuid.Value,
-                        tenantId,
-                        pubStatus,
-                        pubGraphJson,
-                        nodeIdToClear,
-                        ctInner)
-                    .ConfigureAwait(false);
-                await AppendEventPublishedAsync(
-                        uow,
-                        uuid.Value,
-                        clientEventId,
-                        publishedPayload,
-                        skipEventAppend,
-                        ctInner)
-                    .ConfigureAwait(false);
-
-                if (dedupKey is { } saveKey)
-                {
-                    var now = DateTime.UtcNow;
-                    await _dedup.SaveAsync(
-                        uow,
-                        new CommandDedupRow
-                        {
-                            DedupKey = saveKey.DedupKey,
-                            Endpoint = saveKey.Endpoint,
-                            IdempotencyKey = saveKey.IdempotencyKey,
-                            RequestHash = null,
-                            StatusCode = HttpStatus204NoContent,
-                            ResponseBody = null,
-                            CreatedAt = now,
-                            ExpiresAt = now.AddHours(24)
-                        },
-                        ctInner).ConfigureAwait(false);
-                }
-
-                var nowUtc = DateTime.UtcNow;
-                await _eventDeliveryDedup.TryUpdateStatusAsync(
-                    uow,
-                    tenantId,
-                    uuid.Value,
-                    clientEventId,
-                    new EventDeliveryDedupStatusUpdate(
-                        EventDeliveryDedupStatuses.Applied,
-                        nowUtc,
-                        AppliedAt: nowUtc,
-                        ErrorCode: null),
-                    ctInner).ConfigureAwait(false);
-            },
-            ct).ConfigureAwait(false);
-
-        // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
-        if (publishApply.IsApplied)
-            await _projection.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Publish / Resume で Wait を消したあと、完了と後続 quiesce を待つ。
-    /// </summary>
-    private async Task AwaitEngineReadyAfterWaitClearAsync(
-        string engineId,
-        string? nodeIdToClear,
-        CancellationToken ct)
-    {
-        if (string.IsNullOrWhiteSpace(nodeIdToClear))
-            return;
-
-        await WaitForEngineWaitNodeCompletedAsync(engineId, nodeIdToClear, ct).ConfigureAwait(false);
-        // Wait 完了直後の中間グラフ（次 Task RUNNING）を永続化すると完了投影を上書きし固着する。
-        await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// グラフ解決できなかった場合に永続 wait 行から削除対象 nodeId を補完する。
-    /// </summary>
-    private async Task<string?> ResolvePublishNodeIdToClearAsync(
-        ICoreUnitOfWork uow,
-        Guid executionId,
-        bool publishApplied,
-        string? nodeIdFromGraph,
-        string eventName,
-        CancellationToken ct)
-    {
-        if (!publishApplied || !string.IsNullOrWhiteSpace(nodeIdFromGraph))
-            return nodeIdFromGraph;
-
-        var persistedWaits = await _executionWaits
-            .ListByExecutionIdAsync(uow, executionId, ct)
-            .ConfigureAwait(false);
-        return TryResolveWaitNodeIdToClearFromPersisted(persistedWaits, eventName);
-    }
-
-    /// <summary>EventPublished を通常 append または clientEvent 冪等 append する。</summary>
-    private async Task AppendEventPublishedAsync(
-        ICoreUnitOfWork uow,
-        Guid executionId,
-        Guid clientEventId,
-        string publishedPayload,
-        bool skipEventAppend,
-        CancellationToken ct)
-    {
-        if (!skipEventAppend)
-        {
-            await _eventStore
-                .AppendAsync(uow, executionId, EventStoreEventType.EventPublished, publishedPayload, ct)
-                .ConfigureAwait(false);
-            return;
-        }
-
-        await _eventStore.TryAppendIfAbsentByClientEventAsync(
-            uow,
-            executionId,
-            clientEventId,
-            EventStoreEventType.EventPublished,
-            publishedPayload,
-            ct).ConfigureAwait(false);
-    }
+        CancellationToken ct) =>
+        _waitEvents.PublishEventAsync(idOrUuid, eventName, idempotencyKey, requestContext, ct);
 
     public Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct) =>
         _query.GetExecutionViewAsync(idOrUuid, ct);
@@ -616,315 +419,24 @@ internal sealed class ExecutionService : IExecutionService
         int limit,
         CancellationToken ct) =>
         _query.ListEventsAsync(idOrUuid, afterSeq, limit, ct);
-
-    public async Task ResumeNodeAsync(
+    /// <inheritdoc />
+    public Task ResumeNodeAsync(
         string idOrUuid,
         string nodeId,
         string? resumeKey,
         string? idempotencyKey,
         CommandRequestContext requestContext,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(requestContext);
-        ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(resumeKey);
-
-        var eventName = resumeKey.Trim();
-        var tenantKey = _tenantContext.GetRequiredTenantKey();
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var dedupKey = _idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
-
-        if (await _idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
-            return;
-
-        var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
-        if (uuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        var execution = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt),
-            ct).ConfigureAwait(false);
-        if (execution is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        // 親 ID へ届いた分岐 Wait は子 execution へ振り替える（要件4）。
-        if (await TryRedirectResumeToChildWaitAsync(
-                uuid.Value,
-                nodeId,
-                eventName,
-                idempotencyKey,
-                requestContext,
-                ct).ConfigureAwait(false))
-        {
-            return;
-        }
-
-        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
-
-        await _projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
-
-        var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
-
-        if (await _idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
-            return;
-
-        // 物理子終端の予約イベントは Wait Resume ではなく Join 再評価へ振る（D3）。
-        if (string.Equals(eventName, ExecutionWaitEventNames.ChildCompleted, StringComparison.Ordinal))
-        {
-            await HandleChildCompletedResumeAsync(uuid.Value, execution, nodeId, ct).ConfigureAwait(false);
-            return;
-        }
-
-        await _lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
-
-        // Resume 正本: nodeId + eventName。wait 行は nodeId で先行削除する。
-        // 許可外イベント・非アクティブ Wait などは 422。
-        var engineId = uuid.Value.ToString();
-        InvokeEngineWaitMutation(() => _engine.ResumeWaitNode(engineId, nodeId, eventName));
-        // Resume のグラフ完了は非同期継続のため、投影取得前に Wait 完了を待つ。
-        await WaitForEngineWaitNodeCompletedAsync(engineId, nodeId, ct).ConfigureAwait(false);
-        // 続けて後続 Task が落ち着くまで待つ（Wait 完了直後の RUNNING 中間像の永続化を避ける）。
-        await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
-
-        // Again → Fork の Suspend Unload 後は in-process snapshot が欠ける。SuspendHandler 投影を正とする。
-        var (engineStillLoaded, pubStatus, pubCancel, pubGraphJson) =
-            await ResolveProjectionAfterWaitResumeAsync(uuid.Value, ct).ConfigureAwait(false);
-
-        var publishedPayload = JsonSerializer.Serialize(
-            new { tenantId, name = eventName, nodeId },
-            JsonSerializerProfiles.CamelCase);
-
-        await PersistWaitResumeSideEffectsAsync(
-                new WaitResumePersistRequest(
-                    tenantId,
-                    uuid.Value,
-                    engineId,
-                    nodeId,
-                    clientEventId,
-                    dedupKey,
-                    engineStillLoaded,
-                    pubStatus,
-                    pubCancel,
-                    pubGraphJson,
-                    publishedPayload),
-                ct)
-            .ConfigureAwait(false);
-
-        // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
-        await _projection.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
-    }
-
-    /// <summary>Wait Resume 後の投影・checkpoint・event_store・dedup 永続化入力。</summary>
-    private readonly record struct WaitResumePersistRequest(
-        Guid TenantId,
-        Guid ExecutionId,
-        string EngineId,
-        string NodeId,
-        Guid ClientEventId,
-        CommandDedupKey? DedupKey,
-        bool EngineStillLoaded,
-        string PubStatus,
-        bool? PubCancel,
-        string PubGraphJson,
-        string PublishedPayload);
-
-    /// <summary>Wait Resume 後の投影・checkpoint・event_store・dedup を同一 tx で永続化する。</summary>
-    private async Task PersistWaitResumeSideEffectsAsync(
-        WaitResumePersistRequest request,
-        CancellationToken ct)
-    {
-        await _mutationPersistence.ExecuteSerializableWithRetryAsync(
-            request.TenantId,
-            request.ExecutionId,
-            request.ClientEventId,
-            async (uow, ctInner) =>
-            {
-                await _executions
-                    .UpdateExecutionAndSnapshotAsync(
-                        uow,
-                        request.ExecutionId,
-                        request.PubStatus,
-                        request.PubCancel,
-                        request.PubGraphJson,
-                        ctInner)
-                    .ConfigureAwait(false);
-                await _projection.SyncOperationalProjectionAsync(
-                        uow,
-                        request.ExecutionId,
-                        request.TenantId,
-                        request.PubStatus,
-                        request.PubGraphJson,
-                        nodeIdToClear: request.NodeId,
-                        ctInner)
-                    .ConfigureAwait(false);
-
-                if (request.EngineStillLoaded)
-                {
-                    if (await ShouldDiscardRuntimeCheckpointAsync(
-                            request.ExecutionId,
-                            request.PubStatus,
-                            request.PubGraphJson,
-                            ctInner)
-                        .ConfigureAwait(false))
-                    {
-                        await DiscardOrRefreshRuntimeCheckpointAsync(
-                                uow,
-                                request.EngineId,
-                                request.ExecutionId,
-                                ctInner)
-                            .ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await _lifecycle.UpsertRuntimeCheckpointAsync(
-                                uow,
-                                request.EngineId,
-                                request.ExecutionId,
-                                ctInner)
-                            .ConfigureAwait(false);
-                    }
-                }
-
-                await _eventStore
-                    .AppendAsync(
-                        uow,
-                        request.ExecutionId,
-                        EventStoreEventType.EventPublished,
-                        request.PublishedPayload,
-                        ctInner)
-                    .ConfigureAwait(false);
-
-                if (request.DedupKey is { } saveKey)
-                {
-                    var now = DateTime.UtcNow;
-                    await _dedup.SaveAsync(
-                        uow,
-                        new CommandDedupRow
-                        {
-                            DedupKey = saveKey.DedupKey,
-                            Endpoint = saveKey.Endpoint,
-                            IdempotencyKey = saveKey.IdempotencyKey,
-                            RequestHash = null,
-                            StatusCode = HttpStatus204NoContent,
-                            ResponseBody = null,
-                            CreatedAt = now,
-                            ExpiresAt = now.AddHours(24)
-                        },
-                        ctInner).ConfigureAwait(false);
-                }
-
-                var nowUtc = DateTime.UtcNow;
-                await _eventDeliveryDedup.TryUpdateStatusAsync(
-                    uow,
-                    request.TenantId,
-                    request.ExecutionId,
-                    request.ClientEventId,
-                    new EventDeliveryDedupStatusUpdate(
-                        EventDeliveryDedupStatuses.Applied,
-                        nowUtc,
-                        AppliedAt: nowUtc,
-                        ErrorCode: null),
-                    ctInner).ConfigureAwait(false);
-            },
-            ct).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Wait Resume 後の投影断面を Engine または DB（Unload 済み）から解決する。
-    /// </summary>
-    /// <returns>
-    /// Engine がメモリ上に残っているとき <c>engineStillLoaded</c> は true。
-    /// </returns>
-    private async Task<(bool EngineStillLoaded, string Status, bool? CancelRequested, string GraphJson)>
-        ResolveProjectionAfterWaitResumeAsync(Guid executionId, CancellationToken ct)
-    {
-        var (projectedStatus, projectedCancel, projectedGraphJson) = _projection.BuildProjectionFromEngineForQueue(executionId);
-        if (projectedStatus is not null && projectedGraphJson is not null)
-        {
-            return (true, projectedStatus, projectedCancel, projectedGraphJson);
-        }
-
-        var unloadedSnapshot = await _executor.ExecuteReadOnlyAsync(
-                (uow, innerCt) => _executions.GetSnapshotByExecutionIdAsync(uow, executionId, innerCt),
-                ct)
-            .ConfigureAwait(false);
-        var unloadedRow = await _executor.ExecuteReadOnlyAsync(
-                (uow, innerCt) => _executions.GetByExecutionIdAsync(uow, executionId, innerCt),
-                ct)
-            .ConfigureAwait(false);
-        if (unloadedSnapshot is null
-            || unloadedRow is null
-            || string.IsNullOrWhiteSpace(unloadedSnapshot.GraphJson))
-        {
-            throw new InvalidOperationException(
-                $"Cannot project execution '{executionId:D}': engine snapshot is missing after Resume unload.");
-        }
-
-        return (false, unloadedRow.Status, unloadedRow.CancelRequested, unloadedSnapshot.GraphJson);
-    }
-
-    /// <summary>
-    /// 親 ID の Resume を子 Wait へ振り替える。振り替えたとき true。
-    /// </summary>
-    private async Task<bool> TryRedirectResumeToChildWaitAsync(
-        Guid requestedExecutionId,
-        string nodeId,
-        string eventName,
-        string? idempotencyKey,
-        CommandRequestContext requestContext,
-        CancellationToken ct)
-    {
-        if (_forkChildCoordinator is null)
-            return false;
-
-        if (string.Equals(eventName, ExecutionWaitEventNames.ChildCompleted, StringComparison.Ordinal))
-            return false;
-
-        var delivery = await _forkChildCoordinator
-            .TryResolveChildWaitDeliveryAsync(requestedExecutionId, nodeId, eventName, ct)
-            .ConfigureAwait(false);
-        if (delivery is null)
-            return false;
-
-        await ResumeNodeAsync(
-                delivery.ExecutionId.ToString("D"),
-                delivery.NodeId,
-                delivery.EventName,
-                idempotencyKey,
-                requestContext,
-                ct)
-            .ConfigureAwait(false);
-        return true;
-    }
-
-    /// <summary>
-    /// 親 ID の PublishEvent を子 Wait へ振り替える。振り替えたとき true。
-    /// </summary>
-    private async Task<bool> TryRedirectPublishEventToChildWaitAsync(
-        Guid requestedExecutionId,
-        string eventName,
-        string? idempotencyKey,
-        CommandRequestContext requestContext,
-        CancellationToken ct)
-    {
-        if (_forkChildCoordinator is null)
-            return false;
-
-        var delivery = await _forkChildCoordinator
-            .TryResolveChildWaitDeliveryAsync(requestedExecutionId, nodeId: null, eventName, ct)
-            .ConfigureAwait(false);
-        if (delivery is null)
-            return false;
-
-        await PublishEventAsync(
-                delivery.ExecutionId.ToString("D"),
-                delivery.EventName,
-                idempotencyKey,
-                requestContext,
-                ct)
-            .ConfigureAwait(false);
-        return true;
-    }
+        CancellationToken ct) =>
+        _waitEvents.ResumeNodeAsync(
+            idOrUuid,
+            nodeId,
+            resumeKey,
+            idempotencyKey,
+            requestContext,
+            HandleChildCompletedResumeAsync,
+            ShouldDiscardRuntimeCheckpointAsync,
+            DiscardOrRefreshRuntimeCheckpointAsync,
+            ct);
 
     /// <summary>
     /// 物理子終端の予約 Resume を受け、親の Join を再評価する（D2-B / D3）。
@@ -1267,7 +779,7 @@ internal sealed class ExecutionService : IExecutionService
 
         var engineId = executionId.ToString();
         // ImportCheckpoint が起動した継続（Wait 復元または完了フロンティア遷移）が落ち着くのを待つ。
-        await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
+        await _waitEvents.WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
 
         var (status, cancelRequested, graphJson) = _projection.BuildProjectionFromEngine(executionId);
         await _executor.ExecuteReadCommittedAsync(
@@ -1315,88 +827,13 @@ internal sealed class ExecutionService : IExecutionService
     }
 
     /// <summary>
-    /// Resume 適用後、対象 Wait ノードのグラフ完了が反映されるまで短く待つ。
-    /// </summary>
-    /// <remarks>
-    /// Engine 側の完了処理は <c>RunContinuationsAsynchronously</c> のため、
-    /// <see cref="IExecutionEngine.ResumeWaitNode"/> 復帰直後の投影は古い Wait を含み得る。
-    /// </remarks>
-    private async Task WaitForEngineWaitNodeCompletedAsync(
-        string engineExecutionId,
-        string nodeId,
-        CancellationToken ct)
-    {
-        const int maxAttempts = 200;
-        for (var attempt = 0; attempt < maxAttempts; attempt++)
-        {
-            ct.ThrowIfCancellationRequested();
-            if (_engine.GetSnapshot(engineExecutionId) is null)
-                return;
-
-            var graphJson = _engine.ExportExecutionGraph(engineExecutionId);
-            if (!TryGetGraphNodeCompletion(graphJson, nodeId, out var completed))
-            {
-                // ノードが無い（テスト用 stub 等）場合は待たない。
-                return;
-            }
-
-            if (completed)
-                return;
-
-            await Task.Delay(10, ct).ConfigureAwait(false);
-        }
-
-        _logger.WaitNodeCompletionTimedOut(nodeId, engineExecutionId);
-    }
-
-    /// <summary>
-    /// Wait 再開後、後続状態の実行が落ち着くまで短く待つ。
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <see cref="WaitForEngineWaitNodeCompletedAsync"/> は Wait の <c>completedAt</c> 時点で戻る。
-    /// その直後は <c>ProcessFact</c> → 次 Task の <c>AddNode</c> が走り、グラフは
-    /// 「Wait SUCCEEDED + 次 Task RUNNING」の中間像になり得る。
-    /// </para>
-    /// <para>
-    /// Resume / Publish がこの中間像を serializable トランザクションで永続化すると、
-    /// 後続の完了投影（noop 完了 → Completed）を上書きし、次ノードが RUNNING のまま固着する。
-    /// </para>
-    /// </remarks>
-    private async Task WaitForEngineQuiescedAfterWaitAsync(
-        string engineExecutionId,
-        CancellationToken ct)
-    {
-        const int maxAttempts = 200;
-        for (var attempt = 0; attempt < maxAttempts; attempt++)
-        {
-            ct.ThrowIfCancellationRequested();
-            var snapshot = _engine.GetSnapshot(engineExecutionId);
-            if (snapshot is null)
-                return;
-
-            if (snapshot.IsCompleted || snapshot.IsCancelled || snapshot.IsFailed)
-                return;
-
-            // ContinueRestoredWait は次 Task を ActiveStates に載せてから Wait を外すため、
-            // 後続実行中は Count > 0。空なら後続未起動または完了済み。
-            if (snapshot.ActiveStates.Count == 0)
-                return;
-
-            await Task.Delay(10, ct).ConfigureAwait(false);
-        }
-
-        _logger.WaitResumeQuiesceTimedOut(engineExecutionId);
-    }
-
-    /// <summary>
     /// 物理 Join 完了後、Join ノード完了・decide Wait 登録・Unload・終端のいずれかまで待つ。
     /// </summary>
     /// <remarks>
     /// <para>
     /// <see cref="IExecutionEngine.CompletePhysicalJoin"/> は Join を非同期 Schedule するだけなので、
     /// 直後は <c>ActiveStates</c> が空のままである。ここで
-    /// <see cref="WaitForEngineQuiescedAfterWaitAsync"/> を使うと Join 前断面を投影してしまう。
+    /// <see cref="ExecutionWaitEventService.WaitForEngineQuiescedAfterWaitAsync"/> を使うと Join 前断面を投影してしまう。
     /// </para>
     /// <para>
     /// Join 直後に長い Action が続く場合でも、Join ノード完了で抜けて投影する。
@@ -1551,46 +988,6 @@ internal sealed class ExecutionService : IExecutionService
         {
             return false;
         }
-    }
-
-    /// <summary>グラフ JSON 上の指定 nodeId の完了有無を取得する。</summary>
-    /// <returns>ノードが存在するとき <see langword="true"/>。</returns>
-    private static bool TryGetGraphNodeCompletion(string graphJson, string nodeId, out bool completed)
-    {
-        completed = false;
-        if (string.IsNullOrWhiteSpace(graphJson) || string.IsNullOrWhiteSpace(nodeId))
-            return false;
-
-        try
-        {
-            using var document = JsonDocument.Parse(graphJson);
-            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
-                || nodes.ValueKind != JsonValueKind.Array)
-            {
-                return false;
-            }
-
-            foreach (var node in nodes.EnumerateArray())
-            {
-                if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var idProp)
-                    || idProp.ValueKind != JsonValueKind.String
-                    || !string.Equals(idProp.GetString(), nodeId, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                completed = node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
-                    && completedAt.ValueKind is not JsonValueKind.Null
-                    && completedAt.ValueKind is not JsonValueKind.Undefined;
-                return true;
-            }
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-
-        return false;
     }
 
     /// <summary>
@@ -1981,185 +1378,5 @@ internal sealed class ExecutionService : IExecutionService
             DiscardOrRefreshRuntimeCheckpointAsync,
             _lifecycle.UpsertRuntimeCheckpointAsync,
             ct);
-
-    /// <summary>
-    /// Engine Wait 操作の <see cref="InvalidOperationException"/> を API 422 に写像する。
-    /// </summary>
-    /// <remarks>
-    /// PublishEvent シム条件外・Resume の許可外イベントなどは Engine が
-    /// <see cref="InvalidOperationException"/> を投げる。クライアント向けには
-    /// <see cref="ApiValidationException"/>（422）へ変換する。
-    /// </remarks>
-    private static T InvokeEngineWaitMutation<T>(Func<T> action)
-    {
-        try
-        {
-            return action();
-        }
-        catch (InvalidOperationException ex)
-        {
-            throw new ApiValidationException(ex.Message, ex);
-        }
-    }
-
-    /// <summary>
-    /// Engine Wait 操作の <see cref="InvalidOperationException"/> を API 422 に写像する。
-    /// </summary>
-    private static void InvokeEngineWaitMutation(Action action)
-    {
-        try
-        {
-            action();
-        }
-        catch (InvalidOperationException ex)
-        {
-            throw new ApiValidationException(ex.Message, ex);
-        }
-    }
-
-    /// <summary>
-    /// PublishEvent シム用。グラフ上の未完了 Wait がちょうど 1 件ならその nodeId を返す。
-    /// </summary>
-    /// <remarks>
-    /// Engine の <c>PublishEvent</c> は単一アクティブ Wait のみ許可する。投影同期では
-    /// 復帰直後にグラフ完了が遅延し得るため、発行前に取得した nodeId で wait 行を先行削除する。
-    /// </remarks>
-    /// <param name="graphJson"><see cref="IExecutionEngine.ExportExecutionGraph"/> の JSON。</param>
-    /// <returns>唯一のアクティブ Wait の nodeId。0 件または 2 件以上なら null。</returns>
-    private static string? TryResolveSoleActiveWaitNodeId(string graphJson)
-    {
-        if (string.IsNullOrWhiteSpace(graphJson))
-            return null;
-
-        try
-        {
-            using var doc = JsonDocument.Parse(graphJson);
-            if (!doc.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
-                || nodes.ValueKind != JsonValueKind.Array)
-            {
-                return null;
-            }
-
-            return FindSoleActiveWaitNodeId(nodes);
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>nodes 配列から唯一の未完了 Wait nodeId を返す（0 件または複数は null）。</summary>
-    private static string? FindSoleActiveWaitNodeId(JsonElement nodes)
-    {
-        string? soleNodeId = null;
-        foreach (var node in nodes.EnumerateArray())
-        {
-            if (!TryGetActiveWaitNodeId(node, out var nodeId))
-                continue;
-
-            if (soleNodeId is not null)
-                return null;
-
-            soleNodeId = nodeId;
-        }
-
-        return soleNodeId;
-    }
-
-    /// <summary>未完了 Wait ノードなら nodeId を取り出す。</summary>
-    /// <remarks>
-    /// 許可イベント未設定の Wait は durable wait 投影対象外のため除外する
-    ///（<c>allowedEvents</c> または互換の <c>waitKey</c> が必要）。
-    /// </remarks>
-    private static bool TryGetActiveWaitNodeId(JsonElement node, out string? nodeId)
-    {
-        nodeId = null;
-        if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeType, out var nodeType)
-            || !string.Equals(nodeType.GetString(), "Wait", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
-            && completedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
-        {
-            return false;
-        }
-
-        if (!HasConfiguredWaitEvents(node))
-            return false;
-
-        if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var nodeIdElement))
-            return false;
-
-        var value = nodeIdElement.GetString();
-        if (string.IsNullOrWhiteSpace(value))
-            return false;
-
-        nodeId = value;
-        return true;
-    }
-
-    /// <summary>
-    /// グラフ JSON の Wait ノードに許可イベント設定があるか
-    ///（<c>allowedEvents</c> 優先、なければ非空の <c>waitKey</c>）。
-    /// </summary>
-    private static bool HasConfiguredWaitEvents(JsonElement node)
-    {
-        if (node.TryGetProperty("allowedEvents", out var allowedEvents)
-            && allowedEvents.ValueKind == JsonValueKind.Array)
-        {
-            foreach (var entry in allowedEvents.EnumerateArray())
-            {
-                if (entry.ValueKind == JsonValueKind.String
-                    && !string.IsNullOrWhiteSpace(entry.GetString()))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return node.TryGetProperty("waitKey", out var waitKey)
-            && waitKey.ValueKind == JsonValueKind.String
-            && !string.IsNullOrWhiteSpace(waitKey.GetString());
-    }
-
-    /// <summary>
-    /// グラフから nodeId を解決できないときのフォールバック。永続化済み wait から削除対象を決める。
-    /// </summary>
-    /// <param name="waits">当該 execution の wait 行。</param>
-    /// <param name="eventName">Publish したイベント名（前後空白は Trim して照合）。</param>
-    /// <returns>
-    /// wait が 1 件ならその nodeId。複数なら <paramref name="eventName"/> を許可する行がちょうど 1 件のときその nodeId。
-    /// それ以外は null。
-    /// </returns>
-    internal static string? TryResolveWaitNodeIdToClearFromPersisted(
-        IReadOnlyList<ExecutionWaitRow> waits,
-        string eventName)
-    {
-        if (waits.Count == 0)
-            return null;
-
-        if (waits.Count == 1)
-            return waits[0].NodeId;
-
-        // AllowedEvents は投影時に Trim 済み。Publish 側の前後空白とも揃える。
-        var normalizedEventName = eventName.Trim();
-        string? soleMatchingNodeId = null;
-        foreach (var wait in waits)
-        {
-            var allowsEvent = wait.AllowedEvents.Any(e =>
-                string.Equals(e, normalizedEventName, StringComparison.OrdinalIgnoreCase));
-            if (!allowsEvent)
-                continue;
-
-            if (soleMatchingNodeId is not null)
-                return null;
-
-            soleMatchingNodeId = wait.NodeId;
-        }
-
-        return soleMatchingNodeId;
-    }
 
 }

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -7,18 +7,6 @@ namespace Statevia.Core.Application.Services;
 
 internal sealed class ExecutionService : IExecutionService
 {
-    /// <summary>実行グラフ JSON のプロパティ名（投影・Engine export 共通）。</summary>
-    private static class ExecutionGraphJsonProperties
-    {
-        internal const string Nodes = "nodes";
-        internal const string CompletedAt = "completedAt";
-        internal const string NodeId = "nodeId";
-        internal const string Fact = "fact";
-        internal const string Status = "status";
-        internal const string StartedAt = "startedAt";
-        internal const string NodeType = "nodeType";
-    }
-
     private readonly IExecutionEngine _engine;
     private readonly IDisplayIdService _displayIds;
     private readonly IDefinitionCompilerService _compiler;
@@ -160,9 +148,11 @@ internal sealed class ExecutionService : IExecutionService
         CommandRequestContext requestContext,
         CancellationToken ct) =>
         _lifecycle.CancelAsync(idOrUuid, idempotencyKey, requestContext, ct);
+        
     /// <inheritdoc />
     public Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct) =>
         _checkpoints.PersistCheckpointKeepLoadedAsync(engineExecutionId, ct);
+
     /// <inheritdoc />
     public Task<long?> BeginOwnedSessionAsync(
         Guid executionId,
@@ -170,21 +160,26 @@ internal sealed class ExecutionService : IExecutionService
         TimeSpan leaseDuration,
         CancellationToken ct) =>
         _ownershipSessions.BeginOwnedSessionAsync(executionId, workerId, leaseDuration, ct);
+
     /// <inheritdoc />
     public Task<bool> RenewOwnedSessionLeaseAsync(
         Guid executionId,
         TimeSpan leaseDuration,
         CancellationToken ct) =>
         _ownershipSessions.RenewOwnedSessionLeaseAsync(executionId, leaseDuration, ct);
+
     /// <inheritdoc />
     public Task EndOwnedSessionAsync(Guid executionId, CancellationToken ct) =>
         _ownershipSessions.EndOwnedSessionAsync(executionId, ct);
+
     /// <inheritdoc />
     public Task AbandonLocalOwnedSessionAsync(Guid executionId) =>
         _ownershipSessions.AbandonLocalOwnedSessionAsync(executionId);
+
     /// <inheritdoc />
     public Task AwaitLocalExecutionLoadAsync(Guid executionId, CancellationToken ct) =>
         _ownershipSessions.AwaitLocalExecutionLoadAsync(executionId, ct);
+
     /// <inheritdoc />
     public Task PublishEventAsync(
         string idOrUuid,
@@ -206,6 +201,7 @@ internal sealed class ExecutionService : IExecutionService
         int limit,
         CancellationToken ct) =>
         _query.ListEventsAsync(idOrUuid, afterSeq, limit, ct);
+
     /// <inheritdoc />
     public Task ResumeNodeAsync(
         string idOrUuid,
@@ -220,325 +216,8 @@ internal sealed class ExecutionService : IExecutionService
             resumeKey,
             idempotencyKey,
             requestContext,
-            HandleChildCompletedResumeAsync,
-            _checkpoints.ShouldDiscardRuntimeCheckpointAsync,
-            _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync,
             ct);
 
-    /// <summary>
-    /// 物理子終端の予約 Resume を受け、親の Join を再評価する（D2-B / D3）。
-    /// </summary>
-    /// <param name="parentExecutionId">親 execution。</param>
-    /// <param name="execution">親の投影行。</param>
-    /// <param name="forkNodeId">Resume payload の nodeId（Fork 到達インスタンス）。</param>
-    /// <param name="ct">キャンセル。</param>
-    private async Task HandleChildCompletedResumeAsync(
-        Guid parentExecutionId,
-        ExecutionRow execution,
-        string forkNodeId,
-        CancellationToken ct)
-    {
-        if (_forkChildCoordinator is null)
-            return;
-
-        if (ExecutionLifecycleCommandService.IsTerminalExecutionProjectionStatus(execution.Status))
-            return;
-
-        var evaluation = await _forkChildCoordinator
-            .EvaluateJoinAsync(parentExecutionId, forkNodeId, ct)
-            .ConfigureAwait(false);
-
-        switch (evaluation.Kind)
-        {
-            case ForkJoinEvaluationKind.Waiting:
-                return;
-
-            case ForkJoinEvaluationKind.Failed:
-                await FailParentFromJoinAsync(
-                        parentExecutionId,
-                        forkNodeId,
-                        evaluation.FailureStatus ?? ExecutionProjectionStatuses.Failed,
-                        ct)
-                    .ConfigureAwait(false);
-                return;
-
-            case ForkJoinEvaluationKind.Satisfied:
-                // 既に当該 Fork 訪問の Join が投影上 SUCCEEDED なら再実行しない（child.completed 再送の冪等）。
-                var snapshotRow = await _executor.ExecuteReadOnlyAsync(
-                        (uow, innerCt) => _executions.GetSnapshotByExecutionIdAsync(
-                            uow,
-                            parentExecutionId,
-                            innerCt),
-                        ct)
-                    .ConfigureAwait(false);
-                if (snapshotRow is not null
-                    && IsPhysicalJoinAlreadyCompleted(
-                        snapshotRow.GraphJson,
-                        forkNodeId,
-                        evaluation.JoinState))
-                {
-                    _logger.ForkJoinAlreadyCompleted(parentExecutionId, forkNodeId, evaluation.JoinState);
-                    return;
-                }
-
-                await CompleteParentPhysicalJoinAsync(
-                        parentExecutionId,
-                        execution,
-                        forkNodeId,
-                        evaluation,
-                        ct)
-                    .ConfigureAwait(false);
-                return;
-
-            default:
-                throw new InvalidOperationException($"Unknown fork join evaluation kind '{evaluation.Kind}'.");
-        }
-    }
-
-    /// <summary>
-    /// Unload 後でも、Join が進んで Wait / 終端断面が checkpoint に残っているか。
-    /// </summary>
-    private async Task<bool> HasPhysicalJoinProgressAfterUnloadAsync(
-        Guid parentExecutionId,
-        CancellationToken ct)
-    {
-        var document = await _executor.ExecuteReadOnlyAsync(
-                (uow, innerCt) => _checkpointStore.GetByExecutionIdAsync(uow, parentExecutionId, innerCt),
-                ct)
-            .ConfigureAwait(false);
-        if (document is null
-            || !ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(document.CheckpointJson, out var checkpoint, out _))
-        {
-            return false;
-        }
-
-        if (checkpoint.IsCompleted || checkpoint.IsCancelled || checkpoint.IsFailed)
-            return true;
-
-        if (checkpoint.PendingWaits.Count > 0)
-            return true;
-
-        return checkpoint.ActiveStates.Count > 0;
-    }
-
-    /// <summary>
-    /// 親グラフ上で、当該 Fork 訪問に対応する Join が既に SUCCEEDED か。
-    /// </summary>
-    /// <remarks>単体テストから到達するため internal。</remarks>
-    internal static bool IsPhysicalJoinAlreadyCompleted(
-        string parentGraphJson,
-        string forkNodeId,
-        string joinState)
-    {
-        var joinNodeId = PhysicalForkGraphComposer.ResolveJoinNodeId(
-            parentGraphJson,
-            forkNodeId,
-            joinState);
-        if (string.IsNullOrWhiteSpace(joinNodeId))
-            return false;
-
-        try
-        {
-            using var document = JsonDocument.Parse(parentGraphJson);
-            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
-                || nodes.ValueKind != JsonValueKind.Array)
-            {
-                return false;
-            }
-
-            // joinNodeId は Fork 訪問ごとに一意。一致ノードが無ければ未完了扱い。
-            var node = nodes.EnumerateArray().FirstOrDefault(candidate =>
-                candidate.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var idEl)
-                && string.Equals(idEl.GetString(), joinNodeId, StringComparison.Ordinal));
-            if (node.ValueKind != JsonValueKind.Object)
-            {
-                return false;
-            }
-
-            // 投影 JSON は UI 用 status ではなく fact / completedAt を持つ。
-            // 当該 Fork 訪問に紐づく Join が既に Joined なら冪等スキップ（循環の別訪問は別 Join nodeId）。
-            var fact = node.TryGetProperty(ExecutionGraphJsonProperties.Fact, out var factEl)
-                ? factEl.GetString()
-                : null;
-            if (string.Equals(fact, "Joined", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(fact, "Completed", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAtEl)
-                && completedAtEl.ValueKind == JsonValueKind.String
-                && !string.IsNullOrWhiteSpace(completedAtEl.GetString()))
-            {
-                return true;
-            }
-
-            var status = node.TryGetProperty(ExecutionGraphJsonProperties.Status, out var statusEl)
-                ? statusEl.GetString()
-                : null;
-            return string.Equals(status, "SUCCEEDED", StringComparison.OrdinalIgnoreCase);
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
-
-    /// <summary>Join 失敗／キャンセルを親投影へ伝播する（残子 Cancel はタスク 6）。</summary>
-    private async Task FailParentFromJoinAsync(
-        Guid parentExecutionId,
-        string forkNodeId,
-        string failureStatus,
-        CancellationToken ct)
-    {
-        _logger.ForkJoinFailedPropagated(parentExecutionId, forkNodeId, failureStatus);
-
-        var snapshot = await _executor.ExecuteReadOnlyAsync(
-                (uow, innerCt) => _executions.GetSnapshotByExecutionIdAsync(uow, parentExecutionId, innerCt),
-                ct)
-            .ConfigureAwait(false);
-        var graphJson = snapshot?.GraphJson ?? """{"nodes":[],"edges":[]}""";
-        var cancelRequested = string.Equals(
-            failureStatus,
-            ExecutionProjectionStatuses.Cancelled,
-            StringComparison.Ordinal);
-
-        await _executor.ExecuteReadCommittedAsync(
-                async (uow, innerCt) =>
-                {
-                    await _executions
-                        .UpdateExecutionAndSnapshotAsync(
-                            uow,
-                            parentExecutionId,
-                            failureStatus,
-                            cancelRequested,
-                            graphJson,
-                            innerCt)
-                        .ConfigureAwait(false);
-
-                    await _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
-                            uow,
-                            parentExecutionId.ToString(),
-                            parentExecutionId,
-                            innerCt)
-                        .ConfigureAwait(false);
-                },
-                ct)
-            .ConfigureAwait(false);
-
-        _engine.Unload(parentExecutionId.ToString());
-    }
-
-    /// <summary>Join 充足時に親 Engine で物理 Join を完了し投影を更新する。</summary>
-    private async Task CompleteParentPhysicalJoinAsync(
-        Guid parentExecutionId,
-        ExecutionRow execution,
-        string forkNodeId,
-        ForkJoinEvaluation evaluation,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(evaluation.CandidateInputs);
-        _logger.ForkJoinSatisfied(parentExecutionId, forkNodeId, evaluation.JoinState);
-
-        await _lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(parentExecutionId, execution, ct).ConfigureAwait(false);
-
-        var engineId = parentExecutionId.ToString();
-        IReadOnlyList<PhysicalJoinContextFragment>? fragments = null;
-        if (evaluation.ContextMerges is { Count: > 0 })
-        {
-            fragments = evaluation.ContextMerges
-                .Select(m => new PhysicalJoinContextFragment(m.States, m.Vars))
-                .ToList();
-        }
-
-        _engine.CompletePhysicalJoin(
-            engineId,
-            evaluation.JoinState,
-            evaluation.CandidateInputs,
-            fragments);
-        // Join は Schedule 非同期のため、ActiveStates==0 ですぐ戻ると decide Wait 前の断面を永続してしまう。
-        await WaitForPhysicalJoinSettlementAsync(
-            engineId,
-            forkNodeId,
-            evaluation.JoinState,
-            ct).ConfigureAwait(false);
-
-        // Join 直後に Wait へ進むと SuspendHandler が PersistCheckpointAndUnload する。
-        // Unload 後は GetSnapshot が null になり得る。checkpoint に Wait / 終端が進んでいれば冪等完了。
-        // Join が startedJoins 等で無動作のまま Unload された場合は再試行する。
-        var (status, cancelRequested, graphJson) = _projection.BuildProjectionFromEngineForQueue(parentExecutionId);
-        if (status is null || graphJson is null)
-        {
-            if (!await HasPhysicalJoinProgressAfterUnloadAsync(parentExecutionId, ct).ConfigureAwait(false))
-            {
-                throw new InvalidOperationException(
-                    $"Physical join for execution '{parentExecutionId:D}' unloaded before Join advanced; will retry.");
-            }
-
-            // SuspendHandler が checkpoint だけ進めて snapshot が遅れている場合の補正。
-            await TrySyncGraphSnapshotFromRuntimeCheckpointAsync(parentExecutionId, execution, ct)
-                .ConfigureAwait(false);
-
-            _logger.ForkJoinProjectionSkippedAfterUnload(
-                parentExecutionId,
-                forkNodeId,
-                evaluation.JoinState);
-            return;
-        }
-
-        await _executor.ExecuteReadCommittedAsync(
-                async (uow, innerCt) =>
-                {
-                    // Settlement 待機後〜tx 開始前に Wait Persist が進んでいることがあるので直前に再取得。
-                    var (freshStatus, freshCancel, freshGraph) = _projection.BuildProjectionFromEngineForQueue(parentExecutionId);
-                    var writeStatus = freshStatus ?? status;
-                    var writeCancel = freshCancel ?? cancelRequested;
-                    var writeGraph = freshGraph ?? graphJson;
-
-                    await _executions
-                        .UpdateExecutionAndSnapshotAsync(
-                            uow,
-                            parentExecutionId,
-                            writeStatus,
-                            writeCancel,
-                            writeGraph,
-                            innerCt)
-                        .ConfigureAwait(false);
-                    await _projection.SyncOperationalProjectionAsync(
-                            uow,
-                            parentExecutionId,
-                            execution.TenantId,
-                            writeStatus,
-                            writeGraph,
-                            nodeIdToClear: null,
-                            innerCt)
-                        .ConfigureAwait(false);
-
-                    if (await _checkpoints.ShouldDiscardRuntimeCheckpointAsync(
-                                parentExecutionId,
-                                writeStatus,
-                                writeGraph,
-                                innerCt)
-                            .ConfigureAwait(false))
-                    {
-                        await _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
-                                uow,
-                                engineId,
-                                parentExecutionId,
-                                innerCt)
-                            .ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await _lifecycle.UpsertRuntimeCheckpointAsync(uow, engineId, parentExecutionId, innerCt)
-                            .ConfigureAwait(false);
-                    }
-                },
-                ct)
-            .ConfigureAwait(false);
-
-        await _projection.EnqueueAsync(parentExecutionId, ct).ConfigureAwait(false);
-    }
     /// <inheritdoc />
     public Task RecoverExecutionAsync(
         Guid executionId,
@@ -546,185 +225,10 @@ internal sealed class ExecutionService : IExecutionService
         CancellationToken ct) =>
         _recovery.RecoverExecutionAsync(executionId, requestContext, ct);
 
-
-    /// <summary>
-    /// 物理 Join 完了後、Join ノード完了・decide Wait 登録・Unload・終端のいずれかまで待つ。
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <see cref="IExecutionEngine.CompletePhysicalJoin"/> は Join を非同期 Schedule するだけなので、
-    /// 直後は <c>ActiveStates</c> が空のままである。ここで
-    /// <see cref="ExecutionWaitEventService.WaitForEngineQuiescedAfterWaitAsync"/> を使うと Join 前断面を投影してしまう。
-    /// </para>
-    /// <para>
-    /// Join 直後に長い Action が続く場合でも、Join ノード完了で抜けて投影する。
-    /// durable Wait 登録・Unload・終端も同様に出口とする。
-    /// </para>
-    /// </remarks>
-    /// <param name="engineExecutionId">Engine 辞書キー。</param>
-    /// <param name="forkNodeId">充足した物理 Fork の graph nodeId。</param>
-    /// <param name="joinState">対応する Join 状態名。</param>
-    /// <param name="ct">キャンセル。</param>
-    private async Task WaitForPhysicalJoinSettlementAsync(
-        string engineExecutionId,
-        string forkNodeId,
-        string joinState,
-        CancellationToken ct)
-    {
-        const int maxAttempts = 200;
-        for (var attempt = 0; attempt < maxAttempts; attempt++)
-        {
-            ct.ThrowIfCancellationRequested();
-            var snapshot = _engine.GetSnapshot(engineExecutionId);
-            if (snapshot is null)
-                return;
-
-            if (snapshot.IsCompleted || snapshot.IsCancelled || snapshot.IsFailed)
-                return;
-
-            var graphJson = _engine.ExportExecutionGraph(engineExecutionId);
-            if (IsPhysicalJoinAlreadyCompleted(graphJson, forkNodeId, joinState))
-                return;
-
-            var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
-            if (checkpoint is { PendingWaits.Count: > 0 })
-                return;
-
-            await Task.Delay(10, ct).ConfigureAwait(false);
-        }
-
-        _logger.WaitResumeQuiesceTimedOut(engineExecutionId);
-    }
-
-    /// <summary>
-    /// Unload 後に runtime checkpoint が Wait 断面まで進んでいるとき、graph snapshot を追いつかせる。
-    /// </summary>
-    private async Task TrySyncGraphSnapshotFromRuntimeCheckpointAsync(
-        Guid executionId,
-        ExecutionRow execution,
-        CancellationToken ct)
-    {
-        await _executor.ExecuteReadCommittedAsync(
-                async (uow, innerCt) =>
-                {
-                    var runtime = await _checkpointStore
-                        .GetByExecutionIdAsync(uow, executionId, innerCt)
-                        .ConfigureAwait(false);
-                    if (runtime is null
-                        || !ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(runtime.CheckpointJson, out var checkpoint, out _)
-                        || checkpoint.PendingWaits.Count == 0)
-                    {
-                        return;
-                    }
-
-                    var graphJson = _engine.ExportExecutionGraph(executionId.ToString());
-                    if (graphJson is "{}" || string.IsNullOrWhiteSpace(graphJson))
-                    {
-                        // Engine Unload 済みなら checkpoint 内グラフを投影 JSON へ写す。
-                        graphJson = JsonSerializer.Serialize(
-                            new
-                            {
-                                nodes = checkpoint.Graph.Nodes,
-                                edges = checkpoint.Graph.Edges
-                            },
-                            JsonSerializerProfiles.CamelCase);
-                    }
-
-                    var existingSnapshot = await _executions
-                        .GetSnapshotByExecutionIdAsync(uow, executionId, innerCt)
-                        .ConfigureAwait(false);
-                    if (existingSnapshot?.GraphJson is not null
-                        && !IsGraphSnapshotBehindCheckpoint(existingSnapshot.GraphJson, checkpoint))
-                    {
-                        return;
-                    }
-
-                    var status = execution.Status;
-                    if (string.IsNullOrWhiteSpace(status))
-                        status = "Running";
-
-                    await _executions
-                        .UpdateExecutionAndSnapshotAsync(
-                            uow,
-                            executionId,
-                            status,
-                            execution.CancelRequested,
-                            graphJson,
-                            innerCt)
-                        .ConfigureAwait(false);
-                    await _projection.SyncOperationalProjectionAsync(
-                            uow,
-                            executionId,
-                            execution.TenantId,
-                            status,
-                            graphJson,
-                            nodeIdToClear: null,
-                            innerCt)
-                        .ConfigureAwait(false);
-
-                    _logger.SyncedGraphSnapshotFromRuntimeCheckpoint(
-                        executionId,
-                        checkpoint.PendingWaits.Count,
-                        checkpoint.Graph.Nodes.Count);
-                },
-                ct)
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>永続 graph snapshot が runtime checkpoint より遅れているか。</summary>
-    private static bool IsGraphSnapshotBehindCheckpoint(
-        string snapshotGraphJson,
-        ExecutionRuntimeCheckpoint checkpoint)
-    {
-        if (!TryCountGraphNodes(snapshotGraphJson, out var snapshotNodeCount))
-            return true;
-
-        if (snapshotNodeCount < checkpoint.Graph.Nodes.Count)
-            return true;
-
-        return checkpoint.PendingWaits.Count > 0
-            && !ExecutionOperationalProjectionSync.HasDurableWaits(snapshotGraphJson);
-    }
-
-    /// <summary>グラフ JSON のノード数を数える。</summary>
-    private static bool TryCountGraphNodes(string graphJson, out int count)
-    {
-        count = 0;
-        if (string.IsNullOrWhiteSpace(graphJson))
-            return false;
-
-        try
-        {
-            using var document = JsonDocument.Parse(graphJson);
-            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
-                || nodes.ValueKind != JsonValueKind.Array)
-            {
-                return false;
-            }
-
-            count = nodes.GetArrayLength();
-            return true;
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
-
-    private Task EnsureExecutionsWriteAsync(CancellationToken ct) =>
-        _runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsWrite, ct);
-
-    private Task EnsureExecutionMutationWriteAsync(ExecutionRow execution, CancellationToken ct)
-    {
-        var snapshot = ExecutionSecuritySnapshotJson.TryDeserialize(execution.SecuritySnapshotJson);
-        return _mutationAuth.EnsureMutationPermissionAsync(
-            snapshot,
-            RuntimePermissionRequirements.ExecutionsWrite,
-            ct);
-    }
     /// <inheritdoc />
     public Task PersistCheckpointAndUnloadAsync(Guid executionId, string nodeId, CancellationToken ct) =>
         _checkpoints.PersistCheckpointAndUnloadAsync(executionId, nodeId, ct);
+
     /// <inheritdoc />
     public Task PersistCheckpointAndUnloadByEngineIdAsync(
         string engineExecutionId,

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -91,6 +91,7 @@ internal sealed class ExecutionService : IExecutionService
     private readonly ICorrelationIdAccessor _correlationIdAccessor;
     private readonly IExecutionProjectionUpdateQueue _projectionUpdateQueue;
     private readonly IForkChildExecutionCoordinator? _forkChildCoordinator;
+    private readonly ExecutionQueryService _query;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
@@ -121,6 +122,7 @@ internal sealed class ExecutionService : IExecutionService
         IOptions<EventDeliveryRetryOptions> eventDeliveryRetryOptions,
         ICorrelationIdAccessor correlationIdAccessor,
         IExecutionCheckpointStore checkpointStore,
+        ExecutionQueryService query,
         IExecutionProjectionUpdateQueue? projectionUpdateQueue = null,
         IExecutionWorkQueue? workQueue = null,
         ExecutionOwnershipTracker? ownershipTracker = null,
@@ -152,6 +154,7 @@ internal sealed class ExecutionService : IExecutionService
         _logger = logger;
         _eventDeliveryRetryOptions = eventDeliveryRetryOptions;
         _correlationIdAccessor = correlationIdAccessor;
+        _query = query;
         _projectionUpdateQueue = projectionUpdateQueue ?? NoopExecutionProjectionUpdateQueue.Instance;
         _forkChildCoordinator = forkChildCoordinator;
     }
@@ -588,118 +591,22 @@ internal sealed class ExecutionService : IExecutionService
         return true;
     }
 
-    public async Task<PagedResult<ExecutionResponse>> ListPagedAsync(
+    public Task<PagedResult<ExecutionResponse>> ListPagedAsync(
         ExecutionListPageQuery query,
-        CancellationToken ct)
-    {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+        CancellationToken ct) =>
+        _query.ListPagedAsync(query, ct);
 
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        ArgumentNullException.ThrowIfNull(query);
+    public Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct) =>
+        _query.GetExecutionResponseAsync(idOrUuid, ct);
 
-        var (total, pairs) = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _executions.ListWithDisplayIdsPageAsync(uow, tenantId, query, innerCt),
-            ct).ConfigureAwait(false);
-        var items = pairs.Select(p => new ExecutionResponse
-        {
-            DisplayId = p.DisplayId ?? p.Execution.ExecutionId.ToString(),
-            ResourceId = p.Execution.ExecutionId,
-            GraphId = p.Execution.DefinitionId.ToString("D"),
-            Status = p.Execution.Status,
-            StartedAt = p.Execution.StartedAt,
-            UpdatedAt = p.Execution.UpdatedAt,
-            CancelRequested = p.Execution.CancelRequested,
-            RestartLost = p.Execution.RestartLost
-        }).ToList();
-
-        return new PagedResult<ExecutionResponse>
-        {
-            Items = items,
-            TotalCount = total,
-            Offset = query.Page.Offset,
-            Limit = query.Page.Limit,
-            HasMore = query.Page.Offset + items.Count < total
-        };
-    }
-
-    public async Task<ExecutionResponse> GetExecutionResponseAsync(string idOrUuid, CancellationToken ct)
-    {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
-
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
-        if (uuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        return await _executor.ExecuteReadOnlyAsync(
-            async (uow, innerCt) =>
-            {
-                var execution = await _executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt).ConfigureAwait(false);
-                if (execution is null)
-                    throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-                var displayId = await _displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Execution, idOrUuid, innerCt)
-                    .ConfigureAwait(false) ?? execution.ExecutionId.ToString("D");
-                var graphId = await _displayIds
-                    .GetDisplayIdAsync(DisplayIdResourceTypes.Definition, execution.DefinitionId.ToString("D"), innerCt)
-                    .ConfigureAwait(false) ?? execution.DefinitionId.ToString("D");
-
-                return new ExecutionResponse
-                {
-                    DisplayId = displayId,
-                    ResourceId = execution.ExecutionId,
-                    GraphId = graphId,
-                    Status = execution.Status,
-                    StartedAt = execution.StartedAt,
-                    UpdatedAt = execution.UpdatedAt,
-                    CancelRequested = execution.CancelRequested,
-                    RestartLost = execution.RestartLost
-                };
-            },
-            ct).ConfigureAwait(false);
-    }
-
-    public async Task<string> GetGraphJsonAsync(string idOrUuid, CancellationToken ct)
-    {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
-
-        var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
-        if (uuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-        await EnsureExecutionExistsAsync(uuid.Value, ct).ConfigureAwait(false);
-        var row = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _executions.GetSnapshotByExecutionIdAsync(uow, uuid.Value, innerCt),
-            ct).ConfigureAwait(false);
-        if (row is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        if (_forkChildCoordinator is null)
-            return row.GraphJson;
-
-        return await _forkChildCoordinator
-            .ComposeReadModelGraphJsonAsync(uuid.Value, row.GraphJson, ct)
-            .ConfigureAwait(false);
-    }
+    public Task<string> GetGraphJsonAsync(string idOrUuid, CancellationToken ct) =>
+        _query.GetGraphJsonAsync(idOrUuid, ct);
 
     public Task EnsureExecutionExistsAsync(Guid executionId, CancellationToken ct) =>
-        _executor.ExecuteReadOnlyAsync(
-            async (uow, innerCt) =>
-            {
-                var tenantId = _tenantContext.GetRequiredTenantId();
-                var execution = await _executions.GetByIdAsync(uow, tenantId, executionId, innerCt).ConfigureAwait(false);
-                if (execution is null)
-                    throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-            },
-            ct);
+        _query.EnsureExecutionExistsAsync(executionId, ct);
 
     public Task<string?> TryGetSnapshotGraphJsonByExecutionIdAsync(Guid executionId, CancellationToken ct) =>
-        _executor.ExecuteReadOnlyAsync(
-            async (uow, innerCt) =>
-            {
-                var row = await _executions.GetSnapshotByExecutionIdAsync(uow, executionId, innerCt).ConfigureAwait(false);
-                return row?.GraphJson;
-            },
-            ct);
+        _query.TryGetSnapshotGraphJsonByExecutionIdAsync(executionId, ct);
 
     public async Task CancelAsync(
         string idOrUuid,
@@ -1330,121 +1237,18 @@ internal sealed class ExecutionService : IExecutionService
             ct).ConfigureAwait(false);
     }
 
-    public async Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct)
-    {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
+    public Task<ExecutionViewDto> GetExecutionViewAsync(string idOrUuid, CancellationToken ct) =>
+        _query.GetExecutionViewAsync(idOrUuid, ct);
 
-        var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
-        if (uuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+    public Task<ExecutionViewDto> GetExecutionViewAtSeqAsync(string idOrUuid, long atSeq, CancellationToken ct) =>
+        _query.GetExecutionViewAtSeqAsync(idOrUuid, atSeq, ct);
 
-        return await BuildExecutionViewInternalAsync(uuid.Value, idOrUuid, ct).ConfigureAwait(false);
-    }
-
-    public async Task<ExecutionViewDto> GetExecutionViewAtSeqAsync(string idOrUuid, long atSeq, CancellationToken ct)
-    {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
-
-        var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
-        if (uuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        var maxSeq = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _eventStore.GetMaxSeqAsync(uow, uuid.Value, innerCt),
-            ct).ConfigureAwait(false);
-        if (maxSeq == 0)
-            return await BuildExecutionViewInternalAsync(uuid.Value, idOrUuid, ct).ConfigureAwait(false);
-
-        if (atSeq > maxSeq)
-            throw new NotFoundException("atSeq out of range");
-
-        return await BuildExecutionViewInternalAsync(uuid.Value, idOrUuid, ct).ConfigureAwait(false);
-    }
-
-    public async Task<ExecutionEventsResponseDto> ListEventsAsync(
+    public Task<ExecutionEventsResponseDto> ListEventsAsync(
         string idOrUuid,
         long afterSeq,
         int limit,
-        CancellationToken ct)
-    {
-        await EnsureExecutionsReadAsync(ct).ConfigureAwait(false);
-
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
-        if (uuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        var execution = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt),
-            ct).ConfigureAwait(false);
-        if (execution is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        var displayId = await _displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false) ?? execution.ExecutionId.ToString("D");
-        // D6 / D6.1: GraphUpdated patch は合成グラフ由来。
-        var graphJson = await GetGraphJsonAsync(idOrUuid, ct).ConfigureAwait(false);
-        var patchNodes = ExecutionViewMapper.MapGraphPatchNodes(graphJson);
-
-        var sourceRows = await LoadEventStoreRowsForTimelineAsync(uuid.Value, ct).ConfigureAwait(false);
-        var (events, hasMore) = PhysicalForkEventTimelineComposer.ComposePage(
-            sourceRows,
-            displayId,
-            patchNodes,
-            afterSeq,
-            limit);
-
-        return new ExecutionEventsResponseDto { Events = events, HasMore = hasMore };
-    }
-
-    /// <summary>
-    /// 親＋再帰子孫の event_store 行を読み取り合成用に集める（D6.1）。
-    /// </summary>
-    private async Task<IReadOnlyList<PhysicalForkEventTimelineComposer.SourceRow>> LoadEventStoreRowsForTimelineAsync(
-        Guid rootExecutionId,
-        CancellationToken ct)
-    {
-        var executionIds = new List<Guid> { rootExecutionId };
-        if (_forkChildCoordinator is not null)
-        {
-            var descendants = await _forkChildCoordinator
-                .ListDescendantExecutionIdsAsync(rootExecutionId, ct)
-                .ConfigureAwait(false);
-            executionIds.AddRange(descendants);
-        }
-
-        var rows = new List<PhysicalForkEventTimelineComposer.SourceRow>();
-        foreach (var executionId in executionIds)
-        {
-            var isRoot = executionId == rootExecutionId;
-            long afterSeq = 0;
-            while (true)
-            {
-                var pageAfter = afterSeq;
-                var (items, hasMore) = await _executor.ExecuteReadOnlyAsync(
-                        (uow, innerCt) => _eventStore.ListAfterSeqAsync(
-                            uow,
-                            executionId,
-                            pageAfter,
-                            limit: 500,
-                            innerCt),
-                        ct)
-                    .ConfigureAwait(false);
-
-                foreach (var item in items)
-                    rows.Add(new PhysicalForkEventTimelineComposer.SourceRow(item, isRoot));
-
-                if (!hasMore || items.Count == 0)
-                    break;
-
-                afterSeq = items[^1].Seq;
-                // 暴走防止（異常に長い event_store）。
-                if (rows.Count >= 50_000)
-                    break;
-            }
-        }
-
-        return rows;
-    }
+        CancellationToken ct) =>
+        _query.ListEventsAsync(idOrUuid, afterSeq, limit, ct);
 
     public async Task ResumeNodeAsync(
         string idOrUuid,
@@ -2429,40 +2233,6 @@ internal sealed class ExecutionService : IExecutionService
         return false;
     }
 
-    private async Task<ExecutionViewDto> BuildExecutionViewInternalAsync(Guid uuid, string idOrUuidForDisplay, CancellationToken ct)
-    {
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        return await _executor.ExecuteReadOnlyAsync(
-            async (uow, innerCt) =>
-            {
-                var execution = await _executions.GetByIdAsync(uow, tenantId, uuid, innerCt).ConfigureAwait(false);
-                if (execution is null)
-                    throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-                var snapshot = await _executions.GetSnapshotByExecutionIdAsync(uow, uuid, innerCt).ConfigureAwait(false);
-                if (snapshot is null)
-                    throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-                var displayId = await _displayIds
-                    .GetDisplayIdAsync(DisplayIdResourceTypes.Execution, idOrUuidForDisplay, innerCt)
-                    .ConfigureAwait(false) ?? execution.ExecutionId.ToString("D");
-                var graphId = await _displayIds
-                    .GetDisplayIdAsync(DisplayIdResourceTypes.Definition, execution.DefinitionId.ToString("D"), innerCt)
-                    .ConfigureAwait(false) ?? execution.DefinitionId.ToString("D");
-
-                var graphJson = snapshot.GraphJson;
-                if (_forkChildCoordinator is not null)
-                {
-                    graphJson = await _forkChildCoordinator
-                        .ComposeReadModelGraphJsonAsync(uuid, snapshot.GraphJson, innerCt)
-                        .ConfigureAwait(false);
-                }
-
-                return ExecutionViewMapper.BuildExecutionView(execution, graphJson, displayId, graphId);
-            },
-            ct).ConfigureAwait(false);
-    }
-
     private static ExecutionResponse? DeserializeCachedExecutionResponse(CommandDedupRow existing)
     {
         if (string.IsNullOrEmpty(existing.ResponseBody))
@@ -2727,9 +2497,6 @@ internal sealed class ExecutionService : IExecutionService
         await _checkpointStore.DeleteAsync(uow, executionId, ct).ConfigureAwait(false);
         return false;
     }
-
-    private Task EnsureExecutionsReadAsync(CancellationToken ct) =>
-        _runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsRead, ct);
 
     private Task EnsureExecutionsWriteAsync(CancellationToken ct) =>
         _runtimeAuth.EnsurePermissionAsync(RuntimePermissionRequirements.ExecutionsWrite, ct);

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -42,7 +42,6 @@ internal sealed class ExecutionService : IExecutionService
     private readonly IDefinitionCompilerService _compiler;
     private readonly IIdGenerator _idGenerator;
     private readonly IExecutionRepository _executions;
-    private readonly IExecutionCursorRepository _executionCursors;
     private readonly IExecutionWaitRepository _executionWaits;
     private readonly IExecutionCheckpointStore _checkpointStore;
     private readonly IExecutionWorkQueue? _workQueue;
@@ -60,10 +59,10 @@ internal sealed class ExecutionService : IExecutionService
     private readonly ICoreTransactionExecutor _executor;
     private readonly IExecutionMutationPersistence _mutationPersistence;
     private readonly ILogger<ExecutionService> _logger;
-    private readonly IExecutionProjectionUpdateQueue _projectionUpdateQueue;
     private readonly IForkChildExecutionCoordinator? _forkChildCoordinator;
     private readonly ExecutionQueryService _query;
     private readonly ExecutionIdempotencyService _idempotency;
+    private readonly ExecutionProjectionOrchestrator _projection;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
@@ -75,7 +74,6 @@ internal sealed class ExecutionService : IExecutionService
         IDefinitionCompilerService compiler,
         IIdGenerator idGenerator,
         IExecutionRepository executions,
-        IExecutionCursorRepository executionCursors,
         IExecutionWaitRepository executionWaits,
         IDefinitionRepository definitions,
         IProjectAuthorizationService projectAuth,
@@ -93,7 +91,7 @@ internal sealed class ExecutionService : IExecutionService
         IExecutionCheckpointStore checkpointStore,
         ExecutionQueryService query,
         ExecutionIdempotencyService idempotency,
-        IExecutionProjectionUpdateQueue? projectionUpdateQueue = null,
+        ExecutionProjectionOrchestrator projection,
         IExecutionWorkQueue? workQueue = null,
         ExecutionOwnershipTracker? ownershipTracker = null,
         IForkChildExecutionCoordinator? forkChildCoordinator = null)
@@ -103,7 +101,6 @@ internal sealed class ExecutionService : IExecutionService
         _compiler = compiler;
         _idGenerator = idGenerator;
         _executions = executions;
-        _executionCursors = executionCursors;
         _executionWaits = executionWaits;
         _checkpointStore = checkpointStore;
         _workQueue = workQueue;
@@ -123,7 +120,7 @@ internal sealed class ExecutionService : IExecutionService
         _logger = logger;
         _query = query;
         _idempotency = idempotency;
-        _projectionUpdateQueue = projectionUpdateQueue ?? NoopExecutionProjectionUpdateQueue.Instance;
+        _projection = projection;
         _forkChildCoordinator = forkChildCoordinator;
     }
 
@@ -324,7 +321,7 @@ internal sealed class ExecutionService : IExecutionService
                     var startSnapshot = _engine.GetSnapshot(engineId)
                         ?? throw new InvalidOperationException(
                             $"Cannot project execution '{resolvedExecutionId}': engine snapshot is missing after Start.");
-                    var status = MapStatus(startSnapshot);
+                    var status = ExecutionProjectionOrchestrator.MapStatus(startSnapshot);
                     var graphJson = _engine.ExportExecutionGraph(engineId);
 
                     ExecutionResponse response;
@@ -436,7 +433,7 @@ internal sealed class ExecutionService : IExecutionService
                             .ConfigureAwait(false);
                     }
 
-                    await SyncOperationalProjectionAsync(
+                    await _projection.SyncOperationalProjectionAsync(
                             uow,
                             resolvedExecutionId,
                             args.TenantId,
@@ -619,7 +616,7 @@ internal sealed class ExecutionService : IExecutionService
                 .ConfigureAwait(false);
         }
 
-        await _projectionUpdateQueue.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
+        await _projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
 
         var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
 
@@ -631,7 +628,7 @@ internal sealed class ExecutionService : IExecutionService
         var cancelApply = await _engine.CancelAsync(uuid.Value.ToString(), clientEventId).ConfigureAwait(false);
         var skipCancelEventAppend = cancelApply.IsAlreadyApplied;
 
-        var (projStatus, projCancel, projGraphJson) = BuildProjectionFromEngine(uuid.Value);
+        var (projStatus, projCancel, projGraphJson) = _projection.BuildProjectionFromEngine(uuid.Value);
         var cancelPayload = JsonSerializer.Serialize(
             new { tenantId },
             JsonSerializerProfiles.CamelCase);
@@ -645,7 +642,7 @@ internal sealed class ExecutionService : IExecutionService
                 await _executions
                     .UpdateExecutionAndSnapshotAsync(uow, uuid.Value, projStatus, projCancel, projGraphJson, ctInner)
                     .ConfigureAwait(false);
-                await SyncOperationalProjectionAsync(
+                await _projection.SyncOperationalProjectionAsync(
                         uow,
                         uuid.Value,
                         tenantId,
@@ -922,7 +919,7 @@ internal sealed class ExecutionService : IExecutionService
             {
                 // 終端後に Unload すると投影キューが engine 不在でスキップし、
                 // Start 直後の不完全 graph のまま Completed だけ残る。最終投影を先に確定する。
-                await _projectionUpdateQueue.DrainAsync(executionId, ct).ConfigureAwait(false);
+                await _projection.DrainAsync(executionId, ct).ConfigureAwait(false);
                 await UpdateProjectionFromEngineAsync(executionId, ct).ConfigureAwait(false);
                 _engine.Unload(engineId);
                 return;
@@ -1022,7 +1019,7 @@ internal sealed class ExecutionService : IExecutionService
 
         await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
-        await _projectionUpdateQueue.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
+        await _projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
 
         var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
 
@@ -1049,7 +1046,7 @@ internal sealed class ExecutionService : IExecutionService
                 ct)
             .ConfigureAwait(false);
 
-        var (pubStatus, pubCancel, pubGraphJson) = BuildProjectionFromEngine(uuid.Value);
+        var (pubStatus, pubCancel, pubGraphJson) = _projection.BuildProjectionFromEngine(uuid.Value);
         var publishedPayload = JsonSerializer.Serialize(
             new { tenantId, name = eventName },
             JsonSerializerProfiles.CamelCase);
@@ -1072,7 +1069,7 @@ internal sealed class ExecutionService : IExecutionService
                 await _executions
                     .UpdateExecutionAndSnapshotAsync(uow, uuid.Value, pubStatus, pubCancel, pubGraphJson, ctInner)
                     .ConfigureAwait(false);
-                await SyncOperationalProjectionAsync(
+                await _projection.SyncOperationalProjectionAsync(
                         uow,
                         uuid.Value,
                         tenantId,
@@ -1126,7 +1123,7 @@ internal sealed class ExecutionService : IExecutionService
 
         // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
         if (publishApply.IsApplied)
-            await _projectionUpdateQueue.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
+            await _projection.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1248,7 +1245,7 @@ internal sealed class ExecutionService : IExecutionService
 
         await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
-        await _projectionUpdateQueue.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
+        await _projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
 
         var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
 
@@ -1298,7 +1295,7 @@ internal sealed class ExecutionService : IExecutionService
             .ConfigureAwait(false);
 
         // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
-        await _projectionUpdateQueue.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
+        await _projection.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
     }
 
     /// <summary>Wait Resume 後の投影・checkpoint・event_store・dedup 永続化入力。</summary>
@@ -1335,7 +1332,7 @@ internal sealed class ExecutionService : IExecutionService
                         request.PubGraphJson,
                         ctInner)
                     .ConfigureAwait(false);
-                await SyncOperationalProjectionAsync(
+                await _projection.SyncOperationalProjectionAsync(
                         uow,
                         request.ExecutionId,
                         request.TenantId,
@@ -1425,7 +1422,7 @@ internal sealed class ExecutionService : IExecutionService
     private async Task<(bool EngineStillLoaded, string Status, bool? CancelRequested, string GraphJson)>
         ResolveProjectionAfterWaitResumeAsync(Guid executionId, CancellationToken ct)
     {
-        var (projectedStatus, projectedCancel, projectedGraphJson) = BuildProjectionFromEngineForQueue(executionId);
+        var (projectedStatus, projectedCancel, projectedGraphJson) = _projection.BuildProjectionFromEngineForQueue(executionId);
         if (projectedStatus is not null && projectedGraphJson is not null)
         {
             return (true, projectedStatus, projectedCancel, projectedGraphJson);
@@ -1754,7 +1751,7 @@ internal sealed class ExecutionService : IExecutionService
         // Join 直後に Wait へ進むと SuspendHandler が PersistCheckpointAndUnload する。
         // Unload 後は GetSnapshot が null になり得る。checkpoint に Wait / 終端が進んでいれば冪等完了。
         // Join が startedJoins 等で無動作のまま Unload された場合は再試行する。
-        var (status, cancelRequested, graphJson) = BuildProjectionFromEngineForQueue(parentExecutionId);
+        var (status, cancelRequested, graphJson) = _projection.BuildProjectionFromEngineForQueue(parentExecutionId);
         if (status is null || graphJson is null)
         {
             if (!await HasPhysicalJoinProgressAfterUnloadAsync(parentExecutionId, ct).ConfigureAwait(false))
@@ -1778,7 +1775,7 @@ internal sealed class ExecutionService : IExecutionService
                 async (uow, innerCt) =>
                 {
                     // Settlement 待機後〜tx 開始前に Wait Persist が進んでいることがあるので直前に再取得。
-                    var (freshStatus, freshCancel, freshGraph) = BuildProjectionFromEngineForQueue(parentExecutionId);
+                    var (freshStatus, freshCancel, freshGraph) = _projection.BuildProjectionFromEngineForQueue(parentExecutionId);
                     var writeStatus = freshStatus ?? status;
                     var writeCancel = freshCancel ?? cancelRequested;
                     var writeGraph = freshGraph ?? graphJson;
@@ -1792,7 +1789,7 @@ internal sealed class ExecutionService : IExecutionService
                             writeGraph,
                             innerCt)
                         .ConfigureAwait(false);
-                    await SyncOperationalProjectionAsync(
+                    await _projection.SyncOperationalProjectionAsync(
                             uow,
                             parentExecutionId,
                             execution.TenantId,
@@ -1825,7 +1822,7 @@ internal sealed class ExecutionService : IExecutionService
                 ct)
             .ConfigureAwait(false);
 
-        await _projectionUpdateQueue.EnqueueAsync(parentExecutionId, ct).ConfigureAwait(false);
+        await _projection.EnqueueAsync(parentExecutionId, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1856,14 +1853,14 @@ internal sealed class ExecutionService : IExecutionService
         // ImportCheckpoint が起動した継続（Wait 復元または完了フロンティア遷移）が落ち着くのを待つ。
         await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
 
-        var (status, cancelRequested, graphJson) = BuildProjectionFromEngine(executionId);
+        var (status, cancelRequested, graphJson) = _projection.BuildProjectionFromEngine(executionId);
         await _executor.ExecuteReadCommittedAsync(
             async (uow, innerCt) =>
             {
                 await _executions
                     .UpdateExecutionAndSnapshotAsync(uow, executionId, status, cancelRequested, graphJson, innerCt)
                     .ConfigureAwait(false);
-                await SyncOperationalProjectionAsync(
+                await _projection.SyncOperationalProjectionAsync(
                         uow,
                         executionId,
                         tenantId,
@@ -2081,7 +2078,7 @@ internal sealed class ExecutionService : IExecutionService
                             graphJson,
                             innerCt)
                         .ConfigureAwait(false);
-                    await SyncOperationalProjectionAsync(
+                    await _projection.SyncOperationalProjectionAsync(
                             uow,
                             executionId,
                             execution.TenantId,
@@ -2301,15 +2298,6 @@ internal sealed class ExecutionService : IExecutionService
             },
             JsonSerializerProfiles.CamelCase);
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
-    }
-
-    private static string MapStatus(ExecutionSnapshot snapshot)
-    {
-        ArgumentNullException.ThrowIfNull(snapshot);
-        if (snapshot.IsCompleted) return ExecutionProjectionStatuses.Completed;
-        if (snapshot.IsCancelled) return ExecutionProjectionStatuses.Cancelled;
-        if (snapshot.IsFailed) return ExecutionProjectionStatuses.Failed;
-        return ExecutionProjectionStatuses.Running;
     }
 
     /// <summary>
@@ -2604,7 +2592,7 @@ internal sealed class ExecutionService : IExecutionService
         string? graphJson = null;
         if (snapshot is not null)
         {
-            status = MapStatus(snapshot);
+            status = ExecutionProjectionOrchestrator.MapStatus(snapshot);
             cancelRequested = snapshot.IsCancelled;
             graphJson = _engine.ExportExecutionGraph(engineExecutionId);
         }
@@ -2693,7 +2681,7 @@ internal sealed class ExecutionService : IExecutionService
                             request.GraphJson,
                             innerCt)
                         .ConfigureAwait(false);
-                    await SyncOperationalProjectionAsync(
+                    await _projection.SyncOperationalProjectionAsync(
                             uow,
                             request.ExecutionId,
                             execution.TenantId,
@@ -2813,187 +2801,13 @@ internal sealed class ExecutionService : IExecutionService
                 || n.CompletedAt is not null));
     }
 
-    public async Task UpdateProjectionFromEngineAsync(Guid executionId, CancellationToken ct)
-    {
-        var (status, cancelRequested, graphJson) = BuildProjectionFromEngineForQueue(executionId);
-        if (status is null || graphJson is null)
-            return;
-
-        var engineExecutionId = executionId.ToString();
-        var shouldUnloadAfterProjection = await _executor.ExecuteReadCommittedAsync(
-            async (uow, innerCt) =>
-            {
-                var execution = await _executions.GetByExecutionIdAsync(uow, executionId, innerCt).ConfigureAwait(false);
-                if (execution is null)
-                    return false;
-
-                await _executions
-                    .UpdateExecutionAndSnapshotAsync(uow, executionId, status, cancelRequested, graphJson, innerCt)
-                    .ConfigureAwait(false);
-                await SyncOperationalProjectionAsync(
-                        uow,
-                        executionId,
-                        execution.TenantId,
-                        status,
-                        graphJson,
-                        nodeIdToClear: null,
-                        innerCt)
-                    .ConfigureAwait(false);
-
-                // durable Wait / 物理 Join 待ちが無い／終端なら checkpoint を削除する。
-                // ただし Worker 所有中は lease / fencing 行を消さない（Heartbeat が世代不一致で落ちる）。
-                if (await ShouldDiscardRuntimeCheckpointAsync(executionId, status, graphJson, innerCt)
-                        .ConfigureAwait(false))
-                {
-                    return await DiscardOrRefreshRuntimeCheckpointAsync(
-                            uow,
-                            engineExecutionId,
-                            executionId,
-                            innerCt)
-                        .ConfigureAwait(false);
-                }
-
-                var upserted = await UpsertRuntimeCheckpointAsync(uow, engineExecutionId, executionId, innerCt)
-                    .ConfigureAwait(false);
-                // 所有セッション中の Unload 境界は Worker（Await / EndOwnedSession）。投影からは落とさない。
-                return upserted && !_ownership.TryGet(executionId, out _, out _);
-            },
-            ct).ConfigureAwait(false);
-
-        string? childTerminalOutputJson = null;
-        string? childTerminalStatesJson = null;
-        string? childTerminalVarsJson = null;
-        if (ExecutionProjectionStatuses.IsTerminal(status))
-        {
-            (childTerminalOutputJson, childTerminalStatesJson, childTerminalVarsJson) =
-                TryGetChildTerminalContextJson(engineExecutionId);
-        }
-
-        if (shouldUnloadAfterProjection)
-        {
-            _engine.Unload(engineExecutionId);
-            _logger.CheckpointUnloadedAfterProjectionSync(executionId);
-        }
-
-        if (ExecutionProjectionStatuses.IsTerminal(status) && _forkChildCoordinator is not null)
-        {
-            await _forkChildCoordinator
-                .NotifyChildTerminalAsync(
-                    executionId,
-                    status,
-                    childTerminalOutputJson,
-                    childTerminalStatesJson,
-                    childTerminalVarsJson,
-                    ct)
-                .ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>ロード中 Engine から終端 Context（output / states / vars）を JSON 文字列として取り出す。</summary>
-    private (string? OutputJson, string? StatesJson, string? VarsJson) TryGetChildTerminalContextJson(
-        string engineExecutionId)
-    {
-        var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
-        if (checkpoint is null)
-            return (null, null, null);
-
-        var output = checkpoint.Context.WorkflowOutput;
-        string? outputJson = null;
-        if (output is not null
-            && output.Value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
-        {
-            outputJson = output.Value.GetRawText();
-        }
-
-        string? statesJson = null;
-        if (checkpoint.Context.States is { Count: > 0 })
-        {
-            statesJson = JsonSerializer.Serialize(
-                checkpoint.Context.States.ToDictionary(
-                    kv => kv.Key,
-                    kv => kv.Value,
-                    StringComparer.OrdinalIgnoreCase),
-                JsonSerializerProfiles.CamelCase);
-        }
-
-        string? varsJson = null;
-        var vars = checkpoint.Context.Vars;
-        if (vars is not null
-            && vars.Value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
-        {
-            varsJson = vars.Value.GetRawText();
-        }
-
-        return (outputJson, statesJson, varsJson);
-    }
-
-    /// <summary>
-    /// executions / snapshot 更新と同一 tx 内で operational projection（cursor / durable wait）を同期する。
-    /// </summary>
-    private async Task SyncOperationalProjectionAsync(
-        ICoreUnitOfWork uow,
-        Guid executionId,
-        Guid tenantId,
-        string status,
-        string graphJson,
-        string? nodeIdToClear,
-        CancellationToken ct)
-    {
-        var snapshot = _engine.GetSnapshot(executionId.ToString());
-        var request = new ExecutionOperationalProjectionSyncRequest(
+    public Task UpdateProjectionFromEngineAsync(Guid executionId, CancellationToken ct) =>
+        _projection.UpdateProjectionFromEngineAsync(
             executionId,
-            tenantId,
-            status,
-            snapshot,
-            graphJson,
-            nodeIdToClear);
-        await ExecutionOperationalProjectionSync.SyncAsync(
-            uow,
-            _executionCursors,
-            _executionWaits,
-            request,
-            _idGenerator,
-            ct).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Engine 上の実行から投影用 status / graph を取得する。
-    /// </summary>
-    /// <remarks>
-    /// snapshot 欠落時に <c>Unknown</c> と <c>{}</c> を永続すると一覧 UI が落ちるため、欠落は例外とする。
-    /// 呼び出し側は事前に Load / Ensure 済みであること。キュー投影は
-    /// <see cref="BuildProjectionFromEngineForQueue"/> を使い欠落をスキップする。
-    /// </remarks>
-    /// <exception cref="InvalidOperationException">Engine に snapshot が無いとき。</exception>
-    private (string Status, bool? CancelRequested, string GraphJson) BuildProjectionFromEngine(Guid executionId)
-    {
-        var engineId = executionId.ToString();
-        var snapshot = _engine.GetSnapshot(engineId);
-        if (snapshot is null)
-        {
-            throw new InvalidOperationException(
-                $"Cannot project execution '{executionId}': engine snapshot is missing.");
-        }
-
-        var graphJson = _engine.ExportExecutionGraph(engineId);
-        var status = MapStatus(snapshot);
-        return (status, snapshot.IsCancelled, graphJson);
-    }
-
-    private (string? status, bool? cancelRequested, string? graphJson) BuildProjectionFromEngineForQueue(Guid executionId)
-    {
-        var engineId = executionId.ToString();
-        var snapshot = _engine.GetSnapshot(engineId);
-        if (snapshot is null)
-        {
-            _logger.SkipProjectionQueueUpdateDebug(executionId);
-            return (null, null, null);
-        }
-
-        var graphJson = _engine.ExportExecutionGraph(engineId);
-        var status = MapStatus(snapshot);
-        return (status, snapshot.IsCancelled, graphJson);
-    }
+            ShouldDiscardRuntimeCheckpointAsync,
+            DiscardOrRefreshRuntimeCheckpointAsync,
+            UpsertRuntimeCheckpointAsync,
+            ct);
 
     /// <summary>
     /// Engine Wait 操作の <see cref="InvalidOperationException"/> を API 422 に写像する。
@@ -3173,15 +2987,6 @@ internal sealed class ExecutionService : IExecutionService
         }
 
         return soleMatchingNodeId;
-    }
-
-    private sealed class NoopExecutionProjectionUpdateQueue : IExecutionProjectionUpdateQueue
-    {
-        internal static readonly NoopExecutionProjectionUpdateQueue Instance = new();
-
-        public Task EnqueueAsync(Guid executionId, CancellationToken ct) => Task.CompletedTask;
-
-        public Task DrainAsync(Guid executionId, CancellationToken ct) => Task.CompletedTask;
     }
 
     /// <summary>同一プロセス Start の入力束。</summary>

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -19,6 +19,9 @@ internal sealed class ExecutionService : IExecutionService
     /// </summary>
     private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> PersistUnloadGates = new();
 
+    /// <summary>HTTP 204 No Content。</summary>
+    private const int HttpStatus204NoContent = 204;
+
     /// <summary>実行グラフ JSON のプロパティ名（投影・Engine export 共通）。</summary>
     private static class ExecutionGraphJsonProperties
     {
@@ -30,12 +33,6 @@ internal sealed class ExecutionService : IExecutionService
         internal const string StartedAt = "startedAt";
         internal const string NodeType = "nodeType";
     }
-
-    /// <summary>HTTP 201 Created。</summary>
-    private const int HttpStatus201Created = 201;
-
-    /// <summary>HTTP 204 No Content。</summary>
-    private const int HttpStatus204NoContent = 204;
 
     private readonly IExecutionEngine _engine;
     private readonly IDisplayIdService _displayIds;
@@ -63,6 +60,7 @@ internal sealed class ExecutionService : IExecutionService
     private readonly ExecutionQueryService _query;
     private readonly ExecutionIdempotencyService _idempotency;
     private readonly ExecutionProjectionOrchestrator _projection;
+    private readonly ExecutionLifecycleCommandService _lifecycle;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
@@ -92,6 +90,7 @@ internal sealed class ExecutionService : IExecutionService
         ExecutionQueryService query,
         ExecutionIdempotencyService idempotency,
         ExecutionProjectionOrchestrator projection,
+        ExecutionLifecycleCommandService lifecycle,
         IExecutionWorkQueue? workQueue = null,
         ExecutionOwnershipTracker? ownershipTracker = null,
         IForkChildExecutionCoordinator? forkChildCoordinator = null)
@@ -121,440 +120,24 @@ internal sealed class ExecutionService : IExecutionService
         _query = query;
         _idempotency = idempotency;
         _projection = projection;
+        _lifecycle = lifecycle;
         _forkChildCoordinator = forkChildCoordinator;
     }
 
-    public async Task<ExecutionResponse> StartAsync(
+    /// <inheritdoc />
+    public Task<ExecutionResponse> StartAsync(
         StartExecutionRequest request,
         string? idempotencyKey,
         CommandRequestContext requestContext,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(requestContext);
-        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
-
-        var tenantKey = _tenantContext.GetRequiredTenantKey();
-        var requestHash = ComputeStartRequestHash(request);
-        var dedupKey = _idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path, requestHash);
-
-        var cachedStart = await _idempotency.TryGetIdempotentStartResponseAsync(dedupKey, requestHash, ct).ConfigureAwait(false);
-        if (cachedStart is not null)
-        {
-            return cachedStart;
-        }
-
-        var defUuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Definition, request.DefinitionId!, ct).ConfigureAwait(false);
-        if (defUuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
-
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var versionRow = await ResolveStartDefinitionVersionAsync(tenantId, defUuid.Value, request, ct).ConfigureAwait(false);
-        if (versionRow is null)
-            throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
-
-        await EnsureCanExecuteOnDefinitionAsync(tenantId, defUuid.Value, ct).ConfigureAwait(false);
-
-        // HTTP 受理経路: キューがある場合は Engine を回さず Start work item を投入する。
-        // Worker 文脈（またはテストでキュー未注入）は従来どおり同一プロセスで実行する。
-        if (_workQueue is not null
-            && !string.Equals(requestContext.Method, "WORKER", StringComparison.Ordinal))
-        {
-            return await AcceptStartAndEnqueueAsync(
-                    request,
-                    requestHash,
-                    dedupKey,
-                    tenantId,
-                    defUuid.Value,
-                    versionRow,
-                    ct)
-                .ConfigureAwait(false);
-        }
-
-        return await ExecuteStartInProcessAsync(
-                new ExecuteStartInProcessArgs(
-                    request,
-                    requestHash,
-                    dedupKey,
-                    tenantId,
-                    defUuid.Value,
-                    versionRow,
-                    ExecutionId: null),
-                ct)
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>実行行を受理し <see cref="ExecutionWorkItemKinds.Start"/> を enqueue する。</summary>
-    private async Task<ExecutionResponse> AcceptStartAndEnqueueAsync(
-        StartExecutionRequest request,
-        string requestHash,
-        CommandDedupKey? dedupKey,
-        Guid tenantId,
-        Guid definitionId,
-        DefinitionVersionRow versionRow,
-        CancellationToken ct)
-    {
-        var executionId = _idGenerator.NewSequentialGuid();
-        var graphId = await _displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Definition, definitionId.ToString("D"), ct).ConfigureAwait(false)
-            ?? definitionId.ToString("D");
-        const string emptyGraphJson = """{"nodes":[],"edges":[]}""";
-
-        var response = await _executor.ExecuteReadCommittedAsync(
-            async (uow, innerCt) =>
-            {
-                var createdAt = DateTime.UtcNow;
-                var securitySnapshot = await _snapshotFactory
-                    .CaptureForStartAsync(tenantId, definitionId, createdAt, innerCt)
-                    .ConfigureAwait(false);
-                var securitySnapshotJson = ExecutionSecuritySnapshotJson.Serialize(securitySnapshot);
-                var displayId = await _displayIdWrites
-                    .AllocateAsync(uow, DisplayIdResourceTypes.Execution, executionId, innerCt)
-                    .ConfigureAwait(false);
-
-                var executionRow = new ExecutionRow
-                {
-                    ExecutionId = executionId,
-                    TenantId = tenantId,
-                    DefinitionId = definitionId,
-                    DefinitionVersionId = versionRow.DefinitionVersionId,
-                    Status = ExecutionProjectionStatuses.Running,
-                    StartedAt = createdAt,
-                    UpdatedAt = createdAt,
-                    CancelRequested = false,
-                    RestartLost = false,
-                    SecuritySnapshotJson = securitySnapshotJson
-                };
-                var snapshotRow = new ExecutionGraphSnapshotRow
-                {
-                    ExecutionId = executionId,
-                    GraphJson = emptyGraphJson,
-                    UpdatedAt = createdAt
-                };
-                var accepted = new ExecutionResponse
-                {
-                    DisplayId = displayId,
-                    ResourceId = executionId,
-                    GraphId = graphId,
-                    Status = ExecutionProjectionStatuses.Running,
-                    StartedAt = createdAt
-                };
-
-                await _executions.AddExecutionAndSnapshotAsync(uow, executionRow, snapshotRow, innerCt).ConfigureAwait(false);
-
-                var startedPayload = JsonSerializer.Serialize(
-                    new
-                    {
-                        definitionId = definitionId.ToString(),
-                        definitionVersionId = versionRow.DefinitionVersionId.ToString(),
-                        definitionVersion = versionRow.Version,
-                        tenantId,
-                        startedByPrincipalId = securitySnapshot.StartedByPrincipalId,
-                        permissionSetHash = securitySnapshot.PermissionSetHash,
-                        securityModelVersion = securitySnapshot.SecurityModelVersion,
-                        evaluationMode = securitySnapshot.EvaluationMode.ToString()
-                    },
-                    JsonSerializerProfiles.CamelCase);
-                await _eventStore
-                    .AppendAsync(uow, executionId, EventStoreEventType.WorkflowStarted, startedPayload, innerCt)
-                    .ConfigureAwait(false);
-
-                if (dedupKey is { } saveKey)
-                {
-                    var responseJson = JsonSerializer.Serialize(accepted, JsonSerializerProfiles.CamelCase);
-                    await _dedup.SaveAsync(
-                        uow,
-                        new CommandDedupRow
-                        {
-                            DedupKey = saveKey.DedupKey,
-                            Endpoint = saveKey.Endpoint,
-                            IdempotencyKey = saveKey.IdempotencyKey,
-                            RequestHash = requestHash,
-                            StatusCode = HttpStatus201Created,
-                            ResponseBody = responseJson,
-                            CreatedAt = createdAt,
-                            ExpiresAt = createdAt.AddHours(24)
-                        },
-                        innerCt).ConfigureAwait(false);
-                }
-
-                await _workQueue!.EnqueueAsync(
-                    uow,
-                    new ExecutionWorkItemRow
-                    {
-                        WorkItemId = _idGenerator.NewSequentialGuid(),
-                        ExecutionId = executionId,
-                        Kind = ExecutionWorkItemKinds.Start,
-                        Payload = JsonSerializer.Serialize(
-                            new ExecutionStartWorkItemPayload(executionId, request),
-                            ExecutionWorkItemPayloadJson.Options),
-                        AvailableAt = createdAt,
-                        Attempts = 0,
-                        CreatedAt = createdAt
-                    },
-                    innerCt).ConfigureAwait(false);
-
-                return accepted;
-            },
-            ct).ConfigureAwait(false);
-
-        return response;
-    }
-
-    /// <summary>同一プロセス内で Engine を起動し投影する（Worker / テスト互換）。</summary>
-    private async Task<ExecutionResponse> ExecuteStartInProcessAsync(
-        ExecuteStartInProcessArgs args,
-        CancellationToken ct)
-    {
-        var compiled = RestoreCompiledDefinitionFromVersion(args.VersionRow);
-        var resolvedExecutionId = args.ExecutionId ?? _idGenerator.NewSequentialGuid();
-        var engineId = resolvedExecutionId.ToString();
-        _engine.Start(compiled, engineId, args.Request.Input, args.Request.InitialState);
-
-        var graphId = await _displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Definition, args.DefinitionId.ToString("D"), ct).ConfigureAwait(false)
-            ?? args.DefinitionId.ToString("D");
-
-        try
-        {
-            var startResult = await _executor.ExecuteReadCommittedAsync(
-                async (uow, innerCt) =>
-                {
-                    var createdAt = DateTime.UtcNow;
-                    var startSnapshot = _engine.GetSnapshot(engineId)
-                        ?? throw new InvalidOperationException(
-                            $"Cannot project execution '{resolvedExecutionId}': engine snapshot is missing after Start.");
-                    var status = ExecutionProjectionOrchestrator.MapStatus(startSnapshot);
-                    var graphJson = _engine.ExportExecutionGraph(engineId);
-
-                    ExecutionResponse response;
-                    if (args.ExecutionId is null)
-                    {
-                        // 同一プロセス受理: セキュリティ snapshot と WorkflowStarted をここで確定する。
-                        var securitySnapshot = await _snapshotFactory
-                            .CaptureForStartAsync(args.TenantId, args.DefinitionId, createdAt, innerCt)
-                            .ConfigureAwait(false);
-                        var securitySnapshotJson = ExecutionSecuritySnapshotJson.Serialize(securitySnapshot);
-
-                        var startedPayload = JsonSerializer.Serialize(
-                            new
-                            {
-                                definitionId = args.DefinitionId.ToString(),
-                                definitionVersionId = args.VersionRow.DefinitionVersionId.ToString(),
-                                definitionVersion = args.VersionRow.Version,
-                                tenantId = args.TenantId,
-                                startedByPrincipalId = securitySnapshot.StartedByPrincipalId,
-                                permissionSetHash = securitySnapshot.PermissionSetHash,
-                                securityModelVersion = securitySnapshot.SecurityModelVersion,
-                                evaluationMode = securitySnapshot.EvaluationMode.ToString()
-                            },
-                            JsonSerializerProfiles.CamelCase);
-
-                        var displayId = await _displayIdWrites
-                            .AllocateAsync(uow, DisplayIdResourceTypes.Execution, resolvedExecutionId, innerCt)
-                            .ConfigureAwait(false);
-
-                        var executionRow = new ExecutionRow
-                        {
-                            ExecutionId = resolvedExecutionId,
-                            TenantId = args.TenantId,
-                            DefinitionId = args.DefinitionId,
-                            DefinitionVersionId = args.VersionRow.DefinitionVersionId,
-                            Status = status,
-                            StartedAt = createdAt,
-                            UpdatedAt = createdAt,
-                            CancelRequested = false,
-                            RestartLost = false,
-                            SecuritySnapshotJson = securitySnapshotJson
-                        };
-                        var snapshotRow = new ExecutionGraphSnapshotRow
-                        {
-                            ExecutionId = resolvedExecutionId,
-                            GraphJson = graphJson,
-                            UpdatedAt = createdAt
-                        };
-                        response = new ExecutionResponse
-                        {
-                            DisplayId = displayId,
-                            ResourceId = resolvedExecutionId,
-                            GraphId = graphId,
-                            Status = status,
-                            StartedAt = createdAt
-                        };
-
-                        await _executions.AddExecutionAndSnapshotAsync(uow, executionRow, snapshotRow, innerCt).ConfigureAwait(false);
-                        await _eventStore
-                            .AppendAsync(uow, resolvedExecutionId, EventStoreEventType.WorkflowStarted, startedPayload, innerCt)
-                            .ConfigureAwait(false);
-
-                        if (args.DedupKey is { } saveKey)
-                        {
-                            var responseJson = JsonSerializer.Serialize(response, JsonSerializerProfiles.CamelCase);
-                            await _dedup.SaveAsync(
-                                uow,
-                                new CommandDedupRow
-                                {
-                                    DedupKey = saveKey.DedupKey,
-                                    Endpoint = saveKey.Endpoint,
-                                    IdempotencyKey = saveKey.IdempotencyKey,
-                                    RequestHash = args.RequestHash,
-                                    StatusCode = HttpStatus201Created,
-                                    ResponseBody = responseJson,
-                                    CreatedAt = createdAt,
-                                    ExpiresAt = createdAt.AddHours(24)
-                                },
-                                innerCt).ConfigureAwait(false);
-                        }
-                    }
-                    else
-                    {
-                        // Worker: HTTP 受理時に snapshot / WorkflowStarted 済み。投影のみ更新する。
-                        var existing = await _executions.GetByIdAsync(uow, args.TenantId, resolvedExecutionId, innerCt).ConfigureAwait(false)
-                            ?? throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-                        var displayId = await _displayIds.GetDisplayIdAsync(
-                                DisplayIdResourceTypes.Execution,
-                                resolvedExecutionId.ToString("D"),
-                                innerCt)
-                            .ConfigureAwait(false)
-                            ?? resolvedExecutionId.ToString("D");
-                        response = new ExecutionResponse
-                        {
-                            DisplayId = displayId,
-                            ResourceId = resolvedExecutionId,
-                            GraphId = graphId,
-                            Status = status,
-                            StartedAt = existing.StartedAt
-                        };
-                        await _executions
-                            .UpdateExecutionAndSnapshotAsync(
-                                uow,
-                                resolvedExecutionId,
-                                status,
-                                cancelRequested: existing.CancelRequested,
-                                graphJson,
-                                innerCt)
-                            .ConfigureAwait(false);
-                    }
-
-                    await _projection.SyncOperationalProjectionAsync(
-                            uow,
-                            resolvedExecutionId,
-                            args.TenantId,
-                            status,
-                            graphJson,
-                            nodeIdToClear: null,
-                            innerCt)
-                        .ConfigureAwait(false);
-
-                    var checkpointSaved = false;
-                    if (string.Equals(status, ExecutionProjectionStatuses.Running, StringComparison.Ordinal)
-                        && ExecutionOperationalProjectionSync.HasDurableWaits(graphJson))
-                    {
-                        checkpointSaved = await UpsertRuntimeCheckpointAsync(uow, engineId, resolvedExecutionId, innerCt)
-                            .ConfigureAwait(false);
-                    }
-
-                    return (Response: response, UnloadAfterCommit: checkpointSaved);
-                },
-                ct).ConfigureAwait(false);
-
-            if (startResult.UnloadAfterCommit)
-            {
-                _engine.Unload(engineId);
-                _logger.CheckpointUnloadedAfterStartSync(resolvedExecutionId);
-            }
-
-            return startResult.Response;
-        }
-        catch
-        {
-            // DB 反映前に失敗した場合、再試行で二重 Load しないようローカル Engine を捨てる。
-            _engine.Unload(engineId);
-            throw;
-        }
-    }
+        CancellationToken ct) =>
+        _lifecycle.StartAsync(request, idempotencyKey, requestContext, ct);
 
     /// <inheritdoc />
-    public async Task<ExecutionResponse> ExecuteQueuedStartAsync(
+    public Task<ExecutionResponse> ExecuteQueuedStartAsync(
         Guid executionId,
         StartExecutionRequest request,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
-
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var execution = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _executions.GetByIdAsync(uow, tenantId, executionId, innerCt),
-            ct).ConfigureAwait(false);
-        if (execution is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        var versionRow = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _definitions.GetVersionForExecutionByIdAsync(
-                uow,
-                tenantId,
-                execution.DefinitionVersionId,
-                innerCt),
-            ct).ConfigureAwait(false);
-        if (versionRow is null)
-            throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
-
-        return await ExecuteStartInProcessAsync(
-                new ExecuteStartInProcessArgs(
-                    request,
-                    RequestHash: string.Empty,
-                    DedupKey: null,
-                    tenantId,
-                    execution.DefinitionId,
-                    versionRow,
-                    executionId),
-                ct)
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Engine から checkpoint を export し、同一 UoW へ upsert する。
-    /// </summary>
-    /// <returns>export できて upsert したとき <see langword="true"/>。</returns>
-    private async Task<bool> UpsertRuntimeCheckpointAsync(
-        ICoreUnitOfWork uow,
-        string engineExecutionId,
-        Guid executionId,
-        CancellationToken ct)
-    {
-        var checkpoint = _engine.ExportCheckpoint(engineExecutionId);
-        if (checkpoint is null)
-        {
-            _logger.ExportCheckpointNullWithDurableWaits(engineExecutionId);
-            return false;
-        }
-
-        var json = JsonSerializer.Serialize(checkpoint, JsonSerializerProfiles.CamelCase);
-        var updatedAt = DateTime.UtcNow;
-        if (_ownership.TryGet(executionId, out _, out var generation))
-        {
-            return await _checkpointStore.TryUpsertRuntimeWithGenerationAsync(
-                    uow,
-                    new ExecutionCheckpointRuntimeUpsert(
-                        executionId,
-                        generation,
-                        json,
-                        checkpoint.SchemaVersion,
-                        updatedAt),
-                    ct)
-                .ConfigureAwait(false);
-        }
-
-        await _checkpointStore.UpsertAsync(
-            uow,
-            new ExecutionCheckpointDocument
-            {
-                ExecutionId = executionId,
-                CheckpointJson = json,
-                SchemaVersion = checkpoint.SchemaVersion,
-                UpdatedAt = updatedAt
-            },
-            ct).ConfigureAwait(false);
-        return true;
-    }
+        CancellationToken ct) =>
+        _lifecycle.ExecuteQueuedStartAsync(executionId, request, ct);
 
     public Task<PagedResult<ExecutionResponse>> ListPagedAsync(
         ExecutionListPageQuery query,
@@ -573,180 +156,13 @@ internal sealed class ExecutionService : IExecutionService
     public Task<string?> TryGetSnapshotGraphJsonByExecutionIdAsync(Guid executionId, CancellationToken ct) =>
         _query.TryGetSnapshotGraphJsonByExecutionIdAsync(executionId, ct);
 
-    public async Task CancelAsync(
+    /// <inheritdoc />
+    public Task CancelAsync(
         string idOrUuid,
         string? idempotencyKey,
         CommandRequestContext requestContext,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(requestContext);
-
-        var tenantKey = _tenantContext.GetRequiredTenantKey();
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var dedupKey = _idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
-
-        if (await _idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
-            return;
-
-        var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
-        if (uuid is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        var execution = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt),
-            ct).ConfigureAwait(false);
-        if (execution is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
-
-        // HTTP 受理経路: キューがある場合は Engine を回さず Cancel work item を投入する。
-        if (_workQueue is not null
-            && !string.Equals(requestContext.Method, "WORKER", StringComparison.Ordinal))
-        {
-            await AcceptCancelAndEnqueueAsync(uuid.Value, dedupKey, ct).ConfigureAwait(false);
-            return;
-        }
-
-        // WORKER / 同期 Cancel: 未終端子へ Cancel をカスケード（ネストは各層で再帰）。
-        if (_forkChildCoordinator is not null)
-        {
-            await _forkChildCoordinator
-                .CascadeCancelToRunningChildrenAsync(uuid.Value, ct)
-                .ConfigureAwait(false);
-        }
-
-        await _projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
-
-        var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
-
-        if (await _idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
-            return;
-
-        await EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
-
-        var cancelApply = await _engine.CancelAsync(uuid.Value.ToString(), clientEventId).ConfigureAwait(false);
-        var skipCancelEventAppend = cancelApply.IsAlreadyApplied;
-
-        var (projStatus, projCancel, projGraphJson) = _projection.BuildProjectionFromEngine(uuid.Value);
-        var cancelPayload = JsonSerializer.Serialize(
-            new { tenantId },
-            JsonSerializerProfiles.CamelCase);
-
-        await _mutationPersistence.ExecuteSerializableWithRetryAsync(
-            tenantId,
-            uuid.Value,
-            clientEventId,
-            async (uow, ctInner) =>
-            {
-                await _executions
-                    .UpdateExecutionAndSnapshotAsync(uow, uuid.Value, projStatus, projCancel, projGraphJson, ctInner)
-                    .ConfigureAwait(false);
-                await _projection.SyncOperationalProjectionAsync(
-                        uow,
-                        uuid.Value,
-                        tenantId,
-                        projStatus,
-                        projGraphJson,
-                        nodeIdToClear: null,
-                        ctInner)
-                    .ConfigureAwait(false);
-                if (!skipCancelEventAppend)
-                {
-                    await _eventStore
-                        .AppendAsync(uow, uuid.Value, EventStoreEventType.WorkflowCancelled, cancelPayload, ctInner)
-                        .ConfigureAwait(false);
-                }
-                else
-                {
-                    await _eventStore.TryAppendIfAbsentByClientEventAsync(
-                        uow,
-                        uuid.Value,
-                        clientEventId,
-                        EventStoreEventType.WorkflowCancelled,
-                        cancelPayload,
-                        ctInner).ConfigureAwait(false);
-                }
-
-                if (dedupKey is { } saveKey)
-                {
-                    var now = DateTime.UtcNow;
-                    await _dedup.SaveAsync(
-                        uow,
-                        new CommandDedupRow
-                        {
-                            DedupKey = saveKey.DedupKey,
-                            Endpoint = saveKey.Endpoint,
-                            IdempotencyKey = saveKey.IdempotencyKey,
-                            RequestHash = null,
-                            StatusCode = HttpStatus204NoContent,
-                            ResponseBody = null,
-                            CreatedAt = now,
-                            ExpiresAt = now.AddHours(24)
-                        },
-                        ctInner).ConfigureAwait(false);
-                }
-
-                var nowUtc = DateTime.UtcNow;
-                await _eventDeliveryDedup.TryUpdateStatusAsync(
-                    uow,
-                    tenantId,
-                    uuid.Value,
-                    clientEventId,
-                    new EventDeliveryDedupStatusUpdate(
-                        EventDeliveryDedupStatuses.Applied,
-                        nowUtc,
-                        AppliedAt: nowUtc,
-                        ErrorCode: null),
-                    ctInner).ConfigureAwait(false);
-            },
-            ct).ConfigureAwait(false);
-    }
-
-    /// <summary>Cancel work item を enqueue し、任意で dedup を保存する。</summary>
-    private async Task AcceptCancelAndEnqueueAsync(
-        Guid executionId,
-        CommandDedupKey? dedupKey,
-        CancellationToken ct)
-    {
-        var now = DateTime.UtcNow;
-        await _executor.ExecuteReadCommittedAsync(
-            async (uow, innerCt) =>
-            {
-                if (dedupKey is { } saveKey)
-                {
-                    await _dedup.SaveAsync(
-                        uow,
-                        new CommandDedupRow
-                        {
-                            DedupKey = saveKey.DedupKey,
-                            Endpoint = saveKey.Endpoint,
-                            IdempotencyKey = saveKey.IdempotencyKey,
-                            RequestHash = null,
-                            StatusCode = HttpStatus204NoContent,
-                            ResponseBody = null,
-                            CreatedAt = now,
-                            ExpiresAt = now.AddHours(24)
-                        },
-                        innerCt).ConfigureAwait(false);
-                }
-
-                await _workQueue!.EnqueueAsync(
-                    uow,
-                    new ExecutionWorkItemRow
-                    {
-                        WorkItemId = _idGenerator.NewSequentialGuid(),
-                        ExecutionId = executionId,
-                        Kind = ExecutionWorkItemKinds.Cancel,
-                        Payload = "{}",
-                        AvailableAt = now,
-                        Attempts = 0,
-                        CreatedAt = now
-                    },
-                    innerCt).ConfigureAwait(false);
-            },
-            ct).ConfigureAwait(false);
-    }
+        CancellationToken ct) =>
+        _lifecycle.CancelAsync(idOrUuid, idempotencyKey, requestContext, ct);
 
     /// <inheritdoc />
     public async Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct)
@@ -1026,7 +442,7 @@ internal sealed class ExecutionService : IExecutionService
         if (await _idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
             return;
 
-        await EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
+        await _lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
 
         // PublishEvent 復帰時点ではグラフ上の Wait 完了が未反映になり得るため、発行前の nodeId で先行削除する。
         // グラフ解析失敗時は永続化済み wait 行からフォールバック解決する（Applied 時のみ）。
@@ -1259,7 +675,7 @@ internal sealed class ExecutionService : IExecutionService
             return;
         }
 
-        await EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
+        await _lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
 
         // Resume 正本: nodeId + eventName。wait 行は nodeId で先行削除する。
         // 許可外イベント・非アクティブ Wait などは 422。
@@ -1360,7 +776,7 @@ internal sealed class ExecutionService : IExecutionService
                     }
                     else
                     {
-                        await UpsertRuntimeCheckpointAsync(
+                        await _lifecycle.UpsertRuntimeCheckpointAsync(
                                 uow,
                                 request.EngineId,
                                 request.ExecutionId,
@@ -1526,7 +942,7 @@ internal sealed class ExecutionService : IExecutionService
         if (_forkChildCoordinator is null)
             return;
 
-        if (IsTerminalExecutionProjectionStatus(execution.Status))
+        if (ExecutionLifecycleCommandService.IsTerminalExecutionProjectionStatus(execution.Status))
             return;
 
         var evaluation = await _forkChildCoordinator
@@ -1592,7 +1008,7 @@ internal sealed class ExecutionService : IExecutionService
                 ct)
             .ConfigureAwait(false);
         if (document is null
-            || !TryParseRuntimeCheckpoint(document.CheckpointJson, out var checkpoint, out _))
+            || !ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(document.CheckpointJson, out var checkpoint, out _))
         {
             return false;
         }
@@ -1725,7 +1141,7 @@ internal sealed class ExecutionService : IExecutionService
         ArgumentNullException.ThrowIfNull(evaluation.CandidateInputs);
         _logger.ForkJoinSatisfied(parentExecutionId, forkNodeId, evaluation.JoinState);
 
-        await EnsureEngineRuntimeLoadedForMutationAsync(parentExecutionId, execution, ct).ConfigureAwait(false);
+        await _lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(parentExecutionId, execution, ct).ConfigureAwait(false);
 
         var engineId = parentExecutionId.ToString();
         IReadOnlyList<PhysicalJoinContextFragment>? fragments = null;
@@ -1815,7 +1231,7 @@ internal sealed class ExecutionService : IExecutionService
                     }
                     else
                     {
-                        await UpsertRuntimeCheckpointAsync(uow, engineId, parentExecutionId, innerCt)
+                        await _lifecycle.UpsertRuntimeCheckpointAsync(uow, engineId, parentExecutionId, innerCt)
                             .ConfigureAwait(false);
                     }
                 },
@@ -1843,11 +1259,11 @@ internal sealed class ExecutionService : IExecutionService
 
         await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
-        if (IsTerminalExecutionProjectionStatus(execution.Status))
+        if (ExecutionLifecycleCommandService.IsTerminalExecutionProjectionStatus(execution.Status))
             return;
 
         // Worker が BeginOwnedSession 済み前提。hydrate 後、完了フロンティア／PendingWaits から継続する。
-        await EnsureEngineRuntimeLoadedForMutationAsync(executionId, execution, ct).ConfigureAwait(false);
+        await _lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(executionId, execution, ct).ConfigureAwait(false);
 
         var engineId = executionId.ToString();
         // ImportCheckpoint が起動した継続（Wait 復元または完了フロンティア遷移）が落ち着くのを待つ。
@@ -1882,7 +1298,7 @@ internal sealed class ExecutionService : IExecutionService
                 }
                 else
                 {
-                    await UpsertRuntimeCheckpointAsync(uow, engineId, executionId, innerCt)
+                    await _lifecycle.UpsertRuntimeCheckpointAsync(uow, engineId, executionId, innerCt)
                         .ConfigureAwait(false);
                 }
             },
@@ -2037,7 +1453,7 @@ internal sealed class ExecutionService : IExecutionService
                         .GetByExecutionIdAsync(uow, executionId, innerCt)
                         .ConfigureAwait(false);
                     if (runtime is null
-                        || !TryParseRuntimeCheckpoint(runtime.CheckpointJson, out var checkpoint, out _)
+                        || !ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(runtime.CheckpointJson, out var checkpoint, out _)
                         || checkpoint.PendingWaits.Count == 0)
                     {
                         return;
@@ -2177,135 +1593,6 @@ internal sealed class ExecutionService : IExecutionService
         return false;
     }
 
-    private Task<DefinitionVersionRow?> ResolveStartDefinitionVersionAsync(
-        Guid tenantId,
-        Guid definitionId,
-        StartExecutionRequest request,
-        CancellationToken ct) =>
-        _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => ResolveStartDefinitionVersionInUowAsync(uow, tenantId, definitionId, request, innerCt),
-            ct);
-
-    private async Task<DefinitionVersionRow?> ResolveStartDefinitionVersionInUowAsync(
-        ICoreUnitOfWork uow,
-        Guid tenantId,
-        Guid definitionId,
-        StartExecutionRequest request,
-        CancellationToken ct)
-    {
-        if (request.DefinitionVersionId is { } versionId)
-            return await ResolveVersionByIdForAdmissionAsync(uow, tenantId, definitionId, versionId, ct)
-                .ConfigureAwait(false);
-
-        if (request.DefinitionVersion is { } versionNumber)
-            return await ResolveVersionByNumberForAdmissionAsync(uow, tenantId, definitionId, versionNumber, ct)
-                .ConfigureAwait(false);
-
-        var latest = await _definitions
-            .GetLatestForApiAsync(uow, tenantId, definitionId, ct)
-            .ConfigureAwait(false);
-        return latest?.Version;
-    }
-
-    private async Task<DefinitionVersionRow?> ResolveVersionByIdForAdmissionAsync(
-        ICoreUnitOfWork uow,
-        Guid tenantId,
-        Guid definitionId,
-        Guid versionId,
-        CancellationToken ct)
-    {
-        var byId = await _definitions
-            .GetVersionForExecutionByIdAsync(uow, tenantId, versionId, ct)
-            .ConfigureAwait(false);
-        if (byId is null || byId.DefinitionId != definitionId)
-            return null;
-
-        return await EnsureActiveParentForAdmissionAsync(uow, tenantId, definitionId, ct).ConfigureAwait(false)
-            ? byId
-            : null;
-    }
-
-    private async Task<DefinitionVersionRow?> ResolveVersionByNumberForAdmissionAsync(
-        ICoreUnitOfWork uow,
-        Guid tenantId,
-        Guid definitionId,
-        int versionNumber,
-        CancellationToken ct)
-    {
-        var byNumber = await _definitions
-            .GetVersionForExecutionAsync(uow, tenantId, definitionId, versionNumber, ct)
-            .ConfigureAwait(false);
-        if (byNumber is null)
-            return null;
-
-        return await EnsureActiveParentForAdmissionAsync(uow, tenantId, definitionId, ct).ConfigureAwait(false)
-            ? byNumber
-            : null;
-    }
-
-    private async Task<bool> EnsureActiveParentForAdmissionAsync(
-        ICoreUnitOfWork uow,
-        Guid tenantId,
-        Guid definitionId,
-        CancellationToken ct)
-    {
-        var active = await _definitions
-            .GetLatestForApiAsync(uow, tenantId, definitionId, ct)
-            .ConfigureAwait(false);
-        return active is not null;
-    }
-
-    private Task EnsureCanExecuteOnDefinitionAsync(
-        Guid tenantId,
-        Guid definitionId,
-        CancellationToken ct) =>
-        _executor.ExecuteReadOnlyAsync(
-            async (uow, innerCt) =>
-            {
-                var projectId = await _definitions
-                    .ResolveProjectIdAsync(uow, tenantId, definitionId, innerCt)
-                    .ConfigureAwait(false);
-                if (projectId is null)
-                    throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
-
-                await _projectAuth
-                    .EnsureCanExecuteAsync(uow, tenantId, projectId.Value, innerCt)
-                    .ConfigureAwait(false);
-            },
-            ct);
-
-    private CompiledWorkflowDefinition RestoreCompiledDefinitionFromVersion(DefinitionVersionRow versionRow)
-    {
-        try
-        {
-            return _compiler.RestoreFromStoredVersion(versionRow.SourceYaml, versionRow.CompiledJson);
-        }
-        catch (ArgumentException ex)
-        {
-            throw new InvalidOperationException("Stored definition version is invalid.", ex);
-        }
-    }
-
-    private static string ComputeStartRequestHash(StartExecutionRequest request)
-    {
-        var normalized = JsonSerializer.Serialize(
-            new
-            {
-                definitionId = request.DefinitionId,
-                definitionVersion = request.DefinitionVersion,
-                definitionVersionId = request.DefinitionVersionId,
-                input = request.Input
-            },
-            JsonSerializerProfiles.CamelCase);
-        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
-    }
-
-    /// <summary>
-    /// 投影が終了状態かどうかを、<c>executions.status</c> の文字列値から判定する。
-    /// </summary>
-    private static bool IsTerminalExecutionProjectionStatus(string status) =>
-        ExecutionProjectionStatuses.IsTerminal(status);
-
     /// <summary>
     /// 寿命表に従い checkpoint <b>内容</b>の破棄候補か。
     /// </summary>
@@ -2372,7 +1659,7 @@ internal sealed class ExecutionService : IExecutionService
         if (_ownership.TryGet(executionId, out _, out _))
         {
             // Worker 所有中。寿命表上は破棄候補でも lease 行は残し runtime だけ更新する。
-            _ = await UpsertRuntimeCheckpointAsync(uow, engineExecutionId, executionId, ct)
+            _ = await _lifecycle.UpsertRuntimeCheckpointAsync(uow, engineExecutionId, executionId, ct)
                 .ConfigureAwait(false);
             return false;
         }
@@ -2391,120 +1678,6 @@ internal sealed class ExecutionService : IExecutionService
             snapshot,
             RuntimePermissionRequirements.ExecutionsWrite,
             ct);
-    }
-
-    /// <summary>
-    /// キャンセル／イベント発行の適用直前に、エンジンへ実行をロードする（未ロードなら checkpoint から hydrate）。
-    /// </summary>
-    private async Task EnsureEngineRuntimeLoadedForMutationAsync(
-        Guid executionId,
-        ExecutionRow execution,
-        CancellationToken ct)
-    {
-        if (_engine.GetSnapshot(executionId.ToString()) is not null)
-            return;
-
-        if (IsTerminalExecutionProjectionStatus(execution.Status))
-        {
-            throw new ArgumentException(
-                "The execution is already in a terminal state in the database projection, but there is no in-memory instance in this API process. Cancel or event delivery cannot be applied.");
-        }
-
-        var checkpointDocument = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _checkpointStore.GetByExecutionIdAsync(uow, executionId, innerCt),
-            ct).ConfigureAwait(false);
-        if (checkpointDocument is null)
-        {
-            throw new ArgumentException(
-                "The execution state is not loaded in this API process and no runtime checkpoint was found.");
-        }
-
-        var versionRow = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _definitions.GetVersionForExecutionByIdAsync(
-                uow,
-                execution.TenantId,
-                execution.DefinitionVersionId,
-                innerCt),
-            ct).ConfigureAwait(false);
-        if (versionRow is null)
-        {
-            throw new InvalidOperationException(
-                $"Definition version '{execution.DefinitionVersionId}' was not found for execution '{executionId}'.");
-        }
-
-        var compiled = RestoreCompiledDefinitionFromVersion(versionRow);
-        if (!TryParseRuntimeCheckpoint(checkpointDocument.CheckpointJson, out var checkpoint, out var parseError))
-        {
-            _logger.RuntimeCheckpointInvalidForHydrate(
-                executionId,
-                checkpointDocument.CheckpointJson?.Length ?? 0);
-            if (parseError is not null)
-                _logger.RuntimeCheckpointDeserializeFailed(parseError, executionId);
-
-            throw new InvalidOperationException(
-                $"Stored runtime checkpoint for execution '{executionId:D}' is empty or invalid and cannot be hydrated.");
-        }
-
-        try
-        {
-            _engine.ImportCheckpoint(compiled, checkpoint);
-        }
-        catch (InvalidOperationException ex)
-        {
-            // 二重 hydrate 等はクライアント向け 422（ArgumentException）へ写像する。
-            throw new ArgumentException(ex.Message, ex);
-        }
-    }
-
-    /// <summary>
-    /// 永続 checkpoint JSON を hydrate 用に検証・デシリアライズする。
-    /// </summary>
-    /// <remarks>
-    /// <c>BeginOwnedSessionAsync</c> の seed <c>{}</c> や必須欠落は不正とし、Import しない。
-    /// </remarks>
-    private static bool TryParseRuntimeCheckpoint(
-        string? checkpointJson,
-        out ExecutionRuntimeCheckpoint checkpoint,
-        out Exception? parseError)
-    {
-        checkpoint = null!;
-        parseError = null;
-
-        if (string.IsNullOrWhiteSpace(checkpointJson))
-            return false;
-
-        var trimmed = checkpointJson.Trim();
-        if (trimmed is "{}" or "null")
-            return false;
-
-        try
-        {
-            var parsed = JsonSerializer.Deserialize<ExecutionRuntimeCheckpoint>(
-                checkpointJson,
-                JsonSerializerProfiles.CamelCase);
-            if (parsed is null
-                || string.IsNullOrWhiteSpace(parsed.ExecutionId)
-                || string.IsNullOrWhiteSpace(parsed.DefinitionName)
-                || parsed.ActiveStates is null
-                || parsed.Graph is null
-                || parsed.Join is null
-                || parsed.Context is null
-                || parsed.PendingWaits is null)
-            {
-                return false;
-            }
-
-            // 物理 Join 待ち中は ActiveStates / PendingWaits が空の正規断面になり得る（Fork Unload 後）。
-            // 空配列だけでは破損とみなさない（seed "{}" は上で拒否済み）。
-
-            checkpoint = parsed;
-            return true;
-        }
-        catch (JsonException ex)
-        {
-            parseError = ex;
-            return false;
-        }
     }
 
     /// <summary>
@@ -2654,7 +1827,7 @@ internal sealed class ExecutionService : IExecutionService
                     .GetByExecutionIdAsync(uow, request.ExecutionId, innerCt)
                     .ConfigureAwait(false);
                 if (existingCheckpoint is not null
-                    && TryParseRuntimeCheckpoint(existingCheckpoint.CheckpointJson, out var stored, out _)
+                    && ExecutionLifecycleCommandService.TryParseRuntimeCheckpoint(existingCheckpoint.CheckpointJson, out var stored, out _)
                     && IsRuntimeCheckpointLessAdvanced(request.Checkpoint, stored))
                 {
                     skippedStalePersist = true;
@@ -2806,7 +1979,7 @@ internal sealed class ExecutionService : IExecutionService
             executionId,
             ShouldDiscardRuntimeCheckpointAsync,
             DiscardOrRefreshRuntimeCheckpointAsync,
-            UpsertRuntimeCheckpointAsync,
+            _lifecycle.UpsertRuntimeCheckpointAsync,
             ct);
 
     /// <summary>
@@ -2989,13 +2162,4 @@ internal sealed class ExecutionService : IExecutionService
         return soleMatchingNodeId;
     }
 
-    /// <summary>同一プロセス Start の入力束。</summary>
-    private sealed record ExecuteStartInProcessArgs(
-        StartExecutionRequest Request,
-        string RequestHash,
-        CommandDedupKey? DedupKey,
-        Guid TenantId,
-        Guid DefinitionId,
-        DefinitionVersionRow VersionRow,
-        Guid? ExecutionId);
 }

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -1,15 +1,9 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Statevia.Core.Application.Configuration;
 using Statevia.Core.Application.Infrastructure;
-using Statevia.Core.Application.Contracts.Persistence;
-using Statevia.Core.Application.Contracts.Services;
 using Statevia.Core.Engine.Abstractions;
 
 namespace Statevia.Core.Application.Services;
@@ -25,17 +19,6 @@ internal sealed class ExecutionService : IExecutionService
     /// </summary>
     private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> PersistUnloadGates = new();
 
-    /// <summary><c>event_delivery_decision</c> 構造化ログの <c>decision</c> プロパティ値。</summary>
-    private static class EventDeliveryLogDecisions
-    {
-        internal const string Inserted = "inserted";
-        internal const string DuplicateKey = "duplicate_key";
-        internal const string AbortedTimeout = "aborted_timeout";
-        internal const string Retry = "retry";
-        internal const string BackoffBudgetExhausted = "backoff_budget_exhausted";
-        internal const string Failed = "failed";
-    }
-
     /// <summary>実行グラフ JSON のプロパティ名（投影・Engine export 共通）。</summary>
     private static class ExecutionGraphJsonProperties
     {
@@ -48,15 +31,6 @@ internal sealed class ExecutionService : IExecutionService
         internal const string NodeType = "nodeType";
     }
 
-    /// <summary>
-    /// <c>event_delivery_decision</c> 構造化ログの <c>errorCode</c>、および dedup 行の既知 <c>error_code</c> 値。
-    /// </summary>
-    private static class EventDeliveryLogErrorCodes
-    {
-        internal const string None = "none";
-        internal const string UniqueViolation = "unique_violation";
-    }
-
     /// <summary>HTTP 201 Created。</summary>
     private const int HttpStatus201Created = 201;
 
@@ -67,7 +41,6 @@ internal sealed class ExecutionService : IExecutionService
     private readonly IDisplayIdService _displayIds;
     private readonly IDefinitionCompilerService _compiler;
     private readonly IIdGenerator _idGenerator;
-    private readonly ICommandDedupService _dedupService;
     private readonly IExecutionRepository _executions;
     private readonly IExecutionCursorRepository _executionCursors;
     private readonly IExecutionWaitRepository _executionWaits;
@@ -87,11 +60,10 @@ internal sealed class ExecutionService : IExecutionService
     private readonly ICoreTransactionExecutor _executor;
     private readonly IExecutionMutationPersistence _mutationPersistence;
     private readonly ILogger<ExecutionService> _logger;
-    private readonly IOptions<EventDeliveryRetryOptions> _eventDeliveryRetryOptions;
-    private readonly ICorrelationIdAccessor _correlationIdAccessor;
     private readonly IExecutionProjectionUpdateQueue _projectionUpdateQueue;
     private readonly IForkChildExecutionCoordinator? _forkChildCoordinator;
     private readonly ExecutionQueryService _query;
+    private readonly ExecutionIdempotencyService _idempotency;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
@@ -102,7 +74,6 @@ internal sealed class ExecutionService : IExecutionService
         IDisplayIdService displayIds,
         IDefinitionCompilerService compiler,
         IIdGenerator idGenerator,
-        ICommandDedupService dedupService,
         IExecutionRepository executions,
         IExecutionCursorRepository executionCursors,
         IExecutionWaitRepository executionWaits,
@@ -119,10 +90,9 @@ internal sealed class ExecutionService : IExecutionService
         ICoreTransactionExecutor executor,
         IExecutionMutationPersistence mutationPersistence,
         ILogger<ExecutionService> logger,
-        IOptions<EventDeliveryRetryOptions> eventDeliveryRetryOptions,
-        ICorrelationIdAccessor correlationIdAccessor,
         IExecutionCheckpointStore checkpointStore,
         ExecutionQueryService query,
+        ExecutionIdempotencyService idempotency,
         IExecutionProjectionUpdateQueue? projectionUpdateQueue = null,
         IExecutionWorkQueue? workQueue = null,
         ExecutionOwnershipTracker? ownershipTracker = null,
@@ -132,7 +102,6 @@ internal sealed class ExecutionService : IExecutionService
         _displayIds = displayIds;
         _compiler = compiler;
         _idGenerator = idGenerator;
-        _dedupService = dedupService;
         _executions = executions;
         _executionCursors = executionCursors;
         _executionWaits = executionWaits;
@@ -152,9 +121,8 @@ internal sealed class ExecutionService : IExecutionService
         _executor = executor;
         _mutationPersistence = mutationPersistence;
         _logger = logger;
-        _eventDeliveryRetryOptions = eventDeliveryRetryOptions;
-        _correlationIdAccessor = correlationIdAccessor;
         _query = query;
+        _idempotency = idempotency;
         _projectionUpdateQueue = projectionUpdateQueue ?? NoopExecutionProjectionUpdateQueue.Instance;
         _forkChildCoordinator = forkChildCoordinator;
     }
@@ -170,9 +138,9 @@ internal sealed class ExecutionService : IExecutionService
 
         var tenantKey = _tenantContext.GetRequiredTenantKey();
         var requestHash = ComputeStartRequestHash(request);
-        var dedupKey = _dedupService.Create(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path, requestHash);
+        var dedupKey = _idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path, requestHash);
 
-        var cachedStart = await TryGetIdempotentStartResponseAsync(dedupKey, requestHash, ct).ConfigureAwait(false);
+        var cachedStart = await _idempotency.TryGetIdempotentStartResponseAsync(dedupKey, requestHash, ct).ConfigureAwait(false);
         if (cachedStart is not null)
         {
             return cachedStart;
@@ -618,17 +586,10 @@ internal sealed class ExecutionService : IExecutionService
 
         var tenantKey = _tenantContext.GetRequiredTenantKey();
         var tenantId = _tenantContext.GetRequiredTenantId();
-        var dedupKey = _dedupService.Create(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
+        var dedupKey = _idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
 
-        if (dedupKey is { } key)
-        {
-            var dedupCheckTime = DateTime.UtcNow;
-            var existing = await _executor.ExecuteReadOnlyAsync(
-                (uow, innerCt) => _dedup.FindValidAsync(uow, key.DedupKey, dedupCheckTime, innerCt),
-                ct).ConfigureAwait(false);
-            if (existing is not null)
-                return;
-        }
+        if (await _idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
+            return;
 
         var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
         if (uuid is null)
@@ -662,7 +623,7 @@ internal sealed class ExecutionService : IExecutionService
 
         var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
 
-        if (await TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
+        if (await _idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
             return;
 
         await EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
@@ -1033,17 +994,10 @@ internal sealed class ExecutionService : IExecutionService
 
         var tenantKey = _tenantContext.GetRequiredTenantKey();
         var tenantId = _tenantContext.GetRequiredTenantId();
-        var dedupKey = _dedupService.Create(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
+        var dedupKey = _idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
 
-        if (dedupKey is { } key)
-        {
-            var dedupCheckTime = DateTime.UtcNow;
-            var existing = await _executor.ExecuteReadOnlyAsync(
-                (uow, innerCt) => _dedup.FindValidAsync(uow, key.DedupKey, dedupCheckTime, innerCt),
-                ct).ConfigureAwait(false);
-            if (existing is not null)
-                return;
-        }
+        if (await _idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
+            return;
 
         var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
         if (uuid is null)
@@ -1072,7 +1026,7 @@ internal sealed class ExecutionService : IExecutionService
 
         var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
 
-        if (await TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
+        if (await _idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
             return;
 
         await EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
@@ -1265,17 +1219,10 @@ internal sealed class ExecutionService : IExecutionService
         var eventName = resumeKey.Trim();
         var tenantKey = _tenantContext.GetRequiredTenantKey();
         var tenantId = _tenantContext.GetRequiredTenantId();
-        var dedupKey = _dedupService.Create(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
+        var dedupKey = _idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
 
-        if (dedupKey is { } key)
-        {
-            var dedupCheckTime = DateTime.UtcNow;
-            var existing = await _executor.ExecuteReadOnlyAsync(
-                (uow, innerCt) => _dedup.FindValidAsync(uow, key.DedupKey, dedupCheckTime, innerCt),
-                ct).ConfigureAwait(false);
-            if (existing is not null)
-                return;
-        }
+        if (await _idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
+            return;
 
         var uuid = await _displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
         if (uuid is null)
@@ -1305,7 +1252,7 @@ internal sealed class ExecutionService : IExecutionService
 
         var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, _idGenerator);
 
-        if (await TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
+        if (await _idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
             return;
 
         // 物理子終端の予約イベントは Wait Resume ではなく Join 再評価へ振る（D3）。
@@ -2231,58 +2178,6 @@ internal sealed class ExecutionService : IExecutionService
         }
 
         return false;
-    }
-
-    private static ExecutionResponse? DeserializeCachedExecutionResponse(CommandDedupRow existing)
-    {
-        if (string.IsNullOrEmpty(existing.ResponseBody))
-            return null;
-        return JsonDeserialize.TryDeserialize<ExecutionResponse>(existing.ResponseBody, JsonSerializerProfiles.CaseInsensitive, out var deserialized)
-            ? deserialized
-            : null;
-    }
-
-    private async Task<ExecutionResponse?> TryGetIdempotentStartResponseAsync(
-        CommandDedupKey? dedupKey,
-        string requestHash,
-        CancellationToken ct)
-    {
-        if (dedupKey is not { } key)
-        {
-            return null;
-        }
-
-        var tenantKey = _tenantContext.GetRequiredTenantKey();
-        var dedupCheckTime = DateTime.UtcNow;
-        var existing = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _dedup.FindValidAsync(uow, key.DedupKey, dedupCheckTime, innerCt),
-            ct).ConfigureAwait(false);
-        if (existing is not null)
-        {
-            var cached = DeserializeCachedExecutionResponse(existing);
-            if (cached is not null)
-            {
-                return cached;
-            }
-        }
-
-        var conflicting = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _dedup.FindValidConflictingRequestHashAsync(
-                uow,
-                tenantKey,
-                key.Endpoint,
-                key.IdempotencyKey,
-                requestHash,
-                dedupCheckTime,
-                innerCt),
-            ct).ConfigureAwait(false);
-        if (conflicting is not null)
-        {
-            throw new IdempotencyConflictException(
-                "The same X-Idempotency-Key was used with a different request body.");
-        }
-
-        return null;
     }
 
     private Task<DefinitionVersionRow?> ResolveStartDefinitionVersionAsync(
@@ -3287,229 +3182,6 @@ internal sealed class ExecutionService : IExecutionService
         public Task EnqueueAsync(Guid executionId, CancellationToken ct) => Task.CompletedTask;
 
         public Task DrainAsync(Guid executionId, CancellationToken ct) => Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// 現在リクエストの相関 ID（無ければ空文字）を返す。
-    /// </summary>
-    private string GetTraceIdOrEmpty() => _correlationIdAccessor.GetCorrelationId();
-
-    /// <summary>
-    /// イベント配送 dedup の観測性用に必須キーを構造化ログへ書き出す。
-    /// </summary>
-    private void LogEventDeliveryDecision(EventDeliveryDecisionDetails details, Exception? exception = null)
-    {
-        switch (details.Decision)
-        {
-            case EventDeliveryLogDecisions.Failed:
-            case EventDeliveryLogDecisions.BackoffBudgetExhausted:
-                _logger.EventDeliveryDecisionError(exception!, details);
-                break;
-            case EventDeliveryLogDecisions.Retry:
-            case EventDeliveryLogDecisions.AbortedTimeout:
-                _logger.EventDeliveryDecisionWarning(exception!, details);
-                break;
-            default:
-                _logger.EventDeliveryDecisionInformation(details);
-                break;
-        }
-    }
-
-    /// <summary>
-    /// ログ用のエラー分類コード（例外種別・SQLSTATE 等の短い識別子）。
-    /// </summary>
-    private static string MapErrorCode(Exception exception) =>
-        exception switch
-        {
-            TaskCanceledException => nameof(TaskCanceledException),
-            OperationCanceledException => nameof(OperationCanceledException),
-            TimeoutException => nameof(TimeoutException),
-            DbUpdateException dbUpdateException =>
-                dbUpdateException.InnerException?.GetType().Name ?? nameof(DbUpdateException),
-            _ => exception.GetType().Name
-        };
-
-    /// <summary>
-    /// <c>event_delivery_dedup</c> に RECEIVED を先行挿入する。一意制約違反時は既存行を読み、
-    /// 既に APPLIED なら true（呼び出し側は即 return）。それ以外は false（処理継続）。
-    /// DB 一時障害時は設定に従い段階的バックオフで再試行する（タイムアウト系は再試行しない）。
-    /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Critical Code Smell",
-        "S3776:Cognitive Complexity of methods should not be too high",
-        Justification = "イベント配送 dedup の再試行・ログ分岐を一箇所に集約している。")]
-    private async Task<bool> TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(
-        Guid executionId,
-        Guid clientEventId,
-        CancellationToken cancellationToken)
-    {
-        var retryOptions = _eventDeliveryRetryOptions.Value;
-        var traceId = GetTraceIdOrEmpty();
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var acceptedAt = DateTime.UtcNow;
-        var row = new EventDeliveryDedupRow
-        {
-            TenantId = tenantId,
-            ExecutionId = executionId,
-            ClientEventId = clientEventId,
-            BatchId = null,
-            Status = EventDeliveryDedupStatuses.Received,
-            AcceptedAt = acceptedAt,
-            AppliedAt = null,
-            ErrorCode = null,
-            UpdatedAt = acceptedAt
-        };
-
-        var totalBackoffMs = 0;
-
-        for (var attempt = 1; attempt <= retryOptions.MaxAttempts; attempt++)
-        {
-            var attemptStopwatch = Stopwatch.StartNew();
-            try
-            {
-                await _executor.ExecuteReadCommittedAsync(
-                    async (uow, innerCt) =>
-                    {
-                        await _eventDeliveryDedup.AddReceivedAsync(uow, row, innerCt).ConfigureAwait(false);
-                    },
-                    cancellationToken).ConfigureAwait(false);
-                attemptStopwatch.Stop();
-                LogEventDeliveryDecision(new EventDeliveryDecisionDetails
-                {
-                    TraceId = traceId,
-                    TenantId = tenantId,
-                    ExecutionId = executionId,
-                    ClientEventId = clientEventId,
-                    Decision = EventDeliveryLogDecisions.Inserted,
-                    Attempt = attempt,
-                    ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
-                    ErrorCode = EventDeliveryLogErrorCodes.None,
-                });
-                return false;
-            }
-            catch (DbUpdateException dbUpdateException)
-                when (EventDeliveryRetryPolicy.IsUniqueConstraintViolation(dbUpdateException))
-            {
-                attemptStopwatch.Stop();
-                LogEventDeliveryDecision(new EventDeliveryDecisionDetails
-                {
-                    TraceId = traceId,
-                    TenantId = tenantId,
-                    ExecutionId = executionId,
-                    ClientEventId = clientEventId,
-                    Decision = EventDeliveryLogDecisions.DuplicateKey,
-                    Attempt = attempt,
-                    ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
-                    ErrorCode = EventDeliveryLogErrorCodes.UniqueViolation,
-                });
-
-                var existing = await _executor.ExecuteReadOnlyAsync(
-                    (uow, innerCt) => _eventDeliveryDedup.FindAsync(uow, tenantId, executionId, clientEventId, innerCt),
-                    cancellationToken).ConfigureAwait(false);
-                if (existing is { Status: EventDeliveryDedupStatuses.Applied })
-                    return true;
-
-                if (existing is null)
-                    throw;
-
-                return false;
-            }
-            catch (Exception exception)
-                when (EventDeliveryRetryPolicy.IsNonRetryableTimeoutOrCancellation(exception))
-            {
-                attemptStopwatch.Stop();
-                LogEventDeliveryDecision(
-                    new EventDeliveryDecisionDetails
-                    {
-                        TraceId = traceId,
-                        TenantId = tenantId,
-                        ExecutionId = executionId,
-                        ClientEventId = clientEventId,
-                        Decision = EventDeliveryLogDecisions.AbortedTimeout,
-                        Attempt = attempt,
-                        ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
-                        ErrorCode = MapErrorCode(exception),
-                    },
-                    exception);
-                throw;
-            }
-            catch (Exception exception) when (
-                EventDeliveryRetryPolicy.IsTransientInfrastructureFailure(exception)
-                && attempt < retryOptions.MaxAttempts)
-            {
-                attemptStopwatch.Stop();
-                LogEventDeliveryDecision(
-                    new EventDeliveryDecisionDetails
-                    {
-                        TraceId = traceId,
-                        TenantId = tenantId,
-                        ExecutionId = executionId,
-                        ClientEventId = clientEventId,
-                        Decision = EventDeliveryLogDecisions.Retry,
-                        Attempt = attempt,
-                        ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
-                        ErrorCode = MapErrorCode(exception),
-                    },
-                    exception);
-
-                var failureIndex = attempt - 1;
-                var delayMs = EventDeliveryRetryPolicy.ComputeBackoffDelayMs(
-                    failureIndex,
-                    retryOptions,
-                    Random.Shared);
-
-                if (retryOptions.MaxTotalBackoffMs > 0)
-                {
-                    var remainingBudgetMs = retryOptions.MaxTotalBackoffMs - totalBackoffMs;
-                    if (remainingBudgetMs <= 0)
-                    {
-                        attemptStopwatch.Stop();
-                        LogEventDeliveryDecision(
-                            new EventDeliveryDecisionDetails
-                            {
-                                TraceId = traceId,
-                                TenantId = tenantId,
-                                ExecutionId = executionId,
-                                ClientEventId = clientEventId,
-                                Decision = EventDeliveryLogDecisions.BackoffBudgetExhausted,
-                                Attempt = attempt,
-                                ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
-                                ErrorCode = EventDeliveryLogDecisions.BackoffBudgetExhausted,
-                            },
-                            exception);
-                        throw new InvalidOperationException(
-                            "Event delivery insert retry stopped: total backoff budget exhausted.",
-                            exception);
-                    }
-
-                    delayMs = Math.Min(delayMs, remainingBudgetMs);
-                }
-
-                totalBackoffMs += delayMs;
-                if (delayMs > 0)
-                    await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                attemptStopwatch.Stop();
-                LogEventDeliveryDecision(
-                    new EventDeliveryDecisionDetails
-                    {
-                        TraceId = traceId,
-                        TenantId = tenantId,
-                        ExecutionId = executionId,
-                        ClientEventId = clientEventId,
-                        Decision = EventDeliveryLogDecisions.Failed,
-                        Attempt = attempt,
-                        ElapsedMs = attemptStopwatch.ElapsedMilliseconds,
-                        ErrorCode = MapErrorCode(exception),
-                    },
-                    exception);
-                throw;
-            }
-        }
-
-        throw new InvalidOperationException("Event delivery insert retry loop ended unexpectedly.");
     }
 
     /// <summary>同一プロセス Start の入力束。</summary>

--- a/core/application/Statevia.Core.Application/Services/ExecutionService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionService.cs
@@ -7,9 +7,6 @@ namespace Statevia.Core.Application.Services;
 
 internal sealed class ExecutionService : IExecutionService
 {
-    /// <summary>Worker が 1 Load を待つときのポーリング間隔。</summary>
-    private static readonly TimeSpan LocalExecutionLoadPollInterval = TimeSpan.FromMilliseconds(250);
-
     /// <summary>実行グラフ JSON のプロパティ名（投影・Engine export 共通）。</summary>
     private static class ExecutionGraphJsonProperties
     {
@@ -51,6 +48,8 @@ internal sealed class ExecutionService : IExecutionService
     private readonly ExecutionLifecycleCommandService _lifecycle;
     private readonly ExecutionWaitEventService _waitEvents;
     private readonly ExecutionCheckpointService _checkpoints;
+    private readonly ExecutionOwnershipService _ownershipSessions;
+    private readonly ExecutionRecoveryService _recovery;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
@@ -83,6 +82,8 @@ internal sealed class ExecutionService : IExecutionService
         ExecutionLifecycleCommandService lifecycle,
         ExecutionWaitEventService waitEvents,
         ExecutionCheckpointService checkpoints,
+        ExecutionOwnershipService ownershipSessions,
+        ExecutionRecoveryService recovery,
         IExecutionWorkQueue? workQueue = null,
         ExecutionOwnershipTracker? ownershipTracker = null,
         IForkChildExecutionCoordinator? forkChildCoordinator = null)
@@ -115,6 +116,8 @@ internal sealed class ExecutionService : IExecutionService
         _lifecycle = lifecycle;
         _waitEvents = waitEvents;
         _checkpoints = checkpoints;
+        _ownershipSessions = ownershipSessions;
+        _recovery = recovery;
         _forkChildCoordinator = forkChildCoordinator;
     }
 
@@ -160,184 +163,28 @@ internal sealed class ExecutionService : IExecutionService
     /// <inheritdoc />
     public Task PersistCheckpointKeepLoadedAsync(string engineExecutionId, CancellationToken ct) =>
         _checkpoints.PersistCheckpointKeepLoadedAsync(engineExecutionId, ct);
-
-
     /// <inheritdoc />
-    public async Task<long?> BeginOwnedSessionAsync(
+    public Task<long?> BeginOwnedSessionAsync(
         Guid executionId,
         string workerId,
         TimeSpan leaseDuration,
-        CancellationToken ct)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(workerId);
-        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(leaseDuration, TimeSpan.Zero);
-
-        var leaseUntil = DateTime.UtcNow.Add(leaseDuration);
-        var generation = await _executor.ExecuteReadCommittedAsync(
-            async (uow, innerCt) =>
-            {
-                var seed = new ExecutionCheckpointDocument
-                {
-                    ExecutionId = executionId,
-                    CheckpointJson = "{}",
-                    SchemaVersion = ExecutionRuntimeCheckpoint.CurrentSchemaVersion,
-                    UpdatedAt = DateTime.UtcNow
-                };
-                return await _checkpointStore.TryAcquireOwnershipAsync(
-                        uow,
-                        executionId,
-                        workerId,
-                        leaseUntil,
-                        seed,
-                        innerCt)
-                    .ConfigureAwait(false);
-            },
-            ct).ConfigureAwait(false);
-
-        if (generation is long gen)
-            _ownership.Set(executionId, workerId, gen);
-
-        return generation;
-    }
-
+        CancellationToken ct) =>
+        _ownershipSessions.BeginOwnedSessionAsync(executionId, workerId, leaseDuration, ct);
     /// <inheritdoc />
-    public async Task<bool> RenewOwnedSessionLeaseAsync(
+    public Task<bool> RenewOwnedSessionLeaseAsync(
         Guid executionId,
         TimeSpan leaseDuration,
-        CancellationToken ct)
-    {
-        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(leaseDuration, TimeSpan.Zero);
-        // Wait Unload 済みでトラッカーが空なら延長不要（失敗扱いにすると heartbeat が誤キャンセルする）。
-        if (!_ownership.TryGet(executionId, out _, out var generation))
-            return true;
-
-        var leaseUntil = DateTime.UtcNow.Add(leaseDuration);
-        return await _executor.ExecuteReadCommittedAsync(
-            (uow, innerCt) => _checkpointStore.TryRenewOwnershipLeaseAsync(
-                uow,
-                executionId,
-                generation,
-                leaseUntil,
-                innerCt),
-            ct).ConfigureAwait(false);
-    }
-
+        CancellationToken ct) =>
+        _ownershipSessions.RenewOwnedSessionLeaseAsync(executionId, leaseDuration, ct);
     /// <inheritdoc />
-    public async Task EndOwnedSessionAsync(Guid executionId, CancellationToken ct)
-    {
-        if (!_ownership.TryGet(executionId, out _, out var generation))
-            return;
-
-        try
-        {
-            await _executor.ExecuteReadCommittedAsync(
-                (uow, innerCt) => _checkpointStore.TryClearOwnershipAsync(
-                    uow,
-                    executionId,
-                    generation,
-                    innerCt),
-                ct).ConfigureAwait(false);
-        }
-        finally
-        {
-            _ownership.Clear(executionId);
-        }
-    }
-
+    public Task EndOwnedSessionAsync(Guid executionId, CancellationToken ct) =>
+        _ownershipSessions.EndOwnedSessionAsync(executionId, ct);
     /// <inheritdoc />
-    public Task AbandonLocalOwnedSessionAsync(Guid executionId)
-    {
-        _ownership.Clear(executionId);
-        var engineId = executionId.ToString();
-        try
-        {
-            _engine.Unload(engineId);
-        }
-#pragma warning disable CA1031 // ローカル放棄はベストエフォート。Unload 失敗で Worker を止めない。
-        catch (Exception exception)
-#pragma warning restore CA1031
-        {
-            _logger.UnloadDuringAbandon(exception, executionId);
-        }
-
-        return Task.CompletedTask;
-    }
-
+    public Task AbandonLocalOwnedSessionAsync(Guid executionId) =>
+        _ownershipSessions.AbandonLocalOwnedSessionAsync(executionId);
     /// <inheritdoc />
-    public async Task AwaitLocalExecutionLoadAsync(Guid executionId, CancellationToken ct)
-    {
-        var engineId = executionId.ToString();
-        while (true)
-        {
-            ct.ThrowIfCancellationRequested();
-            var snapshot = _engine.GetSnapshot(engineId);
-            if (snapshot is null)
-                return;
-
-            if (snapshot.IsCompleted || snapshot.IsCancelled || snapshot.IsFailed)
-            {
-                // 終端後に Unload すると投影キューが engine 不在でスキップし、
-                // Start 直後の不完全 graph のまま Completed だけ残る。最終投影を先に確定する。
-                await _projection.DrainAsync(executionId, ct).ConfigureAwait(false);
-                await UpdateProjectionFromEngineAsync(executionId, ct).ConfigureAwait(false);
-                _engine.Unload(engineId);
-                return;
-            }
-
-            var checkpoint = _engine.ExportCheckpoint(engineId);
-            // recovery hydrate 後など、PendingWaits があるのに Unload されていない場合がある。
-            if (checkpoint is { PendingWaits.Count: > 0 }
-                && !HasRunningNonWaitNodes(_engine.ExportExecutionGraph(engineId)))
-            {
-                var waitNodeId = checkpoint.PendingWaits[0].NodeId;
-                await _checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineId, waitNodeId, ct)
-                    .ConfigureAwait(false);
-                return;
-            }
-
-            await Task.Delay(LocalExecutionLoadPollInterval, ct).ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>Wait 以外で未完了の実行中ノードがあるか。</summary>
-    private static bool HasRunningNonWaitNodes(string graphJson)
-    {
-        try
-        {
-            using var document = JsonDocument.Parse(graphJson);
-            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
-                || nodes.ValueKind != JsonValueKind.Array)
-            {
-                return false;
-            }
-
-            return nodes.EnumerateArray().Any(node =>
-            {
-                var nodeType = node.TryGetProperty(ExecutionGraphJsonProperties.NodeType, out var typeEl)
-                    ? typeEl.GetString()
-                    : null;
-                if (string.Equals(nodeType, "Wait", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(nodeType, "EventWait", StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-
-                if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
-                    && completedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
-                {
-                    return false;
-                }
-
-                // startedAt があり未完了なら実行中とみなす。
-                return node.TryGetProperty(ExecutionGraphJsonProperties.StartedAt, out var startedAt)
-                    && startedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined;
-            });
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
+    public Task AwaitLocalExecutionLoadAsync(Guid executionId, CancellationToken ct) =>
+        _ownershipSessions.AwaitLocalExecutionLoadAsync(executionId, ct);
     /// <inheritdoc />
     public Task PublishEventAsync(
         string idOrUuid,
@@ -692,79 +539,13 @@ internal sealed class ExecutionService : IExecutionService
 
         await _projection.EnqueueAsync(parentExecutionId, ct).ConfigureAwait(false);
     }
-
     /// <inheritdoc />
-    public async Task RecoverExecutionAsync(
+    public Task RecoverExecutionAsync(
         Guid executionId,
         CommandRequestContext requestContext,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(requestContext);
-        await EnsureExecutionsWriteAsync(ct).ConfigureAwait(false);
+        CancellationToken ct) =>
+        _recovery.RecoverExecutionAsync(executionId, requestContext, ct);
 
-        var tenantId = _tenantContext.GetRequiredTenantId();
-        var execution = await _executor.ExecuteReadOnlyAsync(
-            (uow, innerCt) => _executions.GetByIdAsync(uow, tenantId, executionId, innerCt),
-            ct).ConfigureAwait(false);
-        if (execution is null)
-            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
-
-        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
-
-        if (ExecutionLifecycleCommandService.IsTerminalExecutionProjectionStatus(execution.Status))
-            return;
-
-        // Worker が BeginOwnedSession 済み前提。hydrate 後、完了フロンティア／PendingWaits から継続する。
-        await _lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(executionId, execution, ct).ConfigureAwait(false);
-
-        var engineId = executionId.ToString();
-        // ImportCheckpoint が起動した継続（Wait 復元または完了フロンティア遷移）が落ち着くのを待つ。
-        await _waitEvents.WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
-
-        var (status, cancelRequested, graphJson) = _projection.BuildProjectionFromEngine(executionId);
-        await _executor.ExecuteReadCommittedAsync(
-            async (uow, innerCt) =>
-            {
-                await _executions
-                    .UpdateExecutionAndSnapshotAsync(uow, executionId, status, cancelRequested, graphJson, innerCt)
-                    .ConfigureAwait(false);
-                await _projection.SyncOperationalProjectionAsync(
-                        uow,
-                        executionId,
-                        tenantId,
-                        status,
-                        graphJson,
-                        nodeIdToClear: null,
-                        innerCt)
-                    .ConfigureAwait(false);
-
-                if (await _checkpoints.ShouldDiscardRuntimeCheckpointAsync(executionId, status, graphJson, innerCt)
-                        .ConfigureAwait(false))
-                {
-                    await _checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
-                            uow,
-                            engineId,
-                            executionId,
-                            innerCt)
-                        .ConfigureAwait(false);
-                }
-                else
-                {
-                    await _lifecycle.UpsertRuntimeCheckpointAsync(uow, engineId, executionId, innerCt)
-                        .ConfigureAwait(false);
-                }
-            },
-            ct).ConfigureAwait(false);
-
-        // Wait 復元のみで継続が無い場合、ここで Unload しないと Worker Await が解放されない。
-        var restored = _engine.ExportCheckpoint(engineId);
-        if (restored is { PendingWaits.Count: > 0 }
-            && !HasRunningNonWaitNodes(_engine.ExportExecutionGraph(engineId)))
-        {
-            await _checkpoints.PersistCheckpointAndUnloadByEngineIdAsync(engineId, restored.PendingWaits[0].NodeId, ct)
-                .ConfigureAwait(false);
-        }
-    }
 
     /// <summary>
     /// 物理 Join 完了後、Join ノード完了・decide Wait 登録・Unload・終端のいずれかまで待つ。

--- a/core/application/Statevia.Core.Application/Services/ExecutionWaitEventService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionWaitEventService.cs
@@ -18,7 +18,7 @@ namespace Statevia.Core.Application.Services;
 /// <param name="idGenerator">ID 生成。</param>
 /// <param name="executions">executions 永続化。</param>
 /// <param name="executionWaits">wait 行。</param>
-/// <param name="mutationAuth">実行ミューテーション認可。</param>
+/// <param name="authorization">横断認可。</param>
 /// <param name="tenantContext">テナント文脈。</param>
 /// <param name="dedup">command_dedup。</param>
 /// <param name="eventStore">event_store。</param>
@@ -28,7 +28,8 @@ namespace Statevia.Core.Application.Services;
 /// <param name="logger">構造化ログ。</param>
 /// <param name="idempotency">冪等サービス。</param>
 /// <param name="projection">投影オーケストレータ。</param>
-/// <param name="lifecycle">ライフサイクル（Engine hydrate / checkpoint upsert）。</param>
+/// <param name="lifecycle">ライフサイクル（checkpoint upsert）。</param>
+/// <param name="engineSession">Engine Load / hydrate。</param>
 /// <param name="checkpoints">checkpoint 寿命・破棄。</param>
 /// <param name="forkJoin">親 Physical Join 再評価。</param>
 /// <param name="forkChildCoordinator">Fork 子 Wait 配送（任意）。</param>
@@ -42,7 +43,7 @@ internal sealed class ExecutionWaitEventService(
     IIdGenerator idGenerator,
     IExecutionRepository executions,
     IExecutionWaitRepository executionWaits,
-    IExecutionMutationAuthorization mutationAuth,
+    ExecutionAuthorizationGuard authorization,
     ITenantContextAccessor tenantContext,
     ICommandDedupRepository dedup,
     IEventStoreRepository eventStore,
@@ -53,6 +54,7 @@ internal sealed class ExecutionWaitEventService(
     ExecutionIdempotencyService idempotency,
     ExecutionProjectionOrchestrator projection,
     ExecutionLifecycleCommandService lifecycle,
+    ExecutionEngineSession engineSession,
     ExecutionCheckpointService checkpoints,
     ExecutionForkJoinCoordinator forkJoin,
     IForkChildExecutionCoordinator? forkChildCoordinator = null)
@@ -114,7 +116,7 @@ internal sealed class ExecutionWaitEventService(
             return;
         }
 
-        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
         await projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
 
@@ -123,7 +125,7 @@ internal sealed class ExecutionWaitEventService(
         if (await idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
             return;
 
-        await lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
+        await engineSession.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
 
         // PublishEvent 復帰時点ではグラフ上の Wait 完了が未反映になり得るため、発行前の nodeId で先行削除する。
         // グラフ解析失敗時は永続化済み wait 行からフォールバック解決する（Applied 時のみ）。
@@ -336,7 +338,7 @@ internal sealed class ExecutionWaitEventService(
             return;
         }
 
-        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
+        await authorization.EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
 
         await projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
 
@@ -352,7 +354,7 @@ internal sealed class ExecutionWaitEventService(
             return;
         }
 
-        await lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
+        await engineSession.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
 
         // Resume 正本: nodeId + eventName。wait 行は nodeId で先行削除する。
         // 許可外イベント・非アクティブ Wait などは 422。
@@ -896,15 +898,6 @@ internal sealed class ExecutionWaitEventService(
         }
 
         return soleMatchingNodeId;
-    }
-
-    private Task EnsureExecutionMutationWriteAsync(ExecutionRow execution, CancellationToken ct)
-    {
-        var snapshot = ExecutionSecuritySnapshotJson.TryDeserialize(execution.SecuritySnapshotJson);
-        return mutationAuth.EnsureMutationPermissionAsync(
-            snapshot,
-            RuntimePermissionRequirements.ExecutionsWrite,
-            ct);
     }
 
 }

--- a/core/application/Statevia.Core.Application/Services/ExecutionWaitEventService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionWaitEventService.cs
@@ -1,0 +1,929 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Core.Application.Services;
+
+/// <summary>
+/// Wait / イベント適用（Publish / Resume）と子 Wait リダイレクト入口。
+/// </summary>
+/// <remarks>
+/// <para><see cref="ExecutionService"/> Facade から委譲される。HTTP 契約は変更しない。</para>
+/// <para>物理子終端 <c>child.completed</c> の Join 再評価は Facade 側コールバックへ委譲する（Fork/Join 分離まで）。</para>
+/// <para>checkpoint 寿命の破棄判定は Facade フックとして Resume 永続化時に受け取る。</para>
+/// </remarks>
+/// <param name="engine">実行エンジン。</param>
+/// <param name="displayIds">表示 ID 解決。</param>
+/// <param name="idGenerator">ID 生成。</param>
+/// <param name="executions">executions 永続化。</param>
+/// <param name="executionWaits">wait 行。</param>
+/// <param name="mutationAuth">実行ミューテーション認可。</param>
+/// <param name="tenantContext">テナント文脈。</param>
+/// <param name="dedup">command_dedup。</param>
+/// <param name="eventStore">event_store。</param>
+/// <param name="eventDeliveryDedup">event_delivery_dedup。</param>
+/// <param name="executor">トランザクション実行。</param>
+/// <param name="mutationPersistence">Serializable 永続化。</param>
+/// <param name="logger">構造化ログ。</param>
+/// <param name="idempotency">冪等サービス。</param>
+/// <param name="projection">投影オーケストレータ。</param>
+/// <param name="lifecycle">ライフサイクル（Engine hydrate / checkpoint upsert）。</param>
+/// <param name="forkChildCoordinator">Fork 子 Wait 配送（任意）。</param>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Major Code Smell",
+    "S107:Methods should not have too many parameters",
+    Justification = "DI による明示的コンストラクタ注入。")]
+internal sealed class ExecutionWaitEventService(
+    IExecutionEngine engine,
+    IDisplayIdService displayIds,
+    IIdGenerator idGenerator,
+    IExecutionRepository executions,
+    IExecutionWaitRepository executionWaits,
+    IExecutionMutationAuthorization mutationAuth,
+    ITenantContextAccessor tenantContext,
+    ICommandDedupRepository dedup,
+    IEventStoreRepository eventStore,
+    IEventDeliveryDedupRepository eventDeliveryDedup,
+    ICoreTransactionExecutor executor,
+    IExecutionMutationPersistence mutationPersistence,
+    ILogger<ExecutionWaitEventService> logger,
+    ExecutionIdempotencyService idempotency,
+    ExecutionProjectionOrchestrator projection,
+    ExecutionLifecycleCommandService lifecycle,
+    IForkChildExecutionCoordinator? forkChildCoordinator = null)
+{
+    /// <summary>HTTP 204 No Content。</summary>
+    private const int HttpStatus204NoContent = 204;
+
+    private static class ExecutionGraphJsonProperties
+    {
+        internal const string Nodes = "nodes";
+        internal const string CompletedAt = "completedAt";
+        internal const string NodeId = "nodeId";
+        internal const string NodeType = "nodeType";
+    }
+
+
+    /// <summary>
+    /// 名前付きイベントを Engine へ発行し、投影・Wait clear・delivery / dedup を永続化する。
+    /// </summary>
+    /// <param name="idOrUuid">表示 ID または UUID。</param>
+    /// <param name="eventName">イベント名。</param>
+    /// <param name="idempotencyKey">冪等キー（任意）。</param>
+    /// <param name="requestContext">HTTP / Worker 文脈。</param>
+    /// <param name="ct">キャンセル。</param>
+    public async Task PublishEventAsync(
+        string idOrUuid,
+        string eventName,
+        string? idempotencyKey,
+        CommandRequestContext requestContext,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(requestContext);
+
+        var tenantKey = tenantContext.GetRequiredTenantKey();
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var dedupKey = idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
+
+        if (await idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
+            return;
+
+        var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
+        if (uuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        var execution = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt),
+            ct).ConfigureAwait(false);
+        if (execution is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        // 親 ID への PublishEvent も子 Wait へ振り替える（要件4）。
+        if (await TryRedirectPublishEventToChildWaitAsync(
+                uuid.Value,
+                eventName,
+                idempotencyKey,
+                requestContext,
+                ct).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
+
+        await projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
+
+        var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, idGenerator);
+
+        if (await idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
+            return;
+
+        await lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
+
+        // PublishEvent 復帰時点ではグラフ上の Wait 完了が未反映になり得るため、発行前の nodeId で先行削除する。
+        // グラフ解析失敗時は永続化済み wait 行からフォールバック解決する（Applied 時のみ）。
+        var engineId = uuid.Value.ToString();
+        var prePublishGraphJson = engine.ExportExecutionGraph(engineId);
+
+        // PublishEvent シム条件外（複数 Wait / 複数 events 等）は設計どおり 422。
+        var publishApply = InvokeEngineWaitMutation(
+            () => engine.PublishEvent(engineId, eventName, clientEventId));
+        var skipEventAppend = publishApply.IsAlreadyApplied;
+        var nodeIdToClearFromGraph = publishApply.IsApplied
+            ? TryResolveSoleActiveWaitNodeId(prePublishGraphJson)
+            : null;
+        await AwaitEngineReadyAfterWaitClearAsync(
+                engineId,
+                publishApply.IsApplied ? nodeIdToClearFromGraph : null,
+                ct)
+            .ConfigureAwait(false);
+
+        var (pubStatus, pubCancel, pubGraphJson) = projection.BuildProjectionFromEngine(uuid.Value);
+        var publishedPayload = JsonSerializer.Serialize(
+            new { tenantId, name = eventName },
+            JsonSerializerProfiles.CamelCase);
+
+        await mutationPersistence.ExecuteSerializableWithRetryAsync(
+            tenantId,
+            uuid.Value,
+            clientEventId,
+            async (uow, ctInner) =>
+            {
+                var nodeIdToClear = await ResolvePublishNodeIdToClearAsync(
+                        uow,
+                        uuid.Value,
+                        publishApply.IsApplied,
+                        nodeIdToClearFromGraph,
+                        eventName,
+                        ctInner)
+                    .ConfigureAwait(false);
+
+                await executions
+                    .UpdateExecutionAndSnapshotAsync(uow, uuid.Value, pubStatus, pubCancel, pubGraphJson, ctInner)
+                    .ConfigureAwait(false);
+                await projection.SyncOperationalProjectionAsync(
+                        uow,
+                        uuid.Value,
+                        tenantId,
+                        pubStatus,
+                        pubGraphJson,
+                        nodeIdToClear,
+                        ctInner)
+                    .ConfigureAwait(false);
+                await AppendEventPublishedAsync(
+                        uow,
+                        uuid.Value,
+                        clientEventId,
+                        publishedPayload,
+                        skipEventAppend,
+                        ctInner)
+                    .ConfigureAwait(false);
+
+                if (dedupKey is { } saveKey)
+                {
+                    var now = DateTime.UtcNow;
+                    await dedup.SaveAsync(
+                        uow,
+                        new CommandDedupRow
+                        {
+                            DedupKey = saveKey.DedupKey,
+                            Endpoint = saveKey.Endpoint,
+                            IdempotencyKey = saveKey.IdempotencyKey,
+                            RequestHash = null,
+                            StatusCode = HttpStatus204NoContent,
+                            ResponseBody = null,
+                            CreatedAt = now,
+                            ExpiresAt = now.AddHours(24)
+                        },
+                        ctInner).ConfigureAwait(false);
+                }
+
+                var nowUtc = DateTime.UtcNow;
+                await eventDeliveryDedup.TryUpdateStatusAsync(
+                    uow,
+                    tenantId,
+                    uuid.Value,
+                    clientEventId,
+                    new EventDeliveryDedupStatusUpdate(
+                        EventDeliveryDedupStatuses.Applied,
+                        nowUtc,
+                        AppliedAt: nowUtc,
+                        ErrorCode: null),
+                    ctInner).ConfigureAwait(false);
+            },
+            ct).ConfigureAwait(false);
+
+        // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
+        if (publishApply.IsApplied)
+            await projection.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Publish / Resume で Wait を消したあと、完了と後続 quiesce を待つ。
+    /// </summary>
+    private async Task AwaitEngineReadyAfterWaitClearAsync(
+        string engineId,
+        string? nodeIdToClear,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(nodeIdToClear))
+            return;
+
+        await WaitForEngineWaitNodeCompletedAsync(engineId, nodeIdToClear, ct).ConfigureAwait(false);
+        // Wait 完了直後の中間グラフ（次 Task RUNNING）を永続化すると完了投影を上書きし固着する。
+        await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// グラフ解決できなかった場合に永続 wait 行から削除対象 nodeId を補完する。
+    /// </summary>
+    private async Task<string?> ResolvePublishNodeIdToClearAsync(
+        ICoreUnitOfWork uow,
+        Guid executionId,
+        bool publishApplied,
+        string? nodeIdFromGraph,
+        string eventName,
+        CancellationToken ct)
+    {
+        if (!publishApplied || !string.IsNullOrWhiteSpace(nodeIdFromGraph))
+            return nodeIdFromGraph;
+
+        var persistedWaits = await executionWaits
+            .ListByExecutionIdAsync(uow, executionId, ct)
+            .ConfigureAwait(false);
+        return TryResolveWaitNodeIdToClearFromPersisted(persistedWaits, eventName);
+    }
+
+    /// <summary>EventPublished を通常 append または clientEvent 冪等 append する。</summary>
+    private async Task AppendEventPublishedAsync(
+        ICoreUnitOfWork uow,
+        Guid executionId,
+        Guid clientEventId,
+        string publishedPayload,
+        bool skipEventAppend,
+        CancellationToken ct)
+    {
+        if (!skipEventAppend)
+        {
+            await eventStore
+                .AppendAsync(uow, executionId, EventStoreEventType.EventPublished, publishedPayload, ct)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        await eventStore.TryAppendIfAbsentByClientEventAsync(
+            uow,
+            executionId,
+            clientEventId,
+            EventStoreEventType.EventPublished,
+            publishedPayload,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Wait ノードを Resume する。子 Wait リダイレクトと <c>child.completed</c> Join コールバックを含む。
+    /// </summary>
+    /// <param name="idOrUuid">表示 ID または UUID。</param>
+    /// <param name="nodeId">Wait ノード ID。</param>
+    /// <param name="resumeKey">Resume イベント名。</param>
+    /// <param name="idempotencyKey">冪等キー（任意）。</param>
+    /// <param name="requestContext">HTTP / Worker 文脈。</param>
+    /// <param name="handleChildCompletedResume">物理子終端時の Join 再評価（Facade）。</param>
+    /// <param name="shouldDiscardRuntimeCheckpoint">checkpoint 破棄候補判定（Facade）。</param>
+    /// <param name="discardOrRefreshRuntimeCheckpoint">checkpoint 破棄または所有中更新（Facade）。</param>
+    /// <param name="ct">キャンセル。</param>
+    public async Task ResumeNodeAsync(
+        string idOrUuid,
+        string nodeId,
+        string? resumeKey,
+        string? idempotencyKey,
+        CommandRequestContext requestContext,
+        Func<Guid, ExecutionRow, string, CancellationToken, Task> handleChildCompletedResume,
+        Func<Guid, string, string, CancellationToken, Task<bool>> shouldDiscardRuntimeCheckpoint,
+        Func<ICoreUnitOfWork, string, Guid, CancellationToken, Task<bool>> discardOrRefreshRuntimeCheckpoint,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(handleChildCompletedResume);
+        ArgumentNullException.ThrowIfNull(shouldDiscardRuntimeCheckpoint);
+        ArgumentNullException.ThrowIfNull(discardOrRefreshRuntimeCheckpoint);
+
+        ArgumentNullException.ThrowIfNull(requestContext);
+        ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resumeKey);
+
+        var eventName = resumeKey.Trim();
+        var tenantKey = tenantContext.GetRequiredTenantKey();
+        var tenantId = tenantContext.GetRequiredTenantId();
+        var dedupKey = idempotency.CreateKey(tenantKey, idempotencyKey, requestContext.Method, requestContext.Path);
+
+        if (await idempotency.HasValidCommandDedupAsync(dedupKey, ct).ConfigureAwait(false))
+            return;
+
+        var uuid = await displayIds.ResolveAsync(DisplayIdResourceTypes.Execution, idOrUuid, ct).ConfigureAwait(false);
+        if (uuid is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        var execution = await executor.ExecuteReadOnlyAsync(
+            (uow, innerCt) => executions.GetByIdAsync(uow, tenantId, uuid.Value, innerCt),
+            ct).ConfigureAwait(false);
+        if (execution is null)
+            throw new NotFoundException(ExecutionValidationMessages.ExecutionNotFound);
+
+        // 親 ID へ届いた分岐 Wait は子 execution へ振り替える（要件4）。
+        if (await TryRedirectResumeToChildWaitAsync(
+                uuid.Value,
+                nodeId,
+                eventName,
+                idempotencyKey,
+                requestContext,
+                handleChildCompletedResume,
+                shouldDiscardRuntimeCheckpoint,
+                discardOrRefreshRuntimeCheckpoint,
+                ct).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        await EnsureExecutionMutationWriteAsync(execution, ct).ConfigureAwait(false);
+
+        await projection.DrainAsync(uuid.Value, ct).ConfigureAwait(false);
+
+        var clientEventId = ClientEventIdResolver.FromIdempotencyKey(idempotencyKey, idGenerator);
+
+        if (await idempotency.TryBeginEventDeliveryOrAbortIfAlreadyAppliedAsync(uuid.Value, clientEventId, ct).ConfigureAwait(false))
+            return;
+
+        // 物理子終端の予約イベントは Wait Resume ではなく Join 再評価へ振る（D3）。
+        if (string.Equals(eventName, ExecutionWaitEventNames.ChildCompleted, StringComparison.Ordinal))
+        {
+            await handleChildCompletedResume(uuid.Value, execution, nodeId, ct).ConfigureAwait(false);
+            return;
+        }
+
+        await lifecycle.EnsureEngineRuntimeLoadedForMutationAsync(uuid.Value, execution, ct).ConfigureAwait(false);
+
+        // Resume 正本: nodeId + eventName。wait 行は nodeId で先行削除する。
+        // 許可外イベント・非アクティブ Wait などは 422。
+        var engineId = uuid.Value.ToString();
+        InvokeEngineWaitMutation(() => engine.ResumeWaitNode(engineId, nodeId, eventName));
+        // Resume のグラフ完了は非同期継続のため、投影取得前に Wait 完了を待つ。
+        await WaitForEngineWaitNodeCompletedAsync(engineId, nodeId, ct).ConfigureAwait(false);
+        // 続けて後続 Task が落ち着くまで待つ（Wait 完了直後の RUNNING 中間像の永続化を避ける）。
+        await WaitForEngineQuiescedAfterWaitAsync(engineId, ct).ConfigureAwait(false);
+
+        // Again → Fork の Suspend Unload 後は in-process snapshot が欠ける。SuspendHandler 投影を正とする。
+        var (engineStillLoaded, pubStatus, pubCancel, pubGraphJson) =
+            await ResolveProjectionAfterWaitResumeAsync(uuid.Value, ct).ConfigureAwait(false);
+
+        var publishedPayload = JsonSerializer.Serialize(
+            new { tenantId, name = eventName, nodeId },
+            JsonSerializerProfiles.CamelCase);
+
+        await PersistWaitResumeSideEffectsAsync(
+                new WaitResumePersistRequest(
+                    tenantId,
+                    uuid.Value,
+                    engineId,
+                    nodeId,
+                    clientEventId,
+                    dedupKey,
+                    engineStillLoaded,
+                    pubStatus,
+                    pubCancel,
+                    pubGraphJson,
+                    publishedPayload),
+                shouldDiscardRuntimeCheckpoint,
+                discardOrRefreshRuntimeCheckpoint,
+                ct)
+            .ConfigureAwait(false);
+
+        // 永続化中に進んだ Engine 完了を取りこぼさない（中間 RUNNING 上書きの保険）。
+        await projection.EnqueueAsync(uuid.Value, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Wait Resume 後の投影・checkpoint・event_store・dedup 永続化入力。</summary>
+    private readonly record struct WaitResumePersistRequest(
+        Guid TenantId,
+        Guid ExecutionId,
+        string EngineId,
+        string NodeId,
+        Guid ClientEventId,
+        CommandDedupKey? DedupKey,
+        bool EngineStillLoaded,
+        string PubStatus,
+        bool? PubCancel,
+        string PubGraphJson,
+        string PublishedPayload);
+
+    /// <summary>Wait Resume 後の投影・checkpoint・event_store・dedup を同一 tx で永続化する。</summary>
+    private async Task PersistWaitResumeSideEffectsAsync(
+        WaitResumePersistRequest request,
+        Func<Guid, string, string, CancellationToken, Task<bool>> shouldDiscardRuntimeCheckpoint,
+        Func<ICoreUnitOfWork, string, Guid, CancellationToken, Task<bool>> discardOrRefreshRuntimeCheckpoint,
+        CancellationToken ct)
+    {
+        await mutationPersistence.ExecuteSerializableWithRetryAsync(
+            request.TenantId,
+            request.ExecutionId,
+            request.ClientEventId,
+            async (uow, ctInner) =>
+            {
+                await executions
+                    .UpdateExecutionAndSnapshotAsync(
+                        uow,
+                        request.ExecutionId,
+                        request.PubStatus,
+                        request.PubCancel,
+                        request.PubGraphJson,
+                        ctInner)
+                    .ConfigureAwait(false);
+                await projection.SyncOperationalProjectionAsync(
+                        uow,
+                        request.ExecutionId,
+                        request.TenantId,
+                        request.PubStatus,
+                        request.PubGraphJson,
+                        nodeIdToClear: request.NodeId,
+                        ctInner)
+                    .ConfigureAwait(false);
+
+                if (request.EngineStillLoaded)
+                {
+                    if (await shouldDiscardRuntimeCheckpoint(
+                            request.ExecutionId,
+                            request.PubStatus,
+                            request.PubGraphJson,
+                            ctInner)
+                        .ConfigureAwait(false))
+                    {
+                        await discardOrRefreshRuntimeCheckpoint(
+                                uow,
+                                request.EngineId,
+                                request.ExecutionId,
+                                ctInner)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await lifecycle.UpsertRuntimeCheckpointAsync(
+                                uow,
+                                request.EngineId,
+                                request.ExecutionId,
+                                ctInner)
+                            .ConfigureAwait(false);
+                    }
+                }
+
+                await eventStore
+                    .AppendAsync(
+                        uow,
+                        request.ExecutionId,
+                        EventStoreEventType.EventPublished,
+                        request.PublishedPayload,
+                        ctInner)
+                    .ConfigureAwait(false);
+
+                if (request.DedupKey is { } saveKey)
+                {
+                    var now = DateTime.UtcNow;
+                    await dedup.SaveAsync(
+                        uow,
+                        new CommandDedupRow
+                        {
+                            DedupKey = saveKey.DedupKey,
+                            Endpoint = saveKey.Endpoint,
+                            IdempotencyKey = saveKey.IdempotencyKey,
+                            RequestHash = null,
+                            StatusCode = HttpStatus204NoContent,
+                            ResponseBody = null,
+                            CreatedAt = now,
+                            ExpiresAt = now.AddHours(24)
+                        },
+                        ctInner).ConfigureAwait(false);
+                }
+
+                var nowUtc = DateTime.UtcNow;
+                await eventDeliveryDedup.TryUpdateStatusAsync(
+                    uow,
+                    request.TenantId,
+                    request.ExecutionId,
+                    request.ClientEventId,
+                    new EventDeliveryDedupStatusUpdate(
+                        EventDeliveryDedupStatuses.Applied,
+                        nowUtc,
+                        AppliedAt: nowUtc,
+                        ErrorCode: null),
+                    ctInner).ConfigureAwait(false);
+            },
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Wait Resume 後の投影断面を Engine または DB（Unload 済み）から解決する。
+    /// </summary>
+    /// <returns>
+    /// Engine がメモリ上に残っているとき <c>engineStillLoaded</c> は true。
+    /// </returns>
+    private async Task<(bool EngineStillLoaded, string Status, bool? CancelRequested, string GraphJson)>
+        ResolveProjectionAfterWaitResumeAsync(Guid executionId, CancellationToken ct)
+    {
+        var (projectedStatus, projectedCancel, projectedGraphJson) = projection.BuildProjectionFromEngineForQueue(executionId);
+        if (projectedStatus is not null && projectedGraphJson is not null)
+        {
+            return (true, projectedStatus, projectedCancel, projectedGraphJson);
+        }
+
+        var unloadedSnapshot = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => executions.GetSnapshotByExecutionIdAsync(uow, executionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        var unloadedRow = await executor.ExecuteReadOnlyAsync(
+                (uow, innerCt) => executions.GetByExecutionIdAsync(uow, executionId, innerCt),
+                ct)
+            .ConfigureAwait(false);
+        if (unloadedSnapshot is null
+            || unloadedRow is null
+            || string.IsNullOrWhiteSpace(unloadedSnapshot.GraphJson))
+        {
+            throw new InvalidOperationException(
+                $"Cannot project execution '{executionId:D}': engine snapshot is missing after Resume unload.");
+        }
+
+        return (false, unloadedRow.Status, unloadedRow.CancelRequested, unloadedSnapshot.GraphJson);
+    }
+
+    /// <summary>
+    /// 親 ID の Resume を子 Wait へ振り替える。振り替えたとき true。
+    /// </summary>
+    private async Task<bool> TryRedirectResumeToChildWaitAsync(
+        Guid requestedExecutionId,
+        string nodeId,
+        string eventName,
+        string? idempotencyKey,
+        CommandRequestContext requestContext,
+        Func<Guid, ExecutionRow, string, CancellationToken, Task> handleChildCompletedResume,
+        Func<Guid, string, string, CancellationToken, Task<bool>> shouldDiscardRuntimeCheckpoint,
+        Func<ICoreUnitOfWork, string, Guid, CancellationToken, Task<bool>> discardOrRefreshRuntimeCheckpoint,
+        CancellationToken ct)
+    {
+        if (forkChildCoordinator is null)
+            return false;
+
+        if (string.Equals(eventName, ExecutionWaitEventNames.ChildCompleted, StringComparison.Ordinal))
+            return false;
+
+        var delivery = await forkChildCoordinator
+            .TryResolveChildWaitDeliveryAsync(requestedExecutionId, nodeId, eventName, ct)
+            .ConfigureAwait(false);
+        if (delivery is null)
+            return false;
+
+        await ResumeNodeAsync(
+                delivery.ExecutionId.ToString("D"),
+                delivery.NodeId,
+                delivery.EventName,
+                idempotencyKey,
+                requestContext,
+                handleChildCompletedResume,
+                shouldDiscardRuntimeCheckpoint,
+                discardOrRefreshRuntimeCheckpoint,
+                ct)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// 親 ID の PublishEvent を子 Wait へ振り替える。振り替えたとき true。
+    /// </summary>
+    private async Task<bool> TryRedirectPublishEventToChildWaitAsync(
+        Guid requestedExecutionId,
+        string eventName,
+        string? idempotencyKey,
+        CommandRequestContext requestContext,
+        CancellationToken ct)
+    {
+        if (forkChildCoordinator is null)
+            return false;
+
+        var delivery = await forkChildCoordinator
+            .TryResolveChildWaitDeliveryAsync(requestedExecutionId, nodeId: null, eventName, ct)
+            .ConfigureAwait(false);
+        if (delivery is null)
+            return false;
+
+        await PublishEventAsync(
+                delivery.ExecutionId.ToString("D"),
+                delivery.EventName,
+                idempotencyKey,
+                requestContext,
+                ct)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// Resume 適用後、対象 Wait ノードのグラフ完了が反映されるまで短く待つ。
+    /// </summary>
+    /// <remarks>
+    /// Engine 側の完了処理は <c>RunContinuationsAsynchronously</c> のため、
+    /// <see cref="IExecutionEngine.ResumeWaitNode"/> 復帰直後の投影は古い Wait を含み得る。
+    /// </remarks>
+    private async Task WaitForEngineWaitNodeCompletedAsync(
+        string engineExecutionId,
+        string nodeId,
+        CancellationToken ct)
+    {
+        const int maxAttempts = 200;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (engine.GetSnapshot(engineExecutionId) is null)
+                return;
+
+            var graphJson = engine.ExportExecutionGraph(engineExecutionId);
+            if (!TryGetGraphNodeCompletion(graphJson, nodeId, out var completed))
+            {
+                // ノードが無い（テスト用 stub 等）場合は待たない。
+                return;
+            }
+
+            if (completed)
+                return;
+
+            await Task.Delay(10, ct).ConfigureAwait(false);
+        }
+
+        logger.WaitNodeCompletionTimedOut(nodeId, engineExecutionId);
+    }
+
+    /// <summary>
+    /// Wait 再開後、後続状態の実行が落ち着くまで短く待つ。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="WaitForEngineWaitNodeCompletedAsync"/> は Wait の <c>completedAt</c> 時点で戻る。
+    /// その直後は <c>ProcessFact</c> → 次 Task の <c>AddNode</c> が走り、グラフは
+    /// 「Wait SUCCEEDED + 次 Task RUNNING」の中間像になり得る。
+    /// </para>
+    /// <para>
+    /// Resume / Publish がこの中間像を serializable トランザクションで永続化すると、
+    /// 後続の完了投影（noop 完了 → Completed）を上書きし、次ノードが RUNNING のまま固着する。
+    /// </para>
+    /// </remarks>
+    public async Task WaitForEngineQuiescedAfterWaitAsync(
+        string engineExecutionId,
+        CancellationToken ct)
+    {
+        const int maxAttempts = 200;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var snapshot = engine.GetSnapshot(engineExecutionId);
+            if (snapshot is null)
+                return;
+
+            if (snapshot.IsCompleted || snapshot.IsCancelled || snapshot.IsFailed)
+                return;
+
+            // ContinueRestoredWait は次 Task を ActiveStates に載せてから Wait を外すため、
+            // 後続実行中は Count > 0。空なら後続未起動または完了済み。
+            if (snapshot.ActiveStates.Count == 0)
+                return;
+
+            await Task.Delay(10, ct).ConfigureAwait(false);
+        }
+
+        logger.WaitResumeQuiesceTimedOut(engineExecutionId);
+    }
+
+    /// <summary>グラフ JSON 上の指定 nodeId の完了有無を取得する。</summary>
+    /// <returns>ノードが存在するとき <see langword="true"/>。</returns>
+    internal static bool TryGetGraphNodeCompletion(string graphJson, string nodeId, out bool completed)
+    {
+        completed = false;
+        if (string.IsNullOrWhiteSpace(graphJson) || string.IsNullOrWhiteSpace(nodeId))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(graphJson);
+            if (!document.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
+                || nodes.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            foreach (var node in nodes.EnumerateArray())
+            {
+                if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var idProp)
+                    || idProp.ValueKind != JsonValueKind.String
+                    || !string.Equals(idProp.GetString(), nodeId, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                completed = node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
+                    && completedAt.ValueKind is not JsonValueKind.Null
+                    && completedAt.ValueKind is not JsonValueKind.Undefined;
+                return true;
+            }
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Engine Wait 操作の <see cref="InvalidOperationException"/> を API 422 に写像する。
+    /// </summary>
+    /// <remarks>
+    /// PublishEvent シム条件外・Resume の許可外イベントなどは Engine が
+    /// <see cref="InvalidOperationException"/> を投げる。クライアント向けには
+    /// <see cref="ApiValidationException"/>（422）へ変換する。
+    /// </remarks>
+    private static T InvokeEngineWaitMutation<T>(Func<T> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new ApiValidationException(ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// Engine Wait 操作の <see cref="InvalidOperationException"/> を API 422 に写像する。
+    /// </summary>
+    private static void InvokeEngineWaitMutation(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new ApiValidationException(ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// PublishEvent シム用。グラフ上の未完了 Wait がちょうど 1 件ならその nodeId を返す。
+    /// </summary>
+    /// <remarks>
+    /// Engine の <c>PublishEvent</c> は単一アクティブ Wait のみ許可する。投影同期では
+    /// 復帰直後にグラフ完了が遅延し得るため、発行前に取得した nodeId で wait 行を先行削除する。
+    /// </remarks>
+    /// <param name="graphJson"><see cref="IExecutionEngine.ExportExecutionGraph"/> の JSON。</param>
+    /// <returns>唯一のアクティブ Wait の nodeId。0 件または 2 件以上なら null。</returns>
+    private static string? TryResolveSoleActiveWaitNodeId(string graphJson)
+    {
+        if (string.IsNullOrWhiteSpace(graphJson))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(graphJson);
+            if (!doc.RootElement.TryGetProperty(ExecutionGraphJsonProperties.Nodes, out var nodes)
+                || nodes.ValueKind != JsonValueKind.Array)
+            {
+                return null;
+            }
+
+            return FindSoleActiveWaitNodeId(nodes);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>nodes 配列から唯一の未完了 Wait nodeId を返す（0 件または複数は null）。</summary>
+    private static string? FindSoleActiveWaitNodeId(JsonElement nodes)
+    {
+        string? soleNodeId = null;
+        foreach (var node in nodes.EnumerateArray())
+        {
+            if (!TryGetActiveWaitNodeId(node, out var nodeId))
+                continue;
+
+            if (soleNodeId is not null)
+                return null;
+
+            soleNodeId = nodeId;
+        }
+
+        return soleNodeId;
+    }
+
+    /// <summary>未完了 Wait ノードなら nodeId を取り出す。</summary>
+    /// <remarks>
+    /// 許可イベント未設定の Wait は durable wait 投影対象外のため除外する
+    ///（<c>allowedEvents</c> または互換の <c>waitKey</c> が必要）。
+    /// </remarks>
+    private static bool TryGetActiveWaitNodeId(JsonElement node, out string? nodeId)
+    {
+        nodeId = null;
+        if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeType, out var nodeType)
+            || !string.Equals(nodeType.GetString(), "Wait", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (node.TryGetProperty(ExecutionGraphJsonProperties.CompletedAt, out var completedAt)
+            && completedAt.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+        {
+            return false;
+        }
+
+        if (!HasConfiguredWaitEvents(node))
+            return false;
+
+        if (!node.TryGetProperty(ExecutionGraphJsonProperties.NodeId, out var nodeIdElement))
+            return false;
+
+        var value = nodeIdElement.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        nodeId = value;
+        return true;
+    }
+
+    /// <summary>
+    /// グラフ JSON の Wait ノードに許可イベント設定があるか
+    ///（<c>allowedEvents</c> 優先、なければ非空の <c>waitKey</c>）。
+    /// </summary>
+    private static bool HasConfiguredWaitEvents(JsonElement node)
+    {
+        if (node.TryGetProperty("allowedEvents", out var allowedEvents)
+            && allowedEvents.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var entry in allowedEvents.EnumerateArray())
+            {
+                if (entry.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(entry.GetString()))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return node.TryGetProperty("waitKey", out var waitKey)
+            && waitKey.ValueKind == JsonValueKind.String
+            && !string.IsNullOrWhiteSpace(waitKey.GetString());
+    }
+
+    /// <summary>
+    /// グラフから nodeId を解決できないときのフォールバック。永続化済み wait から削除対象を決める。
+    /// </summary>
+    /// <param name="waits">当該 execution の wait 行。</param>
+    /// <param name="eventName">Publish したイベント名（前後空白は Trim して照合）。</param>
+    /// <returns>
+    /// wait が 1 件ならその nodeId。複数なら <paramref name="eventName"/> を許可する行がちょうど 1 件のときその nodeId。
+    /// それ以外は null。
+    /// </returns>
+    internal static string? TryResolveWaitNodeIdToClearFromPersisted(
+        IReadOnlyList<ExecutionWaitRow> waits,
+        string eventName)
+    {
+        if (waits.Count == 0)
+            return null;
+
+        if (waits.Count == 1)
+            return waits[0].NodeId;
+
+        // AllowedEvents は投影時に Trim 済み。Publish 側の前後空白とも揃える。
+        var normalizedEventName = eventName.Trim();
+        string? soleMatchingNodeId = null;
+        foreach (var wait in waits)
+        {
+            var allowsEvent = wait.AllowedEvents.Any(e =>
+                string.Equals(e, normalizedEventName, StringComparison.OrdinalIgnoreCase));
+            if (!allowsEvent)
+                continue;
+
+            if (soleMatchingNodeId is not null)
+                return null;
+
+            soleMatchingNodeId = wait.NodeId;
+        }
+
+        return soleMatchingNodeId;
+    }
+
+    private Task EnsureExecutionMutationWriteAsync(ExecutionRow execution, CancellationToken ct)
+    {
+        var snapshot = ExecutionSecuritySnapshotJson.TryDeserialize(execution.SecuritySnapshotJson);
+        return mutationAuth.EnsureMutationPermissionAsync(
+            snapshot,
+            RuntimePermissionRequirements.ExecutionsWrite,
+            ct);
+    }
+
+}

--- a/core/application/Statevia.Core.Application/Services/ExecutionWaitEventService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionWaitEventService.cs
@@ -10,8 +10,8 @@ namespace Statevia.Core.Application.Services;
 /// </summary>
 /// <remarks>
 /// <para><see cref="ExecutionService"/> Facade から委譲される。HTTP 契約は変更しない。</para>
-/// <para>物理子終端 <c>child.completed</c> の Join 再評価は Facade 側コールバックへ委譲する（Fork/Join 分離まで）。</para>
-/// <para>checkpoint 寿命の破棄判定は Facade フックとして Resume 永続化時に受け取る。</para>
+/// <para>物理子終端 <c>child.completed</c> の Join 再評価は <see cref="ExecutionForkJoinCoordinator"/> へ委譲する。</para>
+/// <para>checkpoint 寿命の破棄判定は <see cref="ExecutionCheckpointService"/> を利用する。</para>
 /// </remarks>
 /// <param name="engine">実行エンジン。</param>
 /// <param name="displayIds">表示 ID 解決。</param>
@@ -29,6 +29,8 @@ namespace Statevia.Core.Application.Services;
 /// <param name="idempotency">冪等サービス。</param>
 /// <param name="projection">投影オーケストレータ。</param>
 /// <param name="lifecycle">ライフサイクル（Engine hydrate / checkpoint upsert）。</param>
+/// <param name="checkpoints">checkpoint 寿命・破棄。</param>
+/// <param name="forkJoin">親 Physical Join 再評価。</param>
 /// <param name="forkChildCoordinator">Fork 子 Wait 配送（任意）。</param>
 [System.Diagnostics.CodeAnalysis.SuppressMessage(
     "Major Code Smell",
@@ -51,6 +53,8 @@ internal sealed class ExecutionWaitEventService(
     ExecutionIdempotencyService idempotency,
     ExecutionProjectionOrchestrator projection,
     ExecutionLifecycleCommandService lifecycle,
+    ExecutionCheckpointService checkpoints,
+    ExecutionForkJoinCoordinator forkJoin,
     IForkChildExecutionCoordinator? forkChildCoordinator = null)
 {
     /// <summary>HTTP 204 No Content。</summary>
@@ -289,9 +293,6 @@ internal sealed class ExecutionWaitEventService(
     /// <param name="resumeKey">Resume イベント名。</param>
     /// <param name="idempotencyKey">冪等キー（任意）。</param>
     /// <param name="requestContext">HTTP / Worker 文脈。</param>
-    /// <param name="handleChildCompletedResume">物理子終端時の Join 再評価（Facade）。</param>
-    /// <param name="shouldDiscardRuntimeCheckpoint">checkpoint 破棄候補判定（Facade）。</param>
-    /// <param name="discardOrRefreshRuntimeCheckpoint">checkpoint 破棄または所有中更新（Facade）。</param>
     /// <param name="ct">キャンセル。</param>
     public async Task ResumeNodeAsync(
         string idOrUuid,
@@ -299,15 +300,8 @@ internal sealed class ExecutionWaitEventService(
         string? resumeKey,
         string? idempotencyKey,
         CommandRequestContext requestContext,
-        Func<Guid, ExecutionRow, string, CancellationToken, Task> handleChildCompletedResume,
-        Func<Guid, string, string, CancellationToken, Task<bool>> shouldDiscardRuntimeCheckpoint,
-        Func<ICoreUnitOfWork, string, Guid, CancellationToken, Task<bool>> discardOrRefreshRuntimeCheckpoint,
         CancellationToken ct)
     {
-        ArgumentNullException.ThrowIfNull(handleChildCompletedResume);
-        ArgumentNullException.ThrowIfNull(shouldDiscardRuntimeCheckpoint);
-        ArgumentNullException.ThrowIfNull(discardOrRefreshRuntimeCheckpoint);
-
         ArgumentNullException.ThrowIfNull(requestContext);
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
         ArgumentException.ThrowIfNullOrWhiteSpace(resumeKey);
@@ -337,9 +331,6 @@ internal sealed class ExecutionWaitEventService(
                 eventName,
                 idempotencyKey,
                 requestContext,
-                handleChildCompletedResume,
-                shouldDiscardRuntimeCheckpoint,
-                discardOrRefreshRuntimeCheckpoint,
                 ct).ConfigureAwait(false))
         {
             return;
@@ -357,7 +348,7 @@ internal sealed class ExecutionWaitEventService(
         // 物理子終端の予約イベントは Wait Resume ではなく Join 再評価へ振る（D3）。
         if (string.Equals(eventName, ExecutionWaitEventNames.ChildCompleted, StringComparison.Ordinal))
         {
-            await handleChildCompletedResume(uuid.Value, execution, nodeId, ct).ConfigureAwait(false);
+            await forkJoin.HandleChildCompletedResumeAsync(uuid.Value, execution, nodeId, ct).ConfigureAwait(false);
             return;
         }
 
@@ -393,8 +384,6 @@ internal sealed class ExecutionWaitEventService(
                     pubCancel,
                     pubGraphJson,
                     publishedPayload),
-                shouldDiscardRuntimeCheckpoint,
-                discardOrRefreshRuntimeCheckpoint,
                 ct)
             .ConfigureAwait(false);
 
@@ -419,8 +408,6 @@ internal sealed class ExecutionWaitEventService(
     /// <summary>Wait Resume 後の投影・checkpoint・event_store・dedup を同一 tx で永続化する。</summary>
     private async Task PersistWaitResumeSideEffectsAsync(
         WaitResumePersistRequest request,
-        Func<Guid, string, string, CancellationToken, Task<bool>> shouldDiscardRuntimeCheckpoint,
-        Func<ICoreUnitOfWork, string, Guid, CancellationToken, Task<bool>> discardOrRefreshRuntimeCheckpoint,
         CancellationToken ct)
     {
         await mutationPersistence.ExecuteSerializableWithRetryAsync(
@@ -450,14 +437,14 @@ internal sealed class ExecutionWaitEventService(
 
                 if (request.EngineStillLoaded)
                 {
-                    if (await shouldDiscardRuntimeCheckpoint(
+                    if (await checkpoints.ShouldDiscardRuntimeCheckpointAsync(
                             request.ExecutionId,
                             request.PubStatus,
                             request.PubGraphJson,
                             ctInner)
                         .ConfigureAwait(false))
                     {
-                        await discardOrRefreshRuntimeCheckpoint(
+                        await checkpoints.DiscardOrRefreshRuntimeCheckpointAsync(
                                 uow,
                                 request.EngineId,
                                 request.ExecutionId,
@@ -562,9 +549,6 @@ internal sealed class ExecutionWaitEventService(
         string eventName,
         string? idempotencyKey,
         CommandRequestContext requestContext,
-        Func<Guid, ExecutionRow, string, CancellationToken, Task> handleChildCompletedResume,
-        Func<Guid, string, string, CancellationToken, Task<bool>> shouldDiscardRuntimeCheckpoint,
-        Func<ICoreUnitOfWork, string, Guid, CancellationToken, Task<bool>> discardOrRefreshRuntimeCheckpoint,
         CancellationToken ct)
     {
         if (forkChildCoordinator is null)
@@ -585,9 +569,6 @@ internal sealed class ExecutionWaitEventService(
                 delivery.EventName,
                 idempotencyKey,
                 requestContext,
-                handleChildCompletedResume,
-                shouldDiscardRuntimeCheckpoint,
-                discardOrRefreshRuntimeCheckpoint,
                 ct)
             .ConfigureAwait(false);
         return true;

--- a/docs/architecture/domain-model-boundaries.md
+++ b/docs/architecture/domain-model-boundaries.md
@@ -1,8 +1,21 @@
 # ドメインモデル関連図（境界付き）
 
+| 項目 | 値 |
+| --- | --- |
+| 種別 | Architecture |
+| Version | 1.1 |
+| 更新日 | 2026-08-13 |
+| 関連 | [overview.md](overview.md), [data-integration.md](../specifications/data-integration.md) |
+
+**Version 1.1（2026-08-13）**: Execution を `IExecutionService` Facade とドメインサービスへ分割した境界を反映。投影キューを実装済みとして実線化する。
+
+---
+
 関連する概念が増えてきたため、Statevia の主要ドメインモデルを「どの境界に属するか」と「どこが正本か」を含めて俯瞰できるように整理する。
 
 ## 1. ドメイン境界と関連
+
+HTTP / Worker は `IExecutionService` のみを見る。実処理は Core-Application のドメインサービスが担い、Facade は Repository / Engine を直接持たない。
 
 ```mermaid
 flowchart LR
@@ -16,13 +29,15 @@ flowchart LR
     UIQuery["Read表示<br/>Executions一覧・詳細・Graph"]
   end
 
-  subgraph API["Service API境界 (Integration/Application)"]
-    ExecutionService["ExecutionService<br/>ユースケース統合"]
-    ProjectionSync["ExecutionOperationalProjectionSync<br/>投影同期"]
-    EngineCallback["Engine観測コールバック<br/>（目標）"]
-    ProjectionQueue["API内 Projection キュー<br/>（目標）"]
-    DefinitionService["DefinitionService<br/>定義版管理"]
+  subgraph API["Service API / Application 境界"]
     ApiContract["HTTP契約<br/>/v1/definitions /v1/executions"]
+    Facade["ExecutionService<br/>IExecutionService Facade"]
+    ExecDomains["Execution ドメインサービス<br/>Query / Lifecycle / WaitEvent / Checkpoint<br/>Ownership / Recovery / Projection"]
+    CrossCut["横断<br/>AuthorizationGuard / EngineSession"]
+    ProjectionSync["ExecutionOperationalProjectionSync<br/>投影同期"]
+    ProjectionQueue["IExecutionProjectionUpdateQueue"]
+    EngineCallback["Engine観測コールバック<br/>（目標）"]
+    DefinitionService["DefinitionService<br/>定義版管理"]
   end
 
   subgraph Engine["Core-Engine境界 (Domain Kernel)"]
@@ -43,19 +58,22 @@ flowchart LR
   UICommand --> ApiContract
   UIQuery --> ApiContract
 
-  ApiContract --> ExecutionService
+  ApiContract --> Facade
   ApiContract --> DefinitionService
-  ExecutionService --> ExecutionModel
-  ExecutionService --> GraphModel
-  ExecutionService --> ProjectionSync
+  Facade --> ExecDomains
+  ExecDomains --> CrossCut
+  ExecDomains --> ExecutionModel
+  ExecDomains --> GraphModel
+  ExecDomains --> ProjectionQueue
+  ExecDomains --> ProjectionSync
   DefinitionService --> DefinitionModel
 
   DefinitionService --> DefinitionTables
-  ExecutionService --> ExecutionTables
+  ExecDomains --> ExecutionTables
   ProjectionSync --> ExecutionTables
   ProjectionSync --> CursorTables
-  ExecutionService --> EventStore
-  ExecutionService --> Dedup
+  ExecDomains --> EventStore
+  ExecDomains --> Dedup
 
   ExecutionModel --> WaitModel
   ExecutionModel -.状態変化通知（目標）.-> EngineCallback
@@ -63,23 +81,46 @@ flowchart LR
   ProjectionQueue --> ProjectionSync
 
   class DefinitionModel,ExecutionModel,GraphModel,WaitModel domain;
-  class ExecutionService,ProjectionSync,EngineCallback,ProjectionQueue,DefinitionService,ApiContract integration;
+  class Facade,ExecDomains,CrossCut,ProjectionSync,EngineCallback,ProjectionQueue,DefinitionService,ApiContract integration;
   class DefinitionTables,ExecutionTables,CursorTables,EventStore,Dedup storage;
   class UICommand,UIQuery external;
 ```
 
+### 1.1 Execution ドメインサービス（Core-Application）
+
+実装パスは `core/application/Statevia.Core.Application/Services/`。Worker / Controller の公開契約は `IExecutionService` のままである。
+
+| 型 | 責務 |
+| --- | --- |
+| `ExecutionService` | `IExecutionService` の薄い Facade。ドメインサービスへ委譲するだけ |
+| `ExecutionQueryService` | 一覧・単体・graph・view・events の read-model |
+| `ExecutionLifecycleCommandService` | Start / Cancel / QueuedStart |
+| `ExecutionWaitEventService` | Publish / Resume、子 Wait リダイレクト入口 |
+| `ExecutionCheckpointService` | Persist+Unload / KeepLoaded、Unload ゲート、世代フェンス |
+| `ExecutionOwnershipService` | Worker 所有セッションとローカル Load 待機 |
+| `ExecutionRecoveryService` | 所有喪失後の hydrate 再開（Wait 非消費） |
+| `ExecutionProjectionOrchestrator` | 投影更新の単一窓口（既存 queue を含む） |
+| `ExecutionIdempotencyService` | command_dedup / event_delivery_dedup |
+| `ExecutionForkJoinCoordinator` | 親 Physical Join 完了/失敗と子完了 Resume。Facade からは見えない |
+| `ExecutionAuthorizationGuard` | 実行系入口の認可（read / write / mutation / 定義 Execute） |
+| `ExecutionEngineSession` | ミューテーション前の Engine hydrate。Unload ゲートは持たない |
+
+`IForkChildExecutionCoordinator` は Fork 展開・親 Cancel カスケード・配送先解決を担う既存資産である。Join 再評価は `ExecutionForkJoinCoordinator` が呼び出す。
+
 ## 2. 読み方（要点）
 
 - `Core-Engine` は純粋ドメインロジック（定義解釈、遷移、グラフ生成）を担当し、I/O は持たない。
-- `Service API` はユースケース実行とトランザクション境界を担当し、Engine 結果を永続化モデルへ写像する。
+- `Service API` は HTTP アダプタと Composition Root である。Execution のユースケースとトランザクション境界は `core/application` が担い、Engine 結果を永続化モデルへ写像する。
+- HTTP / Worker 入口は `IExecutionService` Facade のみ。Repository / Auth / Engine は Facade が直接持たない。
+- 投影更新の窓口は `ExecutionProjectionOrchestrator` である。operational sync の実処理は `ExecutionOperationalProjectionSync`。
 - UI の正本は `GET /v1/executions*` が返す Read Model（`executions` / `execution_graph_snapshots`）である。
 - `execution_cursors` / `execution_waits` は運用用投影であり、Read API 正本とは分離される。
 - `event_store` は外部可視イベント履歴、`command_dedup` / `event_delivery_dedup` は冪等制御の責務を持つ。
 
 ## 3. 現状と目標の切り分け
 
-- **現状（実装済み）**: 永続化テーブル更新は `Service API` からのみ実行される。`UI` や `Core-Engine` が DB に直接書き込む経路は持たない。
-- **目標（仕様記載あり）**: Engine の状態変化を API 側へ観測コールバックし、API 内キューで execution 単位に併合しつつ `ProjectionSync` で DB 反映する流れを想定する。
+- **現状（実装済み）**: 永続化テーブル更新は Application（Service API プロセス内）からのみ実行される。`UI` や `Core-Engine` が DB に直接書き込む経路は持たない。`IExecutionProjectionUpdateQueue` は実装済みで、`ExecutionProjectionOrchestrator` が窓口になる。
+- **目標（未導入）**: Engine の状態変化を API 側へ観測コールバックする経路。現状は Application が Engine スナップショットを読んで投影する。
 - **図の凡例**: 破線は「目標/導入予定」の経路、実線は「現状の責務境界で成立している経路」を示す。
 
 ## 4. 参照元ドキュメント

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,15 @@
 # アーキテクチャ
 
-Version: 2.0
+| 項目 | 値 |
+| --- | --- |
+| 種別 | Architecture |
+| Version | 2.1 |
+| 更新日 | 2026-08-13 |
+| 関連 | [domain-model-boundaries.md](domain-model-boundaries.md), [repository-layout.md](repository-layout.md) |
+
 Project: Statevia — 実行型ステートマシン
+
+**Version 2.1（2026-08-13）**: Execution ユースケースを `IExecutionService` Facade とドメインサービスへ分割した責務を反映。
 
 **Version 2.0（2026-07-04）**: 4 カテゴリ構成（core / infrastructure / service / ui）とクリーン・アーキテクチャ準拠を反映。
 
@@ -97,10 +105,11 @@ flowchart LR
 ### 2.2 Core-Application（ユースケース）
 
 - 定義の登録・publish・一覧・取得
-- 実行の開始・キャンセル・イベント発行
-- コマンド重複排除（dedup）
-- セキュリティスナップショット・認可判定
-- Action スキーマ検証
+- 実行系は `IExecutionService` の薄い Facade。HTTP / Worker は Facade のみを見る
+- 実処理はドメインサービスへ委譲する（Query / Lifecycle / WaitEvent / Checkpoint / Ownership / Recovery / Projection）。冪等は `ExecutionIdempotencyService`、親 Physical Join は `ExecutionForkJoinCoordinator`
+- 横断: `ExecutionAuthorizationGuard`（認可）、`ExecutionEngineSession`（hydrate）。Unload ゲートは Checkpoint 側
+- Facade は Repository / Auth / Engine を直接持たない
+- セキュリティスナップショット・Action スキーマ検証
 
 ### 2.3 Infrastructure
 

--- a/docs/concepts/platform.md
+++ b/docs/concepts/platform.md
@@ -3,9 +3,13 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Concept |
-| Version | 1.0 |
-| 更新日 | 2026-07-07 |
+| Version | 1.1 |
+| 更新日 | 2026-08-13 |
 | 関連 | [../specifications/platform/](../specifications/platform/) |
+
+---
+
+**Version 1.1（2026-08-13）**: Application 層を Execution Facade とドメインサービスとして記述。
 
 ---
 
@@ -16,8 +20,8 @@ Statevia プラットフォームは **Service API** を境界として、認証
 | 層 | 役割 |
 | --- | --- |
 | UI | 表示と Command 発行。`/api/core/*` で Service API にプロキシ |
-| Service API | HTTP 契約、認可、UoW、Engine 起動、Module ホスト |
-| Application | ユースケースの orchestration |
+| Service API | HTTP 契約、Composition Root、Module ホスト |
+| Application | `IExecutionService` Facade とドメインサービスによるユースケース |
 | Engine | 純粋な状態遷移ロジック |
 | Infrastructure | EF Core、JWT、Module Source、Action 実行バックエンド |
 

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -32,10 +32,10 @@ Markdown 執筆ルールは [`DOCUMENTATION-STANDARD.md`](DOCUMENTATION-STANDARD
 
 ## 3. コンポーネント別
 
-### 3.1 Service API（`service/api/`）
+### 3.1 Service API（`service/api/`）と Application（`core/application/`）
 
-- **Controller**: ルーティング・バインディング・ヘッダ・HTTP ステータスのみ。ビジネスロジックは Service へ。
-- **Service**: ユースケース境界。`ICoreTransactionExecutor` / `IExecutionMutationPersistence` 経由でコミット境界を決め、Repository・DisplayId・command dedup・`IExecutionEngine` を組み合わせる。Service から `IDbContextFactory` を直接使わない。
+- **Controller**: ルーティング・バインディング・ヘッダ・HTTP ステータスのみ。ビジネスロジックは Application へ。
+- **ユースケース（`core/application/`）**: `IExecutionService` は薄い Facade でドメインサービスへ委譲する。コミット境界は `ICoreTransactionExecutor` / `IExecutionMutationPersistence`。Facade は Repository / Engine を直接持たない。`IDbContextFactory` をユースケースから直接使わない。境界の正本は [`architecture/domain-model-boundaries.md`](architecture/domain-model-boundaries.md)。
 - **Repository**: 永続化のみ。書き込み API の第一引数は常に `ICoreUnitOfWork`。`SaveChanges` / `BeginTransaction` / `IDbContextFactory` を Repository 内に持たない。
 - **UoW**: `IDbContextFactory<CoreDbContext>` は `CoreUnitOfWork` 実装内に閉じる。
 - **例外**: `ApiExceptionFilter` と契約に沿ったエラー JSON（404 / 422 / 500）。
@@ -251,6 +251,7 @@ npx --yes sonar-scanner "-Dsonar.token=$($env:SONAR_TOKEN)"
 
 | 日付 | 内容 |
 |------|------|
+| 2026-08-13 | §3.1 を Execution Facade / ドメインサービス分割後の責務に合わせて更新 |
 | 2026-07-07 | §1 / §4 / §7 を Git 上の正本として自己完結化（`.cursor` パス参照を廃止） |
 | 2026-05-19 | §4.3 / §5 に UI の ESLint・`StateviaUIStudio` Sonar 手順（§5.2・`sonar-scanner-ui.ps1`）を追記 |
 | 2026-05-17 | §4.3 / §5.1 に Service API 厳格ビルド・coverlet runsettings・`sonar-scanner-api.ps1` 手順を追記 |

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionAuthorizationGuardTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionAuthorizationGuardTests.cs
@@ -1,0 +1,289 @@
+using Statevia.Core.Application.Contracts.Persistence;
+using Statevia.Core.Application.Contracts.Security;
+using Statevia.Core.Application.Contracts.Services;
+using Statevia.Core.Application.Services;
+using Statevia.Service.Api.Tests.Infrastructure;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary><see cref="ExecutionAuthorizationGuard"/> の横断認可呼び出し。</summary>
+public sealed class ExecutionAuthorizationGuardTests
+{
+    /// <summary>read は executions:read を要求する。</summary>
+    [Fact]
+    public async Task EnsureExecutionsReadAsync_RequestsExecutionsRead()
+    {
+        // Arrange
+        var runtimeAuth = new RecordingRuntimePermissionAuthorization();
+        var sut = CreateSut(runtimeAuth: runtimeAuth);
+
+        // Act
+        await sut.EnsureExecutionsReadAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal([RuntimePermissionRequirements.ExecutionsRead], runtimeAuth.RequestedKeys);
+    }
+
+    /// <summary>write は executions:write を要求する。</summary>
+    [Fact]
+    public async Task EnsureExecutionsWriteAsync_RequestsExecutionsWrite()
+    {
+        // Arrange
+        var runtimeAuth = new RecordingRuntimePermissionAuthorization();
+        var sut = CreateSut(runtimeAuth: runtimeAuth);
+
+        // Act
+        await sut.EnsureExecutionsWriteAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal([RuntimePermissionRequirements.ExecutionsWrite], runtimeAuth.RequestedKeys);
+    }
+
+    /// <summary>mutation は snapshot 付きで executions:write を要求する。</summary>
+    [Fact]
+    public async Task EnsureExecutionMutationWriteAsync_RequestsMutationWrite()
+    {
+        // Arrange
+        var mutationAuth = new RecordingExecutionMutationAuthorization();
+        var sut = CreateSut(mutationAuth: mutationAuth);
+        var execution = new ExecutionRow
+        {
+            ExecutionId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            DefinitionId = Guid.NewGuid(),
+            DefinitionVersionId = Guid.NewGuid(),
+            Status = ExecutionProjectionStatuses.Running,
+            StartedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            SecuritySnapshotJson = null
+        };
+
+        // Act
+        await sut.EnsureExecutionMutationWriteAsync(execution, CancellationToken.None);
+
+        // Assert
+        Assert.Single(mutationAuth.Calls);
+        Assert.Equal(RuntimePermissionRequirements.ExecutionsWrite, mutationAuth.Calls[0].PermissionKey);
+    }
+
+    /// <summary>execution が null なら ArgumentNullException。</summary>
+    [Fact]
+    public async Task EnsureExecutionMutationWriteAsync_WhenExecutionNull_Throws()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act / Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            sut.EnsureExecutionMutationWriteAsync(null!, CancellationToken.None));
+    }
+
+    /// <summary>定義のプロジェクトが無ければ NotFound。</summary>
+    [Fact]
+    public async Task EnsureCanExecuteOnDefinitionAsync_WhenProjectMissing_ThrowsNotFound()
+    {
+        // Arrange
+        var sut = CreateSut(definitions: new StubDefinitionRepository(projectId: null));
+
+        // Act / Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sut.EnsureCanExecuteOnDefinitionAsync(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
+    }
+
+    /// <summary>プロジェクト解決後に EnsureCanExecute を呼ぶ。</summary>
+    [Fact]
+    public async Task EnsureCanExecuteOnDefinitionAsync_WhenProjectResolved_CallsProjectAuth()
+    {
+        // Arrange
+        var projectId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var projectAuth = new RecordingProjectAuthorizationService();
+        var sut = CreateSut(
+            projectAuth: projectAuth,
+            definitions: new StubDefinitionRepository(projectId));
+
+        // Act
+        await sut.EnsureCanExecuteOnDefinitionAsync(tenantId, definitionId, CancellationToken.None);
+
+        // Assert
+        Assert.Single(projectAuth.ExecuteCalls);
+        Assert.Equal(tenantId, projectAuth.ExecuteCalls[0].TenantId);
+        Assert.Equal(projectId, projectAuth.ExecuteCalls[0].ProjectId);
+    }
+
+    private static ExecutionAuthorizationGuard CreateSut(
+        IRuntimePermissionAuthorization? runtimeAuth = null,
+        IExecutionMutationAuthorization? mutationAuth = null,
+        IProjectAuthorizationService? projectAuth = null,
+        IDefinitionRepository? definitions = null) =>
+        new(
+            runtimeAuth ?? new AllowAllRuntimePermissionAuthorization(),
+            mutationAuth ?? new AllowAllExecutionMutationAuthorization(),
+            projectAuth ?? new AllowAllProjectAuthorizationService(),
+            definitions ?? new StubDefinitionRepository(Guid.NewGuid()),
+            new ImmediateReadOnlyExecutor());
+
+    private sealed class RecordingRuntimePermissionAuthorization : IRuntimePermissionAuthorization
+    {
+        public List<string> RequestedKeys { get; } = [];
+
+        public Task EnsurePermissionAsync(string permissionKey, CancellationToken cancellationToken)
+        {
+            RequestedKeys.Add(permissionKey);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingExecutionMutationAuthorization : IExecutionMutationAuthorization
+    {
+        public List<(ExecutionSecuritySnapshot? Snapshot, string PermissionKey)> Calls { get; } = [];
+
+        public Task EnsureMutationPermissionAsync(
+            ExecutionSecuritySnapshot? snapshot,
+            string permissionKey,
+            CancellationToken cancellationToken)
+        {
+            Calls.Add((snapshot, permissionKey));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingProjectAuthorizationService : IProjectAuthorizationService
+    {
+        public List<(Guid TenantId, Guid ProjectId)> ExecuteCalls { get; } = [];
+
+        public Task EnsureCanReadAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            Guid projectId,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task EnsureCanExecuteAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            Guid projectId,
+            CancellationToken ct)
+        {
+            ExecuteCalls.Add((tenantId, projectId));
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureCanPublishAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            Guid projectId,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+    }
+
+    private sealed class StubDefinitionRepository(Guid? projectId) : IDefinitionRepository
+    {
+        public Task<Guid?> ResolveProjectIdAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            Guid definitionId,
+            CancellationToken ct) =>
+            Task.FromResult(projectId);
+
+        public Task<DefinitionDetail?> GetLatestForApiAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionRow?> GetLatestForMutationAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionVersionRow?> GetVersionForExecutionAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, int version, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionVersionRow?> GetVersionForExecutionByIdAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionVersionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionVersionRow?> GetVersionForApiAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, int version, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionRow?> GetDeletedCatalogEntryAsync(
+            ICoreUnitOfWork uow, Guid tenantId, Guid definitionId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task AddWithInitialVersionAsync(
+            ICoreUnitOfWork uow, DefinitionRow definition, DefinitionVersionRow version, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionDetail?> PublishVersionAsync(
+            ICoreUnitOfWork uow,
+            DefinitionVersionPublishCommand command,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<(int TotalCount, List<(DefinitionDetail Detail, string? DisplayId)> Items)> ListWithDisplayIdsPageAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            DefinitionListPageQuery query,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionSoftDeleteOutcome> SoftDeleteAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            Guid definitionId,
+            DateTime deletedAt,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<DefinitionDetail?> RestoreAsync(
+            ICoreUnitOfWork uow,
+            Guid tenantId,
+            Guid definitionId,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<bool> ExistsActiveSlugInProjectAsync(
+            ICoreUnitOfWork uow,
+            Guid projectId,
+            string slug,
+            Guid excludingDefinitionId,
+            CancellationToken ct) =>
+            throw new NotImplementedException();
+    }
+
+    private sealed class ImmediateReadOnlyExecutor : ICoreTransactionExecutor
+    {
+        public Task ExecuteReadCommittedAsync(
+            Func<ICoreUnitOfWork, CancellationToken, Task> work,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<T> ExecuteReadCommittedAsync<T>(
+            Func<ICoreUnitOfWork, CancellationToken, Task<T>> work,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task ExecuteReadOnlyAsync(
+            Func<ICoreUnitOfWork, CancellationToken, Task> work,
+            CancellationToken cancellationToken = default) =>
+            work(StubUnitOfWork.Instance, cancellationToken);
+
+        public Task<T> ExecuteReadOnlyAsync<T>(
+            Func<ICoreUnitOfWork, CancellationToken, Task<T>> work,
+            CancellationToken cancellationToken = default) =>
+            work(StubUnitOfWork.Instance, cancellationToken);
+    }
+
+    private sealed class StubUnitOfWork : ICoreUnitOfWork
+    {
+        public static readonly StubUnitOfWork Instance = new();
+        public ICoreDatabase Db => throw new NotImplementedException();
+        public Task BeginTransactionAsync(System.Data.IsolationLevel level, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+        public Task<int> SaveChangesAsync(CancellationToken cancellationToken) => Task.FromResult(0);
+        public Task CommitAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task RollbackAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionEngineSessionTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionEngineSessionTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using Statevia.Core.Application.Services;
+using Statevia.Core.Engine.Abstractions;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary><see cref="ExecutionEngineSession.TryParseRuntimeCheckpoint"/> の hydrate 用検証。</summary>
+public sealed class ExecutionEngineSessionTests
+{
+    /// <summary>空・空白・seed 空オブジェクトは不正。</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{}")]
+    [InlineData("null")]
+    public void TryParseRuntimeCheckpoint_WhenEmptyOrSeed_ReturnsFalse(string? checkpointJson)
+    {
+        // Arrange / Act
+        var ok = ExecutionEngineSession.TryParseRuntimeCheckpoint(checkpointJson, out _, out var parseError);
+
+        // Assert
+        Assert.False(ok);
+        Assert.Null(parseError);
+    }
+
+    /// <summary>不正 JSON は false と parseError を返す。</summary>
+    [Fact]
+    public void TryParseRuntimeCheckpoint_WhenInvalidJson_ReturnsFalseWithParseError()
+    {
+        // Arrange / Act
+        var ok = ExecutionEngineSession.TryParseRuntimeCheckpoint("{not-json", out _, out var parseError);
+
+        // Assert
+        Assert.False(ok);
+        Assert.NotNull(parseError);
+        Assert.IsType<JsonException>(parseError);
+    }
+
+    /// <summary>必須フィールド欠落は false と parseError を返す。</summary>
+    [Fact]
+    public void TryParseRuntimeCheckpoint_WhenRequiredFieldsMissing_ReturnsFalseWithParseError()
+    {
+        // Arrange
+        const string incomplete = """{"schemaVersion":1,"executionId":"e1"}""";
+
+        // Act
+        var ok = ExecutionEngineSession.TryParseRuntimeCheckpoint(incomplete, out _, out var parseError);
+
+        // Assert
+        Assert.False(ok);
+        Assert.NotNull(parseError);
+        Assert.IsType<JsonException>(parseError);
+    }
+
+    /// <summary>正規断面（空 Active/Wait 含む）は hydrate 可能。</summary>
+    [Fact]
+    public void TryParseRuntimeCheckpoint_WhenValidMinimalCheckpoint_ReturnsTrue()
+    {
+        // Arrange
+        var checkpoint = CreateMinimalCheckpoint();
+        var json = JsonSerializer.Serialize(checkpoint, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        // Act
+        var ok = ExecutionEngineSession.TryParseRuntimeCheckpoint(json, out var parsed, out var parseError);
+
+        // Assert
+        Assert.True(ok);
+        Assert.Null(parseError);
+        Assert.Equal("exec-1", parsed.ExecutionId);
+        Assert.Equal("def", parsed.DefinitionName);
+        Assert.Empty(parsed.ActiveStates);
+        Assert.Empty(parsed.PendingWaits);
+    }
+
+    private static ExecutionRuntimeCheckpoint CreateMinimalCheckpoint() =>
+        new()
+        {
+            ExecutionId = "exec-1",
+            DefinitionName = "def",
+            ActiveStates = [],
+            StateAttempts = new Dictionary<string, int>(StringComparer.Ordinal),
+            StateOutputs = new Dictionary<string, JsonElement?>(StringComparer.Ordinal),
+            AppliedPublishClientEventIds = [],
+            AppliedCancelClientEventIds = [],
+            Context = new CheckpointContextData
+            {
+                States = new Dictionary<string, JsonElement?>(StringComparer.Ordinal)
+            },
+            Graph = new CheckpointGraphData
+            {
+                Nodes = [],
+                Edges = []
+            },
+            Join = new CheckpointJoinData
+            {
+                JoinStateResults = new Dictionary<string, IReadOnlyDictionary<string, CheckpointJoinObserved>>(
+                    StringComparer.OrdinalIgnoreCase),
+                JoinSourceNodeIds = new Dictionary<string, IReadOnlyDictionary<string, string>>(
+                    StringComparer.OrdinalIgnoreCase),
+                StartedJoins = []
+            },
+            PendingWaits = []
+        };
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceCheckpointGuardTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceCheckpointGuardTests.cs
@@ -173,7 +173,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
             """;
 
         // Act
-        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
+        var completed = ExecutionForkJoinCoordinator.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
 
         // Assert
         Assert.True(completed);
@@ -195,7 +195,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
             """;
 
         // Act
-        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
+        var completed = ExecutionForkJoinCoordinator.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
 
         // Assert
         Assert.True(completed);
@@ -217,7 +217,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
             """;
 
         // Act
-        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
+        var completed = ExecutionForkJoinCoordinator.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
 
         // Assert
         Assert.True(completed);
@@ -238,7 +238,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
             """;
 
         // Act
-        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
+        var completed = ExecutionForkJoinCoordinator.IsPhysicalJoinAlreadyCompleted(graphJson, "fork1", "Join1");
 
         // Assert
         Assert.False(completed);
@@ -249,7 +249,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
     public void IsPhysicalJoinAlreadyCompleted_WhenInvalidJson_ReturnsFalse()
     {
         // Arrange / Act
-        var completed = ExecutionService.IsPhysicalJoinAlreadyCompleted("{not-json", "fork1", "Join1");
+        var completed = ExecutionForkJoinCoordinator.IsPhysicalJoinAlreadyCompleted("{not-json", "fork1", "Join1");
 
         // Assert
         Assert.False(completed);

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceCheckpointGuardTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceCheckpointGuardTests.cs
@@ -26,7 +26,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
         var stored = CreateCheckpoint(nodeCount: 3);
 
         // Act
-        var lessAdvanced = ExecutionService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
+        var lessAdvanced = ExecutionCheckpointService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
 
         // Assert
         Assert.False(lessAdvanced);
@@ -41,7 +41,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
         var stored = CreateCheckpoint(nodeCount: 3);
 
         // Act
-        var lessAdvanced = ExecutionService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
+        var lessAdvanced = ExecutionCheckpointService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
 
         // Assert
         Assert.True(lessAdvanced);
@@ -66,7 +66,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
             ]);
 
         // Act
-        var lessAdvanced = ExecutionService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
+        var lessAdvanced = ExecutionCheckpointService.IsRuntimeCheckpointLessAdvanced(incoming, stored);
 
         // Assert
         Assert.True(lessAdvanced);
@@ -91,7 +91,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
             activeStates: ["Decide1"]);
 
         // Act
-        var obsolete = ExecutionService.IsForkExpansionUnloadObsolete(checkpoint, "wait1");
+        var obsolete = ExecutionCheckpointService.IsForkExpansionUnloadObsolete(checkpoint, "wait1");
 
         // Assert
         Assert.False(obsolete);
@@ -117,7 +117,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
             activeStates: ["Decide1"]);
 
         // Act
-        var obsolete = ExecutionService.IsForkExpansionUnloadObsolete(checkpoint, "fork1");
+        var obsolete = ExecutionCheckpointService.IsForkExpansionUnloadObsolete(checkpoint, "fork1");
 
         // Assert
         Assert.True(obsolete);
@@ -151,7 +151,7 @@ public sealed class ExecutionServiceCheckpointGuardTests
             ]);
 
         // Act
-        var obsolete = ExecutionService.IsForkExpansionUnloadObsolete(checkpoint, "fork1");
+        var obsolete = ExecutionCheckpointService.IsForkExpansionUnloadObsolete(checkpoint, "fork1");
 
         // Assert
         Assert.True(obsolete);

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceCheckpointGuardTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceCheckpointGuardTests.cs
@@ -4,7 +4,7 @@ using Statevia.Core.Engine.Abstractions;
 
 namespace Statevia.Service.Api.Tests.Services;
 
-/// <summary>ExecutionService の checkpoint / Join ガード静的ヘルパー。</summary>
+/// <summary>Checkpoint / ForkJoin の静的ガードヘルパー（ドメインサービス）。</summary>
 public sealed class ExecutionServiceCheckpointGuardTests
 {
     /// <summary>終端 incoming は遅れ判定しない。</summary>

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceFacadeDependencyTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceFacadeDependencyTests.cs
@@ -1,0 +1,31 @@
+using Statevia.Core.Application.Services;
+
+namespace Statevia.Service.Api.Tests.Services;
+
+/// <summary>
+/// <see cref="ExecutionService"/> Facade が Repository 等を直接 DI せず、ドメインサービスのみに依存することを固定する。
+/// </summary>
+public sealed class ExecutionServiceFacadeDependencyTests
+{
+    /// <summary>コンストラクタ引数はドメインサービス型のみ。</summary>
+    [Fact]
+    public void Constructor_DependsOnlyOnDomainServices()
+    {
+        // Arrange
+        var constructor = typeof(ExecutionService).GetConstructors().Single();
+        var parameterTypes = constructor.GetParameters().Select(p => p.ParameterType).ToArray();
+
+        // Act / Assert
+        Assert.Equal(
+            [
+                typeof(ExecutionQueryService),
+                typeof(ExecutionProjectionOrchestrator),
+                typeof(ExecutionLifecycleCommandService),
+                typeof(ExecutionWaitEventService),
+                typeof(ExecutionCheckpointService),
+                typeof(ExecutionOwnershipService),
+                typeof(ExecutionRecoveryService)
+            ],
+            parameterTypes);
+    }
+}

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4339,6 +4339,19 @@ public sealed class ExecutionServiceTests
             retryOptions,
             new FixedCorrelationIdAccessor(),
             NullLogger<ExecutionIdempotencyService>.Instance);
+        var ownership = ownershipTracker ?? new ExecutionOwnershipTracker();
+        var waits = waitRepo ?? new FakeExecutionWaitRepository();
+        var projection = new ExecutionProjectionOrchestrator(
+            engine,
+            executions,
+            new FakeExecutionCursorRepository(),
+            waits,
+            idGenerator,
+            executor,
+            NullLogger<ExecutionProjectionOrchestrator>.Instance,
+            ownership,
+            projectionUpdateQueue,
+            forkChildCoordinator);
 
         return new ExecutionService(
             engine,
@@ -4346,8 +4359,7 @@ public sealed class ExecutionServiceTests
             compiler,
             idGenerator,
             executions,
-            new FakeExecutionCursorRepository(),
-            waitRepo ?? new FakeExecutionWaitRepository(),
+            waits,
             definitions,
             projectAuthorization ?? new AllowAllProjectAuthorizationService(),
             runtimeAuth,
@@ -4364,9 +4376,9 @@ public sealed class ExecutionServiceTests
             checkpointStore ?? new FakeExecutionCheckpointStore(),
             query,
             idempotency,
-            projectionUpdateQueue,
+            projection,
             workQueue,
-            ownershipTracker,
+            ownership,
             forkChildCoordinator: forkChildCoordinator);
     }
 

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4457,37 +4457,13 @@ public sealed class ExecutionServiceTests
             checkpointService);
 
         return new ExecutionService(
-            engine,
-            displayIds,
-            compiler,
-            idGenerator,
-            executions,
-            waits,
-            definitions,
-            projectAuth,
-            runtimeAuth,
-            mutationAuth,
-            snapshotFactory,
-            sqlite.TenantAccessor,
-            dedup,
-            eventStore,
-            eventDeliveryDedup,
-            displayIdWrites,
-            executor,
-            mutationPersistence,
-            NullLogger<ExecutionService>.Instance,
-            checkpointStoreResolved,
             query,
-            idempotency,
             projection,
             lifecycle,
             waitEvents,
             checkpointService,
             ownershipSessions,
-            recovery,
-            workQueue,
-            ownership,
-            forkChildCoordinator: forkChildCoordinator);
+            recovery);
     }
 
     /// <summary>Reader 付与テナントは Start（Executor）が 403。</summary>

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4381,6 +4381,26 @@ public sealed class ExecutionServiceTests
             projection,
             workQueue,
             forkChildCoordinator);
+        var checkpointService = new ExecutionCheckpointService(
+            engine,
+            checkpointStoreResolved,
+            ownership,
+            executor,
+            executions,
+            projection,
+            lifecycle,
+            NullLogger<ExecutionCheckpointService>.Instance,
+            forkChildCoordinator);
+        var forkJoin = new ExecutionForkJoinCoordinator(
+            engine,
+            executions,
+            checkpointStoreResolved,
+            executor,
+            lifecycle,
+            projection,
+            checkpointService,
+            NullLogger<ExecutionForkJoinCoordinator>.Instance,
+            forkChildCoordinator);
         var waitEvents = new ExecutionWaitEventService(
             engine,
             displayIds,
@@ -4398,16 +4418,8 @@ public sealed class ExecutionServiceTests
             idempotency,
             projection,
             lifecycle,
-            forkChildCoordinator);
-        var checkpointService = new ExecutionCheckpointService(
-            engine,
-            checkpointStoreResolved,
-            ownership,
-            executor,
-            executions,
-            projection,
-            lifecycle,
-            NullLogger<ExecutionCheckpointService>.Instance,
+            checkpointService,
+            forkJoin,
             forkChildCoordinator);
         var ownershipSessions = new ExecutionOwnershipService(
             engine,

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4409,6 +4409,26 @@ public sealed class ExecutionServiceTests
             lifecycle,
             NullLogger<ExecutionCheckpointService>.Instance,
             forkChildCoordinator);
+        var ownershipSessions = new ExecutionOwnershipService(
+            engine,
+            checkpointStoreResolved,
+            ownership,
+            executor,
+            projection,
+            checkpointService,
+            lifecycle,
+            NullLogger<ExecutionOwnershipService>.Instance);
+        var recovery = new ExecutionRecoveryService(
+            engine,
+            executions,
+            runtimeAuth,
+            mutationAuth,
+            sqlite.TenantAccessor,
+            executor,
+            lifecycle,
+            waitEvents,
+            projection,
+            checkpointService);
 
         return new ExecutionService(
             engine,
@@ -4437,6 +4457,8 @@ public sealed class ExecutionServiceTests
             lifecycle,
             waitEvents,
             checkpointService,
+            ownershipSessions,
+            recovery,
             workQueue,
             ownership,
             forkChildCoordinator: forkChildCoordinator);

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4352,6 +4352,35 @@ public sealed class ExecutionServiceTests
             ownership,
             projectionUpdateQueue,
             forkChildCoordinator);
+        var projectAuth = projectAuthorization ?? new AllowAllProjectAuthorizationService();
+        var mutationAuth = new AllowAllExecutionMutationAuthorization();
+        var snapshotFactory = new FakeExecutionSecuritySnapshotFactory(sqlite.TenantAccessor);
+        var checkpoints = checkpointStore ?? new FakeExecutionCheckpointStore();
+        var lifecycle = new ExecutionLifecycleCommandService(
+            engine,
+            displayIds,
+            compiler,
+            idGenerator,
+            executions,
+            definitions,
+            projectAuth,
+            runtimeAuth,
+            mutationAuth,
+            snapshotFactory,
+            sqlite.TenantAccessor,
+            dedup,
+            eventStore,
+            eventDeliveryDedup,
+            displayIdWrites,
+            executor,
+            mutationPersistence,
+            NullLogger<ExecutionLifecycleCommandService>.Instance,
+            checkpoints,
+            ownership,
+            idempotency,
+            projection,
+            workQueue,
+            forkChildCoordinator);
 
         return new ExecutionService(
             engine,
@@ -4361,10 +4390,10 @@ public sealed class ExecutionServiceTests
             executions,
             waits,
             definitions,
-            projectAuthorization ?? new AllowAllProjectAuthorizationService(),
+            projectAuth,
             runtimeAuth,
-            new AllowAllExecutionMutationAuthorization(),
-            new FakeExecutionSecuritySnapshotFactory(sqlite.TenantAccessor),
+            mutationAuth,
+            snapshotFactory,
             sqlite.TenantAccessor,
             dedup,
             eventStore,
@@ -4373,10 +4402,11 @@ public sealed class ExecutionServiceTests
             executor,
             mutationPersistence,
             NullLogger<ExecutionService>.Instance,
-            checkpointStore ?? new FakeExecutionCheckpointStore(),
+            checkpoints,
             query,
             idempotency,
             projection,
+            lifecycle,
             workQueue,
             ownership,
             forkChildCoordinator: forkChildCoordinator);

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4355,7 +4355,7 @@ public sealed class ExecutionServiceTests
         var projectAuth = projectAuthorization ?? new AllowAllProjectAuthorizationService();
         var mutationAuth = new AllowAllExecutionMutationAuthorization();
         var snapshotFactory = new FakeExecutionSecuritySnapshotFactory(sqlite.TenantAccessor);
-        var checkpoints = checkpointStore ?? new FakeExecutionCheckpointStore();
+        var checkpointStoreResolved = checkpointStore ?? new FakeExecutionCheckpointStore();
         var lifecycle = new ExecutionLifecycleCommandService(
             engine,
             displayIds,
@@ -4375,7 +4375,7 @@ public sealed class ExecutionServiceTests
             executor,
             mutationPersistence,
             NullLogger<ExecutionLifecycleCommandService>.Instance,
-            checkpoints,
+            checkpointStoreResolved,
             ownership,
             idempotency,
             projection,
@@ -4399,6 +4399,16 @@ public sealed class ExecutionServiceTests
             projection,
             lifecycle,
             forkChildCoordinator);
+        var checkpointService = new ExecutionCheckpointService(
+            engine,
+            checkpointStoreResolved,
+            ownership,
+            executor,
+            executions,
+            projection,
+            lifecycle,
+            NullLogger<ExecutionCheckpointService>.Instance,
+            forkChildCoordinator);
 
         return new ExecutionService(
             engine,
@@ -4420,12 +4430,13 @@ public sealed class ExecutionServiceTests
             executor,
             mutationPersistence,
             NullLogger<ExecutionService>.Instance,
-            checkpoints,
+            checkpointStoreResolved,
             query,
             idempotency,
             projection,
             lifecycle,
             waitEvents,
+            checkpointService,
             workQueue,
             ownership,
             forkChildCoordinator: forkChildCoordinator);

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4322,10 +4322,26 @@ public sealed class ExecutionServiceTests
         }
 
         var runtimeAuth = new AllowAllRuntimePermissionAuthorization();
+        var projectAuth = projectAuthorization ?? new AllowAllProjectAuthorizationService();
+        var mutationAuth = new AllowAllExecutionMutationAuthorization();
+        var authorization = new ExecutionAuthorizationGuard(
+            runtimeAuth,
+            mutationAuth,
+            projectAuth,
+            definitions,
+            executor);
+        var checkpointStoreResolved = checkpointStore ?? new FakeExecutionCheckpointStore();
+        var engineSession = new ExecutionEngineSession(
+            engine,
+            compiler,
+            definitions,
+            checkpointStoreResolved,
+            executor,
+            NullLogger<ExecutionEngineSession>.Instance);
         var query = new ExecutionQueryService(
             displayIds,
             executions,
-            runtimeAuth,
+            authorization,
             sqlite.TenantAccessor,
             eventStore,
             executor,
@@ -4352,10 +4368,7 @@ public sealed class ExecutionServiceTests
             ownership,
             projectionUpdateQueue,
             forkChildCoordinator);
-        var projectAuth = projectAuthorization ?? new AllowAllProjectAuthorizationService();
-        var mutationAuth = new AllowAllExecutionMutationAuthorization();
         var snapshotFactory = new FakeExecutionSecuritySnapshotFactory(sqlite.TenantAccessor);
-        var checkpointStoreResolved = checkpointStore ?? new FakeExecutionCheckpointStore();
         var lifecycle = new ExecutionLifecycleCommandService(
             engine,
             displayIds,
@@ -4363,9 +4376,8 @@ public sealed class ExecutionServiceTests
             idGenerator,
             executions,
             definitions,
-            projectAuth,
-            runtimeAuth,
-            mutationAuth,
+            authorization,
+            engineSession,
             snapshotFactory,
             sqlite.TenantAccessor,
             dedup,
@@ -4397,6 +4409,7 @@ public sealed class ExecutionServiceTests
             checkpointStoreResolved,
             executor,
             lifecycle,
+            engineSession,
             projection,
             checkpointService,
             NullLogger<ExecutionForkJoinCoordinator>.Instance,
@@ -4407,7 +4420,7 @@ public sealed class ExecutionServiceTests
             idGenerator,
             executions,
             waits,
-            mutationAuth,
+            authorization,
             sqlite.TenantAccessor,
             dedup,
             eventStore,
@@ -4418,6 +4431,7 @@ public sealed class ExecutionServiceTests
             idempotency,
             projection,
             lifecycle,
+            engineSession,
             checkpointService,
             forkJoin,
             forkChildCoordinator);
@@ -4433,11 +4447,11 @@ public sealed class ExecutionServiceTests
         var recovery = new ExecutionRecoveryService(
             engine,
             executions,
-            runtimeAuth,
-            mutationAuth,
+            authorization,
             sqlite.TenantAccessor,
             executor,
             lifecycle,
+            engineSession,
             waitEvents,
             projection,
             checkpointService);

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -2501,7 +2501,7 @@ public sealed class ExecutionServiceTests
         };
 
         // Act
-        var nodeId = ExecutionService.TryResolveWaitNodeIdToClearFromPersisted(waits, "  approve  ");
+        var nodeId = ExecutionWaitEventService.TryResolveWaitNodeIdToClearFromPersisted(waits, "  approve  ");
 
         // Assert
         Assert.Equal("wait-a", nodeId);
@@ -4381,6 +4381,24 @@ public sealed class ExecutionServiceTests
             projection,
             workQueue,
             forkChildCoordinator);
+        var waitEvents = new ExecutionWaitEventService(
+            engine,
+            displayIds,
+            idGenerator,
+            executions,
+            waits,
+            mutationAuth,
+            sqlite.TenantAccessor,
+            dedup,
+            eventStore,
+            eventDeliveryDedup,
+            executor,
+            mutationPersistence,
+            NullLogger<ExecutionWaitEventService>.Instance,
+            idempotency,
+            projection,
+            lifecycle,
+            forkChildCoordinator);
 
         return new ExecutionService(
             engine,
@@ -4407,6 +4425,7 @@ public sealed class ExecutionServiceTests
             idempotency,
             projection,
             lifecycle,
+            waitEvents,
             workQueue,
             ownership,
             forkChildCoordinator: forkChildCoordinator);

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4330,13 +4330,21 @@ public sealed class ExecutionServiceTests
             eventStore,
             executor,
             forkChildCoordinator);
+        var idempotency = new ExecutionIdempotencyService(
+            dedupService,
+            dedup,
+            eventDeliveryDedup,
+            sqlite.TenantAccessor,
+            executor,
+            retryOptions,
+            new FixedCorrelationIdAccessor(),
+            NullLogger<ExecutionIdempotencyService>.Instance);
 
         return new ExecutionService(
             engine,
             displayIds,
             compiler,
             idGenerator,
-            dedupService,
             executions,
             new FakeExecutionCursorRepository(),
             waitRepo ?? new FakeExecutionWaitRepository(),
@@ -4353,10 +4361,9 @@ public sealed class ExecutionServiceTests
             executor,
             mutationPersistence,
             NullLogger<ExecutionService>.Instance,
-            retryOptions,
-            new FixedCorrelationIdAccessor(),
             checkpointStore ?? new FakeExecutionCheckpointStore(),
             query,
+            idempotency,
             projectionUpdateQueue,
             workQueue,
             ownershipTracker,

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionServiceTests.cs
@@ -4321,6 +4321,16 @@ public sealed class ExecutionServiceTests
             sqlite.TenantAccessor.Set(TestTenantIds.T1Context);
         }
 
+        var runtimeAuth = new AllowAllRuntimePermissionAuthorization();
+        var query = new ExecutionQueryService(
+            displayIds,
+            executions,
+            runtimeAuth,
+            sqlite.TenantAccessor,
+            eventStore,
+            executor,
+            forkChildCoordinator);
+
         return new ExecutionService(
             engine,
             displayIds,
@@ -4332,7 +4342,7 @@ public sealed class ExecutionServiceTests
             waitRepo ?? new FakeExecutionWaitRepository(),
             definitions,
             projectAuthorization ?? new AllowAllProjectAuthorizationService(),
-            new AllowAllRuntimePermissionAuthorization(),
+            runtimeAuth,
             new AllowAllExecutionMutationAuthorization(),
             new FakeExecutionSecuritySnapshotFactory(sqlite.TenantAccessor),
             sqlite.TenantAccessor,
@@ -4346,6 +4356,7 @@ public sealed class ExecutionServiceTests
             retryOptions,
             new FixedCorrelationIdAccessor(),
             checkpointStore ?? new FakeExecutionCheckpointStore(),
+            query,
             projectionUpdateQueue,
             workQueue,
             ownershipTracker,

--- a/service/api/Statevia.Service.Api.Tests/Services/RuntimeCheckpointLifetimePolicyTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/RuntimeCheckpointLifetimePolicyTests.cs
@@ -3,31 +3,28 @@ using Statevia.Core.Application.Services;
 
 namespace Statevia.Service.Api.Tests.Services;
 
-/// <summary>runtime checkpoint 内容寿命表（PendingWaits / PendingPhysicalJoin）の単体。</summary>
+/// <summary><see cref="RuntimeCheckpointLifetimePolicy"/> の寿命表破棄候補判定。</summary>
 public sealed class RuntimeCheckpointLifetimePolicyTests
 {
-    /// <summary>終端は保持理由があっても内容破棄候補。</summary>
+    /// <summary>終端 status は保持理由に関わらず破棄候補。</summary>
     [Theory]
     [InlineData(ExecutionProjectionStatuses.Completed)]
     [InlineData(ExecutionProjectionStatuses.Failed)]
     [InlineData(ExecutionProjectionStatuses.Cancelled)]
-    public void IsContentDiscardCandidate_WhenTerminal_ReturnsTrue(
-        string status)
+    public void IsContentDiscardCandidate_WhenTerminal_ReturnsTrue(string status)
     {
-        // Arrange
-        var reasons = RuntimeCheckpointRetainReasons.PendingWaits
-            | RuntimeCheckpointRetainReasons.PendingPhysicalJoin;
-
-        // Act
-        var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(status, reasons);
+        // Arrange / Act
+        var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(
+            status,
+            RuntimeCheckpointRetainReasons.PendingWaits | RuntimeCheckpointRetainReasons.PendingPhysicalJoin);
 
         // Assert
         Assert.True(discard);
     }
 
-    /// <summary>Running かつ保持理由なしは内容破棄候補。</summary>
+    /// <summary>Running で保持理由なしは破棄候補。</summary>
     [Fact]
-    public void IsContentDiscardCandidate_WhenRunningWithoutReasons_ReturnsTrue()
+    public void IsContentDiscardCandidate_WhenRunningWithoutRetainReasons_ReturnsTrue()
     {
         // Arrange / Act
         var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(
@@ -38,9 +35,9 @@ public sealed class RuntimeCheckpointLifetimePolicyTests
         Assert.True(discard);
     }
 
-    /// <summary>PendingWaits がある Running は保持。</summary>
+    /// <summary>Running で Wait 保持は破棄しない。</summary>
     [Fact]
-    public void IsContentDiscardCandidate_WhenPendingWaits_ReturnsFalse()
+    public void IsContentDiscardCandidate_WhenRunningWithPendingWaits_ReturnsFalse()
     {
         // Arrange / Act
         var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(
@@ -51,18 +48,14 @@ public sealed class RuntimeCheckpointLifetimePolicyTests
         Assert.False(discard);
     }
 
-    /// <summary>両方の保持理由がある Running も内容破棄しない。</summary>
+    /// <summary>Running で物理 Join 保持は破棄しない。</summary>
     [Fact]
-    public void IsContentDiscardCandidate_WhenBothRetainReasons_ReturnsFalse()
+    public void IsContentDiscardCandidate_WhenRunningWithPendingPhysicalJoin_ReturnsFalse()
     {
-        // Arrange
-        var reasons = RuntimeCheckpointRetainReasons.PendingWaits
-            | RuntimeCheckpointRetainReasons.PendingPhysicalJoin;
-
-        // Act
+        // Arrange / Act
         var discard = RuntimeCheckpointLifetimePolicy.IsContentDiscardCandidate(
             ExecutionProjectionStatuses.Running,
-            reasons);
+            RuntimeCheckpointRetainReasons.PendingPhysicalJoin);
 
         // Assert
         Assert.False(discard);


### PR DESCRIPTION
## Summary
- HTTP / Worker 契約は `IExecutionService` のまま、実処理を Query / Idempotency / Projection / Lifecycle / WaitEvent / Checkpoint / Ownership / Recovery / ForkJoin へ分離し、Facade を委譲のみの薄い入口にした。
- 認可と Engine hydrate を `ExecutionAuthorizationGuard` / `ExecutionEngineSession` に集約し、fencing 喪失時の DB 所有残置・PersistUnload ゲート・終端時のみ Discard 後 Unload など既存の耐久性契約は維持した。
- ドメイン向け単体テストと Sonar 新規違反の解消、公開ドキュメント（ドメイン境界・overview・開発ガイドライン・AGENTS.md）を実装に同期した。

## Test plan
- [ ] `cd service/api && dotnet test statevia-api.sln` で既存 `ExecutionService` 系および新規 `ExecutionAuthorizationGuard` / `ExecutionEngineSession` / Facade DI テストが通ること
- [ ] Start / Cancel / Publish / Resume / Recover と checkpoint Unload・Worker 所有 fencing が従来どおり動くこと
- [ ] Hosted 物理 Fork の親 Join 完了・失敗・子完了 Resume が回帰しないこと
- [ ] SonarQube プロジェクト `StateviaServiceApi` の Quality Gate（new_violations / new_coverage）が維持されること

Made with [Cursor](https://cursor.com)