### PR TITLE
Definition の project 認可をユースケースへ引き上げ、Repository を Infrastructure に移す

### DIFF
--- a/core/application/Statevia.Core.Application.Contracts/Persistence/IDefinitionRepository.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/IDefinitionRepository.cs
@@ -47,7 +47,7 @@ public interface IDefinitionRepository
         Guid definitionId,
         CancellationToken ct);
 
-    /// <summary>definition の project_id を返す。存在しなければ null。認可しない。</summary>
+    /// <summary>active catalog の project_id を返す。論理削除済みまたは無ければ null。認可しない。</summary>
     Task<Guid?> ResolveProjectIdAsync(
         ICoreUnitOfWork uow,
         Guid tenantId,

--- a/core/application/Statevia.Core.Application.Contracts/Persistence/IDefinitionRepository.cs
+++ b/core/application/Statevia.Core.Application.Contracts/Persistence/IDefinitionRepository.cs
@@ -1,9 +1,9 @@
 namespace Statevia.Core.Application.Contracts.Persistence;
 
-/// <summary>definitions / definition_versions 永続化。</summary>
+/// <summary>definitions / definition_versions の素の永続化ポート。project 認可は呼び出し元の責任である。</summary>
 public interface IDefinitionRepository
 {
-    /// <summary>Active catalog の最新版を取得する（GET / Graph 用）。</summary>
+    /// <summary>Active catalog の最新版を取得する（GET / Graph 用）。認可しない。</summary>
     Task<DefinitionDetail?> GetLatestForApiAsync(
         ICoreUnitOfWork uow,
         Guid tenantId,
@@ -47,6 +47,7 @@ public interface IDefinitionRepository
         Guid definitionId,
         CancellationToken ct);
 
+    /// <summary>definition の project_id を返す。存在しなければ null。認可しない。</summary>
     Task<Guid?> ResolveProjectIdAsync(
         ICoreUnitOfWork uow,
         Guid tenantId,

--- a/core/application/Statevia.Core.Application/Services/DefinitionService.cs
+++ b/core/application/Statevia.Core.Application/Services/DefinitionService.cs
@@ -4,6 +4,10 @@ using Statevia.Core.Application.Infrastructure;
 namespace Statevia.Core.Application.Services;
 
 /// <summary>ワークフロー定義の登録・更新・一覧・取得。</summary>
+/// <remarks>
+/// <para>Runtime 権限に加え、project ロールは <see cref="IProjectAuthorizationService"/> で明示する。</para>
+/// <para>一覧の project 可視性は Repository の DB フィルタ（Reader）に委譲する。</para>
+/// </remarks>
 internal sealed class DefinitionService : IDefinitionService
 {
     private readonly IDisplayIdService _displayIds;
@@ -11,6 +15,7 @@ internal sealed class DefinitionService : IDefinitionService
     private readonly IDefinitionCompilerService _compiler;
     private readonly IDefinitionRepository _definitions;
     private readonly IProjectRepository _projects;
+    private readonly IProjectAuthorizationService _projectAuth;
     private readonly ITenantContextAccessor _tenantContext;
     private readonly IRuntimePermissionAuthorization _runtimeAuth;
     private readonly IIdGenerator _idGenerator;
@@ -25,6 +30,7 @@ internal sealed class DefinitionService : IDefinitionService
         IDefinitionCompilerService compiler,
         IDefinitionRepository definitions,
         IProjectRepository projects,
+        IProjectAuthorizationService projectAuth,
         ITenantContextAccessor tenantContext,
         IRuntimePermissionAuthorization runtimeAuth,
         IIdGenerator idGenerator,
@@ -36,6 +42,7 @@ internal sealed class DefinitionService : IDefinitionService
         _compiler = compiler;
         _definitions = definitions;
         _projects = projects;
+        _projectAuth = projectAuth;
         _tenantContext = tenantContext;
         _runtimeAuth = runtimeAuth;
         _idGenerator = idGenerator;
@@ -168,6 +175,10 @@ internal sealed class DefinitionService : IDefinitionService
                 if (detail is null)
                     throw new NotFoundException(DefinitionValidationMessages.NotFound);
 
+                await _projectAuth
+                    .EnsureCanReadAsync(uow, tenantId, detail.Definition.ProjectId, innerCt)
+                    .ConfigureAwait(false);
+
                 var displayId = await _displayIds.GetDisplayIdAsync(DisplayIdResourceTypes.Definition, idOrUuid, innerCt)
                     .ConfigureAwait(false);
                 return ToResponse(detail, displayId, includeYaml: true);
@@ -212,7 +223,10 @@ internal sealed class DefinitionService : IDefinitionService
         return await _executor.ExecuteReadCommittedAsync(
             async (uow, innerCt) =>
             {
-                await RequireActiveDefinitionAsync(uow, tenantId, uuid.Value, innerCt).ConfigureAwait(false);
+                var active = await RequireActiveDefinitionAsync(uow, tenantId, uuid.Value, innerCt).ConfigureAwait(false);
+                await _projectAuth
+                    .EnsureCanPublishAsync(uow, tenantId, active.ProjectId, innerCt)
+                    .ConfigureAwait(false);
 
                 var detail = await _definitions
                     .PublishVersionAsync(
@@ -248,7 +262,12 @@ internal sealed class DefinitionService : IDefinitionService
         var deletedAt = DateTime.UtcNow;
 
         var outcome = await _executor.ExecuteReadCommittedAsync(
-            (uow, innerCt) => _definitions.SoftDeleteAsync(uow, tenantId, uuid.Value, deletedAt, innerCt),
+            async (uow, innerCt) =>
+            {
+                await EnsureCanPublishOnDefinitionAsync(uow, tenantId, uuid.Value, innerCt).ConfigureAwait(false);
+                return await _definitions.SoftDeleteAsync(uow, tenantId, uuid.Value, deletedAt, innerCt)
+                    .ConfigureAwait(false);
+            },
             ct).ConfigureAwait(false);
 
         if (outcome == DefinitionSoftDeleteOutcome.NotFound)
@@ -272,6 +291,9 @@ internal sealed class DefinitionService : IDefinitionService
             return await _executor.ExecuteReadCommittedAsync(
                 async (uow, innerCt) =>
                 {
+                    await EnsureCanPublishOnDefinitionAsync(uow, tenantId, uuid.Value, innerCt)
+                        .ConfigureAwait(false);
+
                     var deleted = await RequireDeletedDefinitionAsync(uow, tenantId, uuid.Value, innerCt)
                         .ConfigureAwait(false);
 
@@ -321,6 +343,21 @@ internal sealed class DefinitionService : IDefinitionService
             throw new NotFoundException(DefinitionValidationMessages.NotFound);
 
         return definition;
+    }
+
+    /// <summary>definition の project に Publisher 以上を要求する。無ければ NotFound。</summary>
+    private async Task EnsureCanPublishOnDefinitionAsync(
+        ICoreUnitOfWork uow,
+        Guid tenantId,
+        Guid definitionId,
+        CancellationToken ct)
+    {
+        var projectId = await _definitions.ResolveProjectIdAsync(uow, tenantId, definitionId, ct)
+            .ConfigureAwait(false);
+        if (projectId is null)
+            throw new NotFoundException(DefinitionValidationMessages.NotFound);
+
+        await _projectAuth.EnsureCanPublishAsync(uow, tenantId, projectId.Value, ct).ConfigureAwait(false);
     }
 
     private async Task<DefinitionRow> RequireDeletedDefinitionAsync(

--- a/core/application/Statevia.Core.Application/Services/DefinitionService.cs
+++ b/core/application/Statevia.Core.Application/Services/DefinitionService.cs
@@ -345,7 +345,7 @@ internal sealed class DefinitionService : IDefinitionService
         return definition;
     }
 
-    /// <summary>definition の project に Publisher 以上を要求する。無ければ NotFound。</summary>
+    /// <summary>definition の project に Publisher 以上を要求する。論理削除済みも含む。無ければ NotFound。</summary>
     private async Task EnsureCanPublishOnDefinitionAsync(
         ICoreUnitOfWork uow,
         Guid tenantId,
@@ -354,6 +354,13 @@ internal sealed class DefinitionService : IDefinitionService
     {
         var projectId = await _definitions.ResolveProjectIdAsync(uow, tenantId, definitionId, ct)
             .ConfigureAwait(false);
+        if (projectId is null)
+        {
+            var deleted = await _definitions.GetDeletedCatalogEntryAsync(uow, tenantId, definitionId, ct)
+                .ConfigureAwait(false);
+            projectId = deleted?.ProjectId;
+        }
+
         if (projectId is null)
             throw new NotFoundException(DefinitionValidationMessages.NotFound);
 

--- a/core/application/Statevia.Core.Application/Services/ExecutionAuthorizationGuard.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionAuthorizationGuard.cs
@@ -48,7 +48,7 @@ internal sealed class ExecutionAuthorizationGuard(
     /// <param name="tenantId">テナント ID。</param>
     /// <param name="definitionId">定義 ID。</param>
     /// <param name="ct">キャンセル。</param>
-    /// <exception cref="NotFoundException">定義が見つからないとき。</exception>
+    /// <exception cref="NotFoundException">定義が見つからない、または論理削除済みのとき。</exception>
     public Task EnsureCanExecuteOnDefinitionAsync(
         Guid tenantId,
         Guid definitionId,

--- a/core/application/Statevia.Core.Application/Services/ExecutionLifecycleCommandService.cs
+++ b/core/application/Statevia.Core.Application/Services/ExecutionLifecycleCommandService.cs
@@ -106,11 +106,11 @@ internal sealed class ExecutionLifecycleCommandService(
             throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
 
         var tenantId = tenantContext.GetRequiredTenantId();
+        await authorization.EnsureCanExecuteOnDefinitionAsync(tenantId, defUuid.Value, ct).ConfigureAwait(false);
+
         var versionRow = await ResolveStartDefinitionVersionAsync(tenantId, defUuid.Value, request, ct).ConfigureAwait(false);
         if (versionRow is null)
             throw new NotFoundException(ExecutionValidationMessages.DefinitionNotFound);
-
-        await authorization.EnsureCanExecuteOnDefinitionAsync(tenantId, defUuid.Value, ct).ConfigureAwait(false);
 
         // HTTP 受理経路: キューがある場合は Engine を回さず Start work item を投入する。
         // Worker 文脈（またはテストでキュー未注入）は従来どおり同一プロセスで実行する。

--- a/docs/architecture/domain-model-boundaries.md
+++ b/docs/architecture/domain-model-boundaries.md
@@ -3,9 +3,11 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Architecture |
-| Version | 1.1 |
+| Version | 1.2 |
 | 更新日 | 2026-08-13 |
 | 関連 | [overview.md](overview.md), [data-integration.md](../specifications/data-integration.md) |
+
+**Version 1.2（2026-08-13）**: Definition の project 認可は `DefinitionService`、永続化は Infrastructure の `IDefinitionRepository`。
 
 **Version 1.1（2026-08-13）**: Execution を `IExecutionService` Facade とドメインサービスへ分割した境界を反映。投影キューを実装済みとして実線化する。
 
@@ -37,7 +39,7 @@ flowchart LR
     ProjectionSync["ExecutionOperationalProjectionSync<br/>投影同期"]
     ProjectionQueue["IExecutionProjectionUpdateQueue"]
     EngineCallback["Engine観測コールバック<br/>（目標）"]
-    DefinitionService["DefinitionService<br/>定義版管理"]
+    DefinitionService["DefinitionService<br/>定義版管理 + project 認可"]
   end
 
   subgraph Engine["Core-Engine境界 (Domain Kernel)"]

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -3,11 +3,13 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Architecture |
-| Version | 2.1 |
+| Version | 2.2 |
 | 更新日 | 2026-08-13 |
 | 関連 | [domain-model-boundaries.md](domain-model-boundaries.md), [repository-layout.md](repository-layout.md) |
 
 Project: Statevia — 実行型ステートマシン
+
+**Version 2.2（2026-08-13）**: `IDefinitionRepository` を Infrastructure へ移し、project 認可を Application ユースケースへ引き上げた。
 
 **Version 2.1（2026-08-13）**: Execution ユースケースを `IExecutionService` Facade とドメインサービスへ分割した責務を反映。
 
@@ -104,7 +106,7 @@ flowchart LR
 
 ### 2.2 Core-Application（ユースケース）
 
-- 定義の登録・publish・一覧・取得
+- 定義の登録・publish・一覧・取得。project ロールは `IProjectAuthorizationService` でユースケースがゲートし、`IDefinitionRepository` は素の永続化（Infrastructure）
 - 実行系は `IExecutionService` の薄い Facade。HTTP / Worker は Facade のみを見る
 - 実処理はドメインサービスへ委譲する（Query / Lifecycle / WaitEvent / Checkpoint / Ownership / Recovery / Projection）。冪等は `ExecutionIdempotencyService`、親 Physical Join は `ExecutionForkJoinCoordinator`
 - 横断: `ExecutionAuthorizationGuard`（認可）、`ExecutionEngineSession`（hydrate）。Unload ゲートは Checkpoint 側
@@ -113,7 +115,7 @@ flowchart LR
 
 ### 2.3 Infrastructure
 
-- EF Core 永続化（CoreDbContext、Migrations）
+- EF Core 永続化（CoreDbContext、Migrations、`IDefinitionRepository` を含む Repository 実装）
 - JWT 発行・検証・テナントコンテキスト
 - 通知送信（SMTP）
 - Module ホスト・OCI Source・署名検証

--- a/infrastructure/Statevia.Infrastructure.Persistence/DependencyInjection/PersistenceServiceCollectionExtensions.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/DependencyInjection/PersistenceServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class PersistenceServiceCollectionExtensions
         services.AddScoped<ICoreTransactionExecutor, CoreTransactionExecutor>();
 
         services.AddScoped<IProjectRepository, ProjectRepository>();
+        services.AddScoped<IDefinitionRepository, DefinitionRepository>();
         services.AddScoped<IExecutionRepository, ExecutionRepository>();
         services.AddScoped<IExecutionCursorRepository, ExecutionCursorRepository>();
         services.AddScoped<IExecutionWaitRepository, ExecutionWaitRepository>();

--- a/infrastructure/Statevia.Infrastructure.Persistence/Repositories/DefinitionRepository.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Repositories/DefinitionRepository.cs
@@ -1,9 +1,13 @@
 using Microsoft.EntityFrameworkCore;
-using Statevia.Infrastructure.Persistence;
-using Statevia.Service.Api.Abstractions.Services;
 
-namespace Statevia.Service.Api.Persistence.Repositories;
+namespace Statevia.Infrastructure.Persistence.Repositories;
 
+/// <summary>definitions / definition_versions の EF 永続化。project 認可は行わない。</summary>
+/// <remarks>
+/// <para>呼び出し元（Application / Graph ユースケース）が <see cref="IProjectAuthorizationService"/> でゲートする。</para>
+/// <para>一覧のみ <see cref="ProjectAccessQueries"/> で Reader 以上の project 可視性を DB 側に残す（D2-A）。</para>
+/// <para>単体取得は definitionId / versionId で引き、呼び出し元 tenant の行一致では絞らない（project 共有）。</para>
+/// </remarks>
 internal sealed class DefinitionRepository : IDefinitionRepository
 {
     private sealed class DefinitionWithDisplay
@@ -12,12 +16,6 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         public required DefinitionVersionRow Version { get; init; }
         public string? DisplayId { get; init; }
     }
-
-    private readonly IProjectAuthorizationService _projectAuth;
-
-    /// <summary>新しいインスタンスを初期化する。</summary>
-    public DefinitionRepository(IProjectAuthorizationService projectAuth) =>
-        _projectAuth = projectAuth;
 
     /// <inheritdoc />
     public Task<DefinitionDetail?> GetLatestForApiAsync(
@@ -34,17 +32,10 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         Guid definitionId,
         CancellationToken ct)
     {
-        var definition = await uow.GetDb().Definitions
+        _ = tenantId;
+        return await uow.GetDb().Definitions
             .FirstOrDefaultAsync(x => x.DefinitionId == definitionId && x.DeletedAt == null, ct)
             .ConfigureAwait(false);
-        if (definition is null)
-            return null;
-
-        await _projectAuth
-            .EnsureCanPublishAsync(uow, tenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
-
-        return definition;
     }
 
     /// <inheritdoc />
@@ -63,23 +54,17 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         Guid definitionVersionId,
         CancellationToken ct)
     {
+        _ = tenantId;
         var version = await uow.GetDb().DefinitionVersions.AsNoTracking()
             .FirstOrDefaultAsync(x => x.DefinitionVersionId == definitionVersionId, ct)
             .ConfigureAwait(false);
         if (version is null)
             return null;
 
-        var definition = await uow.GetDb().Definitions.AsNoTracking()
-            .FirstOrDefaultAsync(x => x.DefinitionId == version.DefinitionId, ct)
+        var definitionExists = await uow.GetDb().Definitions.AsNoTracking()
+            .AnyAsync(x => x.DefinitionId == version.DefinitionId, ct)
             .ConfigureAwait(false);
-        if (definition is null)
-            return null;
-
-        await _projectAuth
-            .EnsureCanReadAsync(uow, tenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
-
-        return version;
+        return definitionExists ? version : null;
     }
 
     /// <inheritdoc />
@@ -92,23 +77,15 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         GetVersionInternalAsync(uow, tenantId, definitionId, version, activeParentOnly: true, ct);
 
     /// <inheritdoc />
-    public async Task<DefinitionRow?> GetDeletedCatalogEntryAsync(
+    public Task<DefinitionRow?> GetDeletedCatalogEntryAsync(
         ICoreUnitOfWork uow,
         Guid tenantId,
         Guid definitionId,
         CancellationToken ct)
     {
-        var definition = await uow.GetDb().Definitions.AsNoTracking()
-            .FirstOrDefaultAsync(x => x.DefinitionId == definitionId && x.DeletedAt != null, ct)
-            .ConfigureAwait(false);
-        if (definition is null)
-            return null;
-
-        await _projectAuth
-            .EnsureCanPublishAsync(uow, tenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
-
-        return definition;
+        _ = tenantId;
+        return uow.GetDb().Definitions.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.DefinitionId == definitionId && x.DeletedAt != null, ct);
     }
 
     /// <inheritdoc />
@@ -118,18 +95,11 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         Guid definitionId,
         CancellationToken ct)
     {
+        _ = tenantId;
         var definition = await uow.GetDb().Definitions.AsNoTracking()
             .FirstOrDefaultAsync(x => x.DefinitionId == definitionId, ct)
             .ConfigureAwait(false);
-
-        if (definition is null)
-            return null;
-
-        await _projectAuth
-            .EnsureCanReadAsync(uow, tenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
-
-        return definition.ProjectId;
+        return definition?.ProjectId;
     }
 
     /// <inheritdoc />
@@ -157,10 +127,6 @@ internal sealed class DefinitionRepository : IDefinitionRepository
             .ConfigureAwait(false);
         if (definition is null)
             return null;
-
-        await _projectAuth
-            .EnsureCanPublishAsync(uow, command.TenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
 
         var nextVersion = definition.LatestVersion + 1;
         var now = DateTime.UtcNow;
@@ -219,15 +185,12 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         DateTime deletedAt,
         CancellationToken ct)
     {
+        _ = tenantId;
         var definition = await uow.GetDb().Definitions
             .FirstOrDefaultAsync(x => x.DefinitionId == definitionId, ct)
             .ConfigureAwait(false);
         if (definition is null)
             return DefinitionSoftDeleteOutcome.NotFound;
-
-        await _projectAuth
-            .EnsureCanPublishAsync(uow, tenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
 
         if (definition.DeletedAt is not null)
             return DefinitionSoftDeleteOutcome.AlreadyDeleted;
@@ -244,15 +207,12 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         Guid definitionId,
         CancellationToken ct)
     {
+        _ = tenantId;
         var definition = await uow.GetDb().Definitions
             .FirstOrDefaultAsync(x => x.DefinitionId == definitionId && x.DeletedAt != null, ct)
             .ConfigureAwait(false);
         if (definition is null)
             return null;
-
-        await _projectAuth
-            .EnsureCanPublishAsync(uow, tenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
 
         var now = DateTime.UtcNow;
         definition.DeletedAt = null;
@@ -293,6 +253,7 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         bool tracked,
         CancellationToken ct)
     {
+        _ = tenantId;
         var query = tracked
             ? uow.GetDb().Definitions.AsQueryable()
             : uow.GetDb().Definitions.AsNoTracking();
@@ -305,10 +266,6 @@ internal sealed class DefinitionRepository : IDefinitionRepository
             .ConfigureAwait(false);
         if (definition is null)
             return null;
-
-        await _projectAuth
-            .EnsureCanReadAsync(uow, tenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
 
         var version = await uow.GetDb().DefinitionVersions.AsNoTracking()
             .FirstOrDefaultAsync(
@@ -329,6 +286,7 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         bool activeParentOnly,
         CancellationToken ct)
     {
+        _ = tenantId;
         var definitionQuery = uow.GetDb().Definitions.AsNoTracking()
             .Where(x => x.DefinitionId == definitionId);
         if (activeParentOnly)
@@ -339,10 +297,6 @@ internal sealed class DefinitionRepository : IDefinitionRepository
             .ConfigureAwait(false);
         if (definition is null)
             return null;
-
-        await _projectAuth
-            .EnsureCanReadAsync(uow, tenantId, definition.ProjectId, ct)
-            .ConfigureAwait(false);
 
         return await uow.GetDb().DefinitionVersions.AsNoTracking()
             .FirstOrDefaultAsync(
@@ -401,6 +355,10 @@ internal sealed class DefinitionRepository : IDefinitionRepository
 internal static class ProjectAccessQueries
 {
     /// <summary>指定最小ロール以上でアクセス可能な project_id 集合。</summary>
+    /// <param name="db">EF コンテキスト。</param>
+    /// <param name="tenantId">呼び出し元テナント。</param>
+    /// <param name="minimumRole">一覧に含める最小ロール。</param>
+    /// <returns>アクセス可能な project_id。</returns>
     public static IQueryable<Guid> AccessibleProjectIds(
         CoreDbContext db,
         Guid tenantId,

--- a/infrastructure/Statevia.Infrastructure.Persistence/Repositories/DefinitionRepository.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Repositories/DefinitionRepository.cs
@@ -96,10 +96,11 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         CancellationToken ct)
     {
         _ = tenantId;
-        var definition = await uow.GetDb().Definitions.AsNoTracking()
-            .FirstOrDefaultAsync(x => x.DefinitionId == definitionId, ct)
+        return await uow.GetDb().Definitions.AsNoTracking()
+            .Where(x => x.DefinitionId == definitionId && x.DeletedAt == null)
+            .Select(x => (Guid?)x.ProjectId)
+            .FirstOrDefaultAsync(ct)
             .ConfigureAwait(false);
-        return definition?.ProjectId;
     }
 
     /// <inheritdoc />

--- a/infrastructure/Statevia.Infrastructure.Persistence/Repositories/DefinitionRepository.cs
+++ b/infrastructure/Statevia.Infrastructure.Persistence/Repositories/DefinitionRepository.cs
@@ -246,7 +246,7 @@ internal sealed class DefinitionRepository : IDefinitionRepository
                      && x.DeletedAt == null,
                 ct);
 
-    private async Task<DefinitionDetail?> GetLatestDetailAsync(
+    private static async Task<DefinitionDetail?> GetLatestDetailAsync(
         ICoreUnitOfWork uow,
         Guid tenantId,
         Guid definitionId,
@@ -279,7 +279,7 @@ internal sealed class DefinitionRepository : IDefinitionRepository
         return new DefinitionDetail { Definition = definition, Version = version };
     }
 
-    private async Task<DefinitionVersionRow?> GetVersionInternalAsync(
+    private static async Task<DefinitionVersionRow?> GetVersionInternalAsync(
         ICoreUnitOfWork uow,
         Guid tenantId,
         Guid definitionId,

--- a/service/api/Statevia.Service.Api.Tests/Infrastructure/StubDefinitionRepository.cs
+++ b/service/api/Statevia.Service.Api.Tests/Infrastructure/StubDefinitionRepository.cs
@@ -183,7 +183,9 @@ internal sealed class StubDefinitionRepository : IDefinitionRepository
         _ = uow;
         _ = tenantId;
         _ = ct;
-        if (LatestDetail is null || LatestDetail.Definition.DefinitionId != definitionId)
+        if (LatestDetail is null
+            || LatestDetail.Definition.DefinitionId != definitionId
+            || LatestDetail.Definition.DeletedAt is not null)
             return Task.FromResult<Guid?>(null);
 
         return Task.FromResult<Guid?>(LatestDetail.Definition.ProjectId);

--- a/service/api/Statevia.Service.Api.Tests/Infrastructure/TestRepositoryFactory.cs
+++ b/service/api/Statevia.Service.Api.Tests/Infrastructure/TestRepositoryFactory.cs
@@ -1,13 +1,10 @@
 using Statevia.Infrastructure.Persistence.Repositories;
-using Statevia.Service.Api.Persistence.Repositories;
-using Statevia.Core.Application.Services;
 
 namespace Statevia.Service.Api.Tests.Infrastructure;
 
 /// <summary>本番と同構成の Repository スタックを生成する。</summary>
 internal static class TestRepositoryFactory
 {
-    /// <summary>project 認可付き <see cref="DefinitionRepository"/>。</summary>
-    public static DefinitionRepository CreateDefinitionRepository() =>
-        new(new ProjectAuthorizationService(new ProjectRepository(new DefaultIdGenerator())));
+    /// <summary>認可なしの <see cref="DefinitionRepository"/>（Infrastructure Persistence）。</summary>
+    public static DefinitionRepository CreateDefinitionRepository() => new();
 }

--- a/service/api/Statevia.Service.Api.Tests/Persistence/Repositories/DefinitionRepositoryTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Persistence/Repositories/DefinitionRepositoryTests.cs
@@ -130,10 +130,10 @@ public sealed class DefinitionRepositoryTests
     }
 
     /// <summary>
-    /// 他テナントの版は取得できない。
+    /// 他テナントで呼んでも永続化は版行を返す（認可は Repository の責務ではない）。
     /// </summary>
     [Fact]
-    public async Task GetVersionForExecutionByIdAsync_ReturnsNull_ForOtherTenant()
+    public async Task GetVersionForExecutionByIdAsync_ReturnsVersion_ForOtherTenantCaller()
     {
         // Arrange
         using var db = new SqliteTestDatabase();
@@ -173,11 +173,11 @@ public sealed class DefinitionRepositoryTests
 
         // Act
         await using var uow = await uowFactory.CreateAsync();
-        var ex = await Assert.ThrowsAsync<NotFoundException>(() =>
-            repo.GetVersionForExecutionByIdAsync(uow, otherTenantId, versionId, default));
+        var version = await repo.GetVersionForExecutionByIdAsync(uow, otherTenantId, versionId, default);
 
         // Assert
-        Assert.NotNull(ex);
+        Assert.NotNull(version);
+        Assert.Equal(defId, version!.DefinitionId);
     }
 
     /// <summary>

--- a/service/api/Statevia.Service.Api.Tests/Persistence/Repositories/DefinitionRepositoryTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Persistence/Repositories/DefinitionRepositoryTests.cs
@@ -309,6 +309,67 @@ public sealed class DefinitionRepositoryTests
     }
 
     /// <summary>
+    /// 論理削除済み定義の project_id は解決しない（Start 認可は NotFound になる）。
+    /// </summary>
+    [Fact]
+    public async Task ResolveProjectIdAsync_ReturnsNull_WhenSoftDeleted()
+    {
+        // Arrange
+        using var db = new SqliteTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var repo = TestRepositoryFactory.CreateDefinitionRepository();
+        var defId = Guid.NewGuid();
+        var created = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var projectId = Guid.NewGuid();
+        var deletedAt = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await using (var seed = db.Factory.CreateDbContext())
+        {
+            ProjectTestData.AddDefaultProject(seed, OwnerTenantId, OwnerTenantKey, projectId);
+            DefinitionTestData.AddDefinitionWithVersion(
+                seed, OwnerTenantId, defId, "def-1", projectId, createdAt: created);
+            var definition = await seed.Definitions.FindAsync(defId);
+            definition!.DeletedAt = deletedAt;
+            await seed.SaveChangesAsync();
+        }
+
+        // Act
+        await using var uow = await uowFactory.CreateAsync();
+        var resolved = await repo.ResolveProjectIdAsync(uow, OwnerTenantId, defId, default);
+
+        // Assert
+        Assert.Null(resolved);
+    }
+
+    /// <summary>
+    /// active catalog の project_id を返す。
+    /// </summary>
+    [Fact]
+    public async Task ResolveProjectIdAsync_ReturnsProjectId_WhenActive()
+    {
+        // Arrange
+        using var db = new SqliteTestDatabase();
+        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
+        var repo = TestRepositoryFactory.CreateDefinitionRepository();
+        var defId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        await using (var seed = db.Factory.CreateDbContext())
+        {
+            ProjectTestData.AddDefaultProject(seed, OwnerTenantId, OwnerTenantKey, projectId);
+            DefinitionTestData.AddDefinitionWithVersion(seed, OwnerTenantId, defId, "def-1", projectId);
+            await seed.SaveChangesAsync();
+        }
+
+        // Act
+        await using var uow = await uowFactory.CreateAsync();
+        var resolved = await repo.ResolveProjectIdAsync(uow, OwnerTenantId, defId, default);
+
+        // Assert
+        Assert.Equal(projectId, resolved);
+    }
+
+    /// <summary>
     /// soft delete 後は一覧から除外し、includeDeleted で含める。
     /// </summary>
     [Fact]

--- a/service/api/Statevia.Service.Api.Tests/Services/DefinitionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/DefinitionServiceTests.cs
@@ -21,17 +21,19 @@ public sealed class DefinitionServiceTests
         StubDisplayIdService display,
         IDefinitionCompilerService compiler,
         IDefinitionRepository definitionsRepo,
-        IIdGenerator idGen)
+        IIdGenerator idGen,
+        IProjectAuthorizationService? projectAuth = null,
+        ITenantContextAccessor? tenantAccessor = null)
     {
         var executor = new TestCoreTransactionExecutor(new TestCoreUnitOfWorkFactory(inDb.Factory));
         var projectRepo = new ProjectRepository(new DefaultIdGenerator());
-        var tenantAccessor = new FixedTenantContextAccessor(TestTenantIds.DefaultContext);
         return new DefinitionService(
             display,
             compiler,
             definitionsRepo,
             projectRepo,
-            tenantAccessor,
+            projectAuth ?? new AllowAllProjectAuthorizationService(),
+            tenantAccessor ?? new FixedTenantContextAccessor(TestTenantIds.DefaultContext),
             new AllowAllRuntimePermissionAuthorization(),
             idGen,
             executor);
@@ -361,6 +363,41 @@ public sealed class DefinitionServiceTests
         var compiler = new StubCompiler("{}");
         var idGen = new FixedIdGenerator(Guid.NewGuid());
         var sut = CreateDefinitionService(inDb, display, compiler, definitionsRepo, idGen);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() => sut.GetAsync(guid.ToString(), CancellationToken.None));
+    }
+
+    /// <summary>
+    /// project 権限がない呼び出し元は定義 GET で未検出になる。
+    /// </summary>
+    [Fact]
+    public async Task GetAsync_ThrowsNotFound_WhenCallerLacksProjectRead()
+    {
+        // Arrange
+        using var inDb = new InMemoryTestDatabase();
+        var projectId = await SeedDefaultTenantAndProjectAsync(inDb.Options);
+        var guid = Guid.NewGuid();
+        await using (var ctx = new CoreDbContext(inDb.Options))
+        {
+            DefinitionTestData.AddDefinitionWithVersion(ctx, TestTenantIds.DefaultTenantId, guid, "def", projectId);
+            await ctx.SaveChangesAsync();
+        }
+
+        var display = new StubDisplayIdService();
+        display.ResolveMap["definition|" + guid] = guid;
+        var sut = CreateDefinitionService(
+            inDb,
+            display,
+            new StubCompiler("{}"),
+            TestRepositoryFactory.CreateDefinitionRepository(),
+            new FixedIdGenerator(Guid.NewGuid()),
+            new ProjectAuthorizationService(new ProjectRepository(new DefaultIdGenerator())),
+            new FixedTenantContextAccessor(new TenantContextState(
+                TestTenantIds.OtherTenantId,
+                "other",
+                null,
+                TenantLifecycle.Active)));
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(() => sut.GetAsync(guid.ToString(), CancellationToken.None));

--- a/service/api/Statevia.Service.Api.Tests/Services/ExecutionAuthorizationGuardTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ExecutionAuthorizationGuardTests.cs
@@ -2,6 +2,7 @@ using Statevia.Core.Application.Contracts.Persistence;
 using Statevia.Core.Application.Contracts.Security;
 using Statevia.Core.Application.Contracts.Services;
 using Statevia.Core.Application.Services;
+using Statevia.Infrastructure.Persistence;
 using Statevia.Service.Api.Tests.Infrastructure;
 
 namespace Statevia.Service.Api.Tests.Services;
@@ -110,6 +111,40 @@ public sealed class ExecutionAuthorizationGuardTests
         Assert.Single(projectAuth.ExecuteCalls);
         Assert.Equal(tenantId, projectAuth.ExecuteCalls[0].TenantId);
         Assert.Equal(projectId, projectAuth.ExecuteCalls[0].ProjectId);
+    }
+
+    /// <summary>論理削除済み定義は EnsureCanExecute せず NotFound。</summary>
+    [Fact]
+    public async Task EnsureCanExecuteOnDefinitionAsync_WhenDefinitionSoftDeleted_ThrowsNotFoundWithoutExecute()
+    {
+        // Arrange
+        using var db = new SqliteTestDatabase();
+        var projectId = Guid.NewGuid();
+        var definitionId = Guid.NewGuid();
+        var tenantId = TestTenantIds.DefaultTenantId;
+        var deletedAt = DateTime.UtcNow;
+
+        await using (var seed = db.Factory.CreateDbContext())
+        {
+            ProjectTestData.AddDefaultProject(seed, tenantId, "default", projectId);
+            DefinitionTestData.AddDefinitionWithVersion(seed, tenantId, definitionId, "def", projectId);
+            var definition = await seed.Definitions.FindAsync(definitionId);
+            definition!.DeletedAt = deletedAt;
+            await seed.SaveChangesAsync();
+        }
+
+        var projectAuth = new RecordingProjectAuthorizationService();
+        var sut = new ExecutionAuthorizationGuard(
+            new AllowAllRuntimePermissionAuthorization(),
+            new AllowAllExecutionMutationAuthorization(),
+            projectAuth,
+            TestRepositoryFactory.CreateDefinitionRepository(),
+            new TestCoreTransactionExecutor(new TestCoreUnitOfWorkFactory(db.Factory)));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sut.EnsureCanExecuteOnDefinitionAsync(tenantId, definitionId, CancellationToken.None));
+        Assert.Empty(projectAuth.ExecuteCalls);
     }
 
     private static ExecutionAuthorizationGuard CreateSut(

--- a/service/api/Statevia.Service.Api.Tests/Services/GraphDefinitionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/GraphDefinitionServiceTests.cs
@@ -16,7 +16,8 @@ public sealed class GraphDefinitionServiceTests
             display,
             TestRepositoryFactory.CreateDefinitionRepository(),
             new FixedTenantContextAccessor(TestTenantIds.DefaultContext),
-            new AllowAllRuntimePermissionAuthorization());
+            new AllowAllRuntimePermissionAuthorization(),
+            new AllowAllProjectAuthorizationService());
 
     private static async Task<Guid> SeedDefaultTenantAndProjectAsync(DbContextOptions<CoreDbContext> options)
     {

--- a/service/api/Statevia.Service.Api.Tests/Services/ProjectAuthorizationIntegrationTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/ProjectAuthorizationIntegrationTests.cs
@@ -1,58 +1,95 @@
-
-using Statevia.Service.Api.Contracts;
+using Statevia.Service.Api.Abstractions.Services;
 using Statevia.Infrastructure.Persistence;
+using Statevia.Infrastructure.Persistence.Repositories;
+using Statevia.Core.Application.Services;
 using Statevia.Service.Api.Tests.Infrastructure;
 
 namespace Statevia.Service.Api.Tests.Services;
 
-/// <summary>project_accesses 認可 truth の結合テスト（Repository 層）。</summary>
+/// <summary>project_accesses 認可 truth の結合テスト（ユースケース層）。</summary>
 public sealed class ProjectAuthorizationIntegrationTests
 {
-    /// <summary>別テナントは project_access 未付与で定義取得できない。</summary>
+    /// <summary>別テナントは project_access 未付与で定義 GET できない。</summary>
     [Fact]
-    public async Task GetLatestByIdAsync_CrossTenantWithoutAccess_ReturnsNull()
+    public async Task GetAsync_CrossTenantWithoutAccess_ThrowsNotFound()
     {
         // Arrange
-        using var db = new SqliteTestDatabase();
-        var ownerTenantId = Guid.NewGuid();
-        var otherTenantId = Guid.NewGuid();
+        using var db = new InMemoryTestDatabase();
+        var ownerTenantId = TestTenantIds.DefaultTenantId;
         var defId = Guid.NewGuid();
-        var projectId = Guid.NewGuid();
         var now = DateTime.UtcNow;
-        var repo = TestRepositoryFactory.CreateDefinitionRepository();
-        var uowFactory = new TestCoreUnitOfWorkFactory(db.Factory);
 
-        await using (var seed = db.Factory.CreateDbContext())
+        await using (var seed = new CoreDbContext(db.Options))
         {
             seed.Tenants.Add(new TenantRow
             {
                 TenantId = ownerTenantId,
-                TenantKey = "owner",
+                TenantKey = "default",
                 DisplayName = "Owner",
                 Lifecycle = TenantLifecycle.Active,
                 CreatedAt = now,
                 UpdatedAt = now
             });
-            seed.Tenants.Add(new TenantRow
-            {
-                TenantId = otherTenantId,
-                TenantKey = "other",
-                DisplayName = "Other",
-                Lifecycle = TenantLifecycle.Active,
-                CreatedAt = now,
-                UpdatedAt = now
-            });
-            ProjectTestData.AddDefaultProject(seed, ownerTenantId, "owner", projectId);
-            DefinitionTestData.AddDefinitionWithVersion(seed, ownerTenantId, defId, "shared-def", projectId);
+            var project = ProjectTestData.AddDefaultProject(seed, ownerTenantId, "default");
+            DefinitionTestData.AddDefinitionWithVersion(seed, ownerTenantId, defId, "shared-def", project.ProjectId);
             await seed.SaveChangesAsync();
         }
 
-        // Act
-        await using var uow = await uowFactory.CreateAsync();
-        var ex = await Assert.ThrowsAsync<NotFoundException>(() =>
-            repo.GetLatestForApiAsync(uow, otherTenantId, defId, default));
+        var display = new ResolvingDisplayIdService(defId);
+        var executor = new TestCoreTransactionExecutor(new TestCoreUnitOfWorkFactory(db.Factory));
+        var projectRepo = new ProjectRepository(new DefaultIdGenerator());
+        var sut = new DefinitionService(
+            display,
+            new NoopCompiler(),
+            TestRepositoryFactory.CreateDefinitionRepository(),
+            projectRepo,
+            new ProjectAuthorizationService(projectRepo),
+            new FixedTenantContextAccessor(new TenantContextState(
+                TestTenantIds.OtherTenantId,
+                "other",
+                null,
+                TenantLifecycle.Active)),
+            new AllowAllRuntimePermissionAuthorization(),
+            new DefaultIdGenerator(),
+            executor);
 
-        // Assert
-        Assert.NotNull(ex);
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() => sut.GetAsync(defId.ToString(), CancellationToken.None));
+    }
+
+    private sealed class ResolvingDisplayIdService : IDisplayIdService, IDisplayIdWriteService
+    {
+        private readonly Guid _id;
+
+        public ResolvingDisplayIdService(Guid id) => _id = id;
+
+        public Task<string> AllocateAsync(ICoreUnitOfWork uow, string kind, Guid uuid, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<Guid?> ResolveAsync(string kind, string idOrUuid, CancellationToken ct = default) =>
+            Task.FromResult<Guid?>(_id);
+
+        public Task<string?> GetDisplayIdAsync(string kind, string idOrUuid, CancellationToken ct = default) =>
+            Task.FromResult<string?>(null);
+
+        public Task<IReadOnlyDictionary<Guid, string>> GetDisplayIdsAsync(
+            string kind,
+            IEnumerable<Guid> resourceIds,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class NoopCompiler : IDefinitionCompilerService
+    {
+        public (Statevia.Core.Engine.Abstractions.CompiledWorkflowDefinition Compiled, string CompiledJson) ValidateAndCompile(
+            string name,
+            string yaml,
+            Guid? tenantId = null) =>
+            throw new NotSupportedException();
+
+        public Statevia.Core.Engine.Abstractions.CompiledWorkflowDefinition RestoreFromStoredVersion(
+            string sourceYaml,
+            string compiledJson) =>
+            throw new NotSupportedException();
     }
 }

--- a/service/api/Statevia.Service.Api/Hosting/ServiceCollectionExtensions.cs
+++ b/service/api/Statevia.Service.Api/Hosting/ServiceCollectionExtensions.cs
@@ -20,7 +20,6 @@ using Statevia.Infrastructure.Persistence.DependencyInjection;
 using Statevia.Infrastructure.Security.DependencyInjection;
 using Statevia.Service.Api.Abstractions.Services;
 using Statevia.Service.Api.Persistence;
-using Statevia.Service.Api.Persistence.Repositories;
 using Statevia.Core.Application.DependencyInjection;
 using Statevia.Core.Application.Contracts.Services;
 using Statevia.Core.Engine.Abstractions;
@@ -100,7 +99,6 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IExecutionIdGenerator>(
             sp => new DelegateExecutionIdGenerator(() => sp.GetRequiredService<IIdGenerator>().NewSequentialGuid().ToString()));
         services.AddStateviaExecutionEngine();
-        services.AddScoped<IDefinitionRepository, DefinitionRepository>();
         AddExecutionProjectionQueueOptions(services, configuration);
         services.AddSingleton<ExecutionProjectionUpdateQueueService>();
         services.AddSingleton<IExecutionProjectionUpdateQueue>(sp => sp.GetRequiredService<ExecutionProjectionUpdateQueueService>());

--- a/service/api/Statevia.Service.Api/Services/GraphDefinitionService.cs
+++ b/service/api/Statevia.Service.Api/Services/GraphDefinitionService.cs
@@ -20,19 +20,22 @@ internal sealed class GraphDefinitionService : IGraphDefinitionService
     private readonly IDefinitionRepository _definitions;
     private readonly ITenantContextAccessor _tenantContext;
     private readonly IRuntimePermissionAuthorization _runtimeAuth;
+    private readonly IProjectAuthorizationService _projectAuth;
 
     public GraphDefinitionService(
         ICoreTransactionExecutor executor,
         IDisplayIdService displayIds,
         IDefinitionRepository definitions,
         ITenantContextAccessor tenantContext,
-        IRuntimePermissionAuthorization runtimeAuth)
+        IRuntimePermissionAuthorization runtimeAuth,
+        IProjectAuthorizationService projectAuth)
     {
         _executor = executor;
         _displayIds = displayIds;
         _definitions = definitions;
         _tenantContext = tenantContext;
         _runtimeAuth = runtimeAuth;
+        _projectAuth = projectAuth;
     }
 
     public async Task<GraphDefinitionResponse> GetByGraphIdAsync(string graphId, CancellationToken ct = default)
@@ -53,6 +56,10 @@ internal sealed class GraphDefinitionService : IGraphDefinitionService
                     .ConfigureAwait(false);
                 if (detail is null)
                     throw new NotFoundException("Graph not found");
+
+                await _projectAuth
+                    .EnsureCanReadAsync(uow, tenantId, detail.Definition.ProjectId, innerCt)
+                    .ConfigureAwait(false);
 
                 return BuildFromCompiledJson(graphId, detail.Definition.Name, detail.Version.CompiledJson);
             },


### PR DESCRIPTION
## Summary
- `IDefinitionRepository` から project 認可を外し、実装を Infrastructure Persistence へ移した。認可は `DefinitionService` / `GraphDefinitionService` / `ExecutionAuthorizationGuard` が `IProjectAuthorizationService` で行う。
- HTTP の許可/拒否意味と一覧の Reader 可視性は維持する。Start は Execute を版取得より前に行い、論理削除済み定義は認可時点で NotFound にする（Restore/Delete は削除済み catalog へフォールバック）。
- インスタンス状態を使わない Repository ヘルパーを static にし、公開ドキュメント（overview / ドメイン境界）を実装に同期した。

## Test plan
- [ ] `cd service/api && dotnet test statevia-api.sln` で `DefinitionRepository` / `DefinitionService` / `GraphDefinitionService` / `ExecutionAuthorizationGuard` / `ProjectAuthorizationIntegrationTests` が通ること
- [ ] Definition GET / publish / delete / restore と Graph GET の許可・拒否（NotFound 隠蔽含む）が従来どおりであること
- [ ] 論理削除済み定義の Start が `EnsureCanExecute` せず NotFound になること
- [ ] SonarQube プロジェクト `StateviaServiceApi` の Quality Gate（`new_violations = 0` / `new_coverage ≥ 80%`）が維持されること

Made with [Cursor](https://cursor.com)