### PR TITLE
Fork-Join を単一 Definition として定義時検証し、領域横断を拒否する

### DIFF
--- a/core/application/Statevia.Core.Application/Services/DefinitionService.cs
+++ b/core/application/Statevia.Core.Application/Services/DefinitionService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Statevia.Core.Application.Infrastructure;
+using Statevia.Core.Engine.Definition.Validation;
 
 namespace Statevia.Core.Application.Services;
 
@@ -65,6 +66,13 @@ internal sealed class DefinitionService : IDefinitionService
             throw new ApiValidationException(
                 DefinitionValidationMessages.ValidationFailed,
                 MapActionInputValidationDetails(ex),
+                ex);
+        }
+        catch (DefinitionValidationException ex)
+        {
+            throw new ApiValidationException(
+                DefinitionValidationMessages.ValidationFailed,
+                MapDefinitionValidationDetails(ex),
                 ex);
         }
         catch (ArgumentException ex)
@@ -209,6 +217,13 @@ internal sealed class DefinitionService : IDefinitionService
             throw new ApiValidationException(
                 DefinitionValidationMessages.ValidationFailed,
                 MapActionInputValidationDetails(ex),
+                ex);
+        }
+        catch (DefinitionValidationException ex)
+        {
+            throw new ApiValidationException(
+                DefinitionValidationMessages.ValidationFailed,
+                MapDefinitionValidationDetails(ex),
                 ex);
         }
         catch (ArgumentException ex)
@@ -403,6 +418,20 @@ internal sealed class DefinitionService : IDefinitionService
                 state = error.State,
                 actionId = error.ActionId,
                 jsonPath = error.JsonPath,
+            })
+            .ToArray();
+
+    /// <summary>Engine 検証のルール単位 <c>code</c> を 422 details へ写す。</summary>
+    /// <param name="ex">定義検証例外。</param>
+    /// <returns>details 配列。</returns>
+    private static object[] MapDefinitionValidationDetails(DefinitionValidationException ex) =>
+        ex.Issues
+            .Select(issue => (object)new
+            {
+                code = issue.RuleId,
+                message = issue.Message,
+                field = "yaml",
+                state = issue.StateName,
             })
             .ToArray();
 

--- a/core/engine/Statevia.Core.Engine.Tests/Definition/DefinitionValidationExceptionTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Definition/DefinitionValidationExceptionTests.cs
@@ -1,0 +1,133 @@
+using Statevia.Core.Engine.Definition.Validation;
+using Xunit;
+
+namespace Statevia.Core.Engine.Tests.Definition;
+
+/// <summary><see cref="DefinitionValidationException"/> のメッセージ接頭辞と Issues。</summary>
+public class DefinitionValidationExceptionTests
+{
+    /// <summary>引数なしコンストラクタは空 Issues と既定メッセージ。</summary>
+    [Fact]
+    public void Ctor_Default_SetsEmptyIssues()
+    {
+        // Arrange & Act
+        var ex = new DefinitionValidationException();
+
+        // Assert
+        Assert.Equal("Definition validation failed.", ex.Message);
+        Assert.Empty(ex.Issues);
+    }
+
+    /// <summary>メッセージと内部例外を保持し Issues は空。</summary>
+    [Fact]
+    public void Ctor_MessageAndInner_PreservesInner()
+    {
+        // Arrange
+        var inner = new InvalidOperationException("inner");
+
+        // Act
+        var ex = new DefinitionValidationException("wrapped", inner);
+
+        // Assert
+        Assert.Equal("wrapped", ex.Message);
+        Assert.Same(inner, ex.InnerException);
+        Assert.Empty(ex.Issues);
+    }
+
+    /// <summary>Structural の RuleId は Level 1 接頭辞になる。</summary>
+    [Fact]
+    public void Ctor_WhenStructuralIssue_PrefixesLevel1()
+    {
+        // Arrange
+        var result = new ValidationResult(
+        [
+            new ValidationIssue("Structural.AtLeastOneState", "need a state")
+        ]);
+
+        // Act
+        var ex = new DefinitionValidationException(result);
+
+        // Assert
+        Assert.StartsWith("Level 1 validation failed: ", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("need a state", ex.Message, StringComparison.Ordinal);
+        Assert.Equal("Structural.AtLeastOneState", ex.Issues[0].RuleId);
+    }
+
+    /// <summary>Reachability の RuleId は Level 2 接頭辞になる。</summary>
+    [Fact]
+    public void Ctor_WhenReachabilityIssue_PrefixesLevel2()
+    {
+        // Arrange
+        var result = new ValidationResult(
+        [
+            new ValidationIssue("Reachability.UnreachableStates", "orphan")
+        ]);
+
+        // Act
+        var ex = new DefinitionValidationException(result);
+
+        // Assert
+        Assert.StartsWith("Level 2 validation failed: ", ex.Message, StringComparison.Ordinal);
+        Assert.Equal("Reachability.UnreachableStates", ex.Issues[0].RuleId);
+    }
+
+    /// <summary>ForkRegion の RuleId は汎用接頭辞になる。</summary>
+    [Fact]
+    public void Ctor_WhenForkRegionIssue_UsesGenericPrefix()
+    {
+        // Arrange
+        var result = new ValidationResult(
+        [
+            new ValidationIssue("ForkRegion.EgressWithoutJoin", "egress", "Left")
+        ]);
+
+        // Act
+        var ex = new DefinitionValidationException(result);
+
+        // Assert
+        Assert.StartsWith("Definition validation failed: ", ex.Message, StringComparison.Ordinal);
+        Assert.Equal("Left", ex.Issues[0].StateName);
+    }
+
+    /// <summary>Issues が空の結果は汎用接頭辞のみ。</summary>
+    [Fact]
+    public void Ctor_WhenIssuesEmpty_UsesGenericPrefix()
+    {
+        // Arrange
+        var result = new ValidationResult(Array.Empty<ValidationIssue>());
+
+        // Act
+        var ex = new DefinitionValidationException(result);
+
+        // Assert
+        Assert.Equal("Definition validation failed: ", ex.Message);
+        Assert.Empty(ex.Issues);
+    }
+
+    /// <summary>文字列だけの ValidationResult は RuleId 空の Issue になる。</summary>
+    [Fact]
+    public void ValidationResult_FromMessages_SetsEmptyRuleId()
+    {
+        // Arrange
+        var result = new ValidationResult(["legacy error"]);
+
+        // Act
+        var issue = Assert.Single(result.Issues);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Equal(string.Empty, issue.RuleId);
+        Assert.Equal("legacy error", issue.Message);
+    }
+
+    /// <summary>null の検証結果は ArgumentNullException。</summary>
+    [Fact]
+    public void Ctor_WhenResultIsNull_Throws()
+    {
+        // Arrange
+        ValidationResult result = null!;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new DefinitionValidationException(result));
+    }
+}

--- a/core/engine/Statevia.Core.Engine.Tests/Definition/DefinitionValidatorTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Definition/DefinitionValidatorTests.cs
@@ -70,6 +70,50 @@ public class DefinitionValidatorTests
         Assert.Empty(result.Errors);
     }
 
+    /// <summary>
+    /// Structural 失敗時は Reachability を実行せず、指摘に RuleId が付くことを検証する。
+    /// </summary>
+    [Fact]
+    public void Validate_WhenStructuralFails_SkipsReachabilityAndSetsRuleId()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "Test",
+            States = new Dictionary<string, StateDefinition>()
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Single(result.Issues);
+        Assert.Equal("Structural.AtLeastOneState", result.Issues[0].RuleId);
+        Assert.DoesNotContain(result.Issues, i => i.RuleId.StartsWith("Reachability.", StringComparison.Ordinal));
+    }
+
+    /// <summary>パイプラインに Structural と Reachability の細ルールが登録されていることを検証する。</summary>
+    [Fact]
+    public void Pipeline_RegistersFineGrainedRulesByPhase()
+    {
+        // Arrange
+        var rules = ValidationPipeline.Rules;
+
+        // Act
+        var structural = rules.Where(r => r.Phase == ValidationPhase.Structural).Select(r => r.RuleId).ToArray();
+        var reachability = rules.Where(r => r.Phase == ValidationPhase.Reachability).Select(r => r.RuleId).ToArray();
+
+        // Assert
+        Assert.Contains("Structural.AtLeastOneState", structural);
+        Assert.Contains("Structural.StateGraph", structural);
+        Assert.Contains("Reachability.UnreachableStates", reachability);
+        Assert.Contains("Reachability.CircularJoin", reachability);
+        var forkRegion = rules.Where(r => r.Phase == ValidationPhase.ForkRegion).Select(r => r.RuleId).ToArray();
+        Assert.Contains("ForkRegion.Snapshot", forkRegion);
+        Assert.Contains("ForkRegion.NestedCrossBranch", forkRegion);
+    }
+
     /// <summary>定義が null のとき ArgumentNullException が発生することを検証する。</summary>
     [Fact]
     public void Validate_WhenDefinitionIsNull_ThrowsArgumentNullException()

--- a/core/engine/Statevia.Core.Engine.Tests/Definition/ForkRegionValidationTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Definition/ForkRegionValidationTests.cs
@@ -313,6 +313,36 @@ public class ForkRegionValidationTests
         Assert.True(result.IsValid, string.Join("; ", result.Errors));
     }
 
+    /// <summary>枝先頭 action の先に内側 Fork があるネストは合法（D3）。</summary>
+    [Fact]
+    public void Validate_InnerForkAfterMidAction_Passes()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D3InnerForkFromMidBranch",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["start"] = Next("outer.fork"),
+                ["outer.fork"] = Fork("outer.fast", "mid"),
+                ["outer.fast"] = Next("outer.join"),
+                ["mid"] = Next("inner.fork"),
+                ["inner.fork"] = Fork("inner.a", "inner.b"),
+                ["inner.a"] = Next("inner.join"),
+                ["inner.b"] = Next("inner.join"),
+                ["inner.join"] = Join(["inner.a", "inner.b"], "outer.join"),
+                ["outer.join"] = Join(["outer.fast", "mid"], "end"),
+                ["end"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
     /// <summary>条件遷移（cases/default）経由の Join 供給は合法（D9）。</summary>
     [Fact]
     public void Validate_ConditionalEdgesFeedJoin_Passes()

--- a/core/engine/Statevia.Core.Engine.Tests/Definition/ForkRegionValidationTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Definition/ForkRegionValidationTests.cs
@@ -1,0 +1,792 @@
+using Statevia.Core.Engine.Definition;
+using Statevia.Core.Engine.Definition.Validation;
+using Xunit;
+
+namespace Statevia.Core.Engine.Tests.Definition;
+
+/// <summary>Fork 領域検証（単一 Definition 原則）のシナリオ。</summary>
+public class ForkRegionValidationTests
+{
+    /// <summary>標準 Fork-Join は合法のまま通る。</summary>
+    [Fact]
+    public void Validate_SimpleForkJoin_Passes()
+    {
+        // Arrange
+        var def = CreateSimpleForkJoin();
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    /// <summary>枝先頭 Wait の events 経由で Join に着く定義は供給として合法（E1）。</summary>
+    [Fact]
+    public void Validate_WaitEventsFeedJoin_Passes()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "E1",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Wait2"),
+                ["Left"] = Next("Join"),
+                ["Wait2"] = Wait("Resume", "Right"),
+                ["Right"] = Next("Join"),
+                ["Join"] = Join(["Left", "Wait2"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    /// <summary>領域外から枝先頭へ入る遷移は Ingress で拒否する（A1/C1）。</summary>
+    [Fact]
+    public void Validate_IngressFromOutside_Fails()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "A1",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Right"),
+                ["Left"] = Next("Join"),
+                ["Right"] = Next("Join"),
+                ["Join"] = Join(["Left", "Right"], "Decide"),
+                ["Decide"] = Wait(("Finish", "End"), ("Rogue", "Left")),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.IngressFromOutside");
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.BranchHeadExtraEntry");
+    }
+
+    /// <summary>枝内から Join 以外へ出る遷移は Egress で拒否する（A2）。</summary>
+    [Fact]
+    public void Validate_EgressWithoutJoin_Fails()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "A2",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Right"),
+                ["Left"] = Next("End"),
+                ["Right"] = Next("Join"),
+                ["Join"] = Join(["Left", "Right"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.EgressWithoutJoin");
+    }
+
+    /// <summary>兄弟枝が Join 前に中間ノードを共有する定義は CrossBranch で拒否する（A3）。</summary>
+    [Fact]
+    public void Validate_SiblingBodyOverlap_Fails()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "A3",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Right"),
+                ["Left"] = Next("Shared"),
+                ["Right"] = Next("Shared"),
+                ["Shared"] = Next("Join"),
+                ["Join"] = Join(["Left", "Right"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.CrossBranch");
+    }
+
+    /// <summary>Join 後の Again で同一 Fork に戻る循環は合法（D2）。</summary>
+    [Fact]
+    public void Validate_CyclicReentryAfterJoin_Passes()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "Cyclic",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Next("Fork"),
+                ["Fork"] = Fork("A", "B"),
+                ["A"] = Next("Join"),
+                ["B"] = Next("Join"),
+                ["Join"] = Join(["A", "B"], "Decide"),
+                ["Decide"] = Wait(("Again", "Fork"), ("Finish", "End")),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    /// <summary>error が枝内で Join に戻る定義は合法（D10-A）。</summary>
+    [Fact]
+    public void Validate_ErrorHandlerInsideBranch_Passes()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D10A",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Work"),
+                ["Left"] = Next("Join"),
+                ["Work"] = new StateDefinition
+                {
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition { Next = "Join" },
+                        ["Failed"] = new TransitionDefinition { Next = "Recover" }
+                    }
+                },
+                ["Recover"] = Next("Join"),
+                ["Join"] = Join(["Left", "Work"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    /// <summary>error が領域外へ出る定義は Egress で拒否する（D10-A / D10-C 相当）。</summary>
+    [Fact]
+    public void Validate_ErrorToOutside_Fails()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D10C",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Work"),
+                ["Left"] = Next("Join"),
+                ["Work"] = new StateDefinition
+                {
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition { Next = "Join" },
+                        ["Failed"] = new TransitionDefinition { Next = "End" }
+                    }
+                },
+                ["Join"] = Join(["Left", "Work"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.EgressWithoutJoin");
+    }
+
+    /// <summary>Completed 辺が無く Failed だけ Join する枝は供給なし（D10-B 相当 / B1）。</summary>
+    [Fact]
+    public void Validate_ErrorOnlySupply_FailsJoinNotFed()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D10B",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Work"),
+                ["Left"] = Next("Join"),
+                ["Work"] = new StateDefinition
+                {
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Failed"] = new TransitionDefinition { Next = "Join" }
+                    }
+                },
+                ["Join"] = Join(["Left", "Work"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.JoinNotFed");
+    }
+
+    /// <summary>Wait の一方が Join・他方が領域外なら供給は立つが領域外 events は拒否する（D8）。</summary>
+    [Fact]
+    public void Validate_PartialWaitEventsOutside_FailsWaitTarget()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D8",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Wait2"),
+                ["Left"] = Next("Join"),
+                ["Wait2"] = Wait(("Resume", "Join"), ("Timeout", "End")),
+                ["Join"] = Join(["Left", "Wait2"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.WaitTargetOutside");
+        Assert.DoesNotContain(result.Issues, i => i.RuleId == "ForkRegion.JoinNotFed");
+    }
+
+    /// <summary>3 段ネスト Fork-Join（ui-nested-fork 形）は合法のまま通る。</summary>
+    [Fact]
+    public void Validate_NestedForkJoin_Passes()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "NestedForkSample",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["nest.start"] = Next("nest.outer.fork"),
+                ["nest.outer.fork"] = Fork("nest.outer.fast", "nest.mid.fork"),
+                ["nest.outer.fast"] = Next("nest.outer.join"),
+                ["nest.mid.fork"] = Fork("nest.mid.fast", "nest.inner.fork"),
+                ["nest.mid.fast"] = Next("nest.mid.join"),
+                ["nest.inner.fork"] = Fork("nest.inner.a", "nest.inner.b"),
+                ["nest.inner.a"] = Next("nest.inner.join"),
+                ["nest.inner.b"] = Next("nest.inner.join"),
+                ["nest.inner.join"] = Join(["nest.inner.a", "nest.inner.b"], "nest.mid.join"),
+                ["nest.mid.join"] = Join(["nest.mid.fast", "nest.inner.fork"], "nest.outer.join"),
+                ["nest.outer.join"] = Join(["nest.outer.fast", "nest.mid.fork"], "nest.notify"),
+                ["nest.notify"] = Next("nest.end"),
+                ["nest.end"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    /// <summary>条件遷移（cases/default）経由の Join 供給は合法（D9）。</summary>
+    [Fact]
+    public void Validate_ConditionalEdgesFeedJoin_Passes()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "EdgesSupply",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Chooser"),
+                ["Left"] = Next("Join"),
+                ["Chooser"] = new StateDefinition
+                {
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition
+                        {
+                            Cases =
+                            [
+                                new TransitionCaseDefinition
+                                {
+                                    When = new ConditionExpressionDefinition { Path = "$.x", Op = "gt", Value = 0 },
+                                    Transition = new TransitionDefinition { Next = "Join" }
+                                }
+                            ],
+                            Default = new TransitionDefinition { Next = "Join" }
+                        }
+                    }
+                },
+                ["Join"] = Join(["Left", "Chooser"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    /// <summary>内側枝から外側兄弟への Failed 辺は NestedCross で拒否する（A4）。</summary>
+    [Fact]
+    public void Validate_InnerFailedToOuterSibling_FailsNestedCross()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "A4",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Fast", "InnerFork"),
+                ["Fast"] = Next("OuterJoin"),
+                ["InnerFork"] = Fork("A", "B"),
+                ["A"] = new StateDefinition
+                {
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition { Next = "InnerJoin" },
+                        ["Failed"] = new TransitionDefinition { Next = "Fast" }
+                    }
+                },
+                ["B"] = Next("InnerJoin"),
+                ["InnerJoin"] = Join(["A", "B"], "OuterJoin"),
+                ["OuterJoin"] = Join(["Fast", "InnerFork"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.NestedCrossBranch");
+    }
+
+    /// <summary>非入れ子の並列領域を横断する辺は NestedCross で拒否する。</summary>
+    [Fact]
+    public void Validate_ParallelRegionCross_FailsNestedCross()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "ParallelCross",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("LeftFork", "RightFork"),
+                ["LeftFork"] = Fork("L1", "L2"),
+                ["RightFork"] = Fork("R1", "R2"),
+                ["L1"] = new StateDefinition
+                {
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition { Next = "LeftJoin" },
+                        ["Failed"] = new TransitionDefinition { Next = "R1" }
+                    }
+                },
+                ["L2"] = Next("LeftJoin"),
+                ["R1"] = Next("RightJoin"),
+                ["R2"] = Next("RightJoin"),
+                ["LeftJoin"] = Join(["L1", "L2"], "End"),
+                ["RightJoin"] = Join(["R1", "R2"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.NestedCrossBranch");
+    }
+
+    /// <summary>同一 Join を複数 Fork が供給する定義は AmbiguousJoin で拒否する。</summary>
+    [Fact]
+    public void Validate_TwoForksSameJoinAll_FailsAmbiguousJoin()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "Ambiguous",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Next("F1"),
+                ["F1"] = Fork("A", "B"),
+                ["A"] = Next("Join"),
+                ["B"] = Next("Join"),
+                ["Join"] = Join(["A", "B"], "Decide"),
+                ["Decide"] = Wait(("Again", "F1"), ("Other", "F2"), ("Finish", "End")),
+                ["F2"] = Fork("A", "B"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.AmbiguousJoin");
+    }
+
+    /// <summary>対応 Fork が無い Join は JoinNotFed で拒否する。</summary>
+    [Fact]
+    public void Validate_OrphanJoin_FailsJoinNotFed()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "OrphanJoin",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Next("Join"),
+                ["Join"] = Join(["Start"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.JoinNotFed");
+    }
+
+    /// <summary>枝内 Subscribe が Join を供給する定義は合法。</summary>
+    [Fact]
+    public void Validate_WaitSubscribeFeedsJoin_Passes()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "SubscribeSupply",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Wait2"),
+                ["Left"] = Next("Join"),
+                ["Wait2"] = new StateDefinition
+                {
+                    Wait = new WaitDefinition
+                    {
+                        Subscribe =
+                        [
+                            new WaitSubscribeEntry { Topic = "orders", Next = "Join" }
+                        ]
+                    }
+                },
+                ["Join"] = Join(["Left", "Wait2"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.True(result.IsValid, string.Join("; ", result.Errors));
+    }
+
+    /// <summary>枝内 Subscribe が領域外へ出る定義は WaitTarget で拒否する。</summary>
+    [Fact]
+    public void Validate_WaitSubscribeOutside_FailsWaitTarget()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "SubscribeOutside",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Wait2"),
+                ["Left"] = Next("Join"),
+                ["Wait2"] = new StateDefinition
+                {
+                    Wait = new WaitDefinition
+                    {
+                        Subscribe =
+                        [
+                            new WaitSubscribeEntry { Topic = "ok", Next = "Join" },
+                            new WaitSubscribeEntry { Topic = "timeout", Next = "End" }
+                        ]
+                    }
+                },
+                ["Join"] = Join(["Left", "Wait2"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.WaitTargetOutside");
+    }
+
+    /// <summary>Input.Path の兄弟 <c>$.states</c> 参照は拒否する。</summary>
+    [Fact]
+    public void Validate_SiblingStatesLiteralOnInputPath_Fails()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D1Path",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Right"),
+                ["Left"] = new StateDefinition
+                {
+                    Input = new StateInputDefinition { Path = "$.states.Right.output" },
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition { Next = "Join" }
+                    }
+                },
+                ["Right"] = Next("Join"),
+                ["Join"] = Join(["Left", "Right"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.SiblingStateRef");
+    }
+
+    /// <summary>ブラケット形式の兄弟 <c>$.states['Right']</c> 参照は拒否する。</summary>
+    [Fact]
+    public void Validate_SiblingStatesBracketLiteral_Fails()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D1Bracket",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Right"),
+                ["Left"] = new StateDefinition
+                {
+                    Input = new StateInputDefinition
+                    {
+                        Values = new Dictionary<string, StateInputValueDefinition>
+                        {
+                            ["sibling"] = new() { Path = "$.states['Right'].output" }
+                        }
+                    },
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition { Next = "Join" }
+                    }
+                },
+                ["Right"] = Next("Join"),
+                ["Join"] = Join(["Left", "Right"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.SiblingStateRef");
+    }
+
+    /// <summary>二重引用ブラケットの兄弟参照も拒否する。</summary>
+    [Fact]
+    public void Validate_SiblingStatesDoubleQuoteBracket_Fails()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D1DoubleQuote",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Right"),
+                ["Left"] = new StateDefinition
+                {
+                    Input = new StateInputDefinition
+                    {
+                        Values = new Dictionary<string, StateInputValueDefinition>
+                        {
+                            ["sibling"] = new() { Path = "$.states[\"Right\"].output" }
+                        }
+                    },
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition { Next = "Join" }
+                    }
+                },
+                ["Right"] = Next("Join"),
+                ["Join"] = Join(["Left", "Right"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.SiblingStateRef");
+    }
+
+    /// <summary>対応 Join が無い Fork は MissingJoin で拒否する（C3）。</summary>
+    [Fact]
+    public void Validate_UnpairedFork_FailsMissingJoin()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "C3",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("A", "B"),
+                ["A"] = Next("End"),
+                ["B"] = Next("End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.MissingJoin");
+    }
+
+    /// <summary>Join 前の兄弟 <c>$.states</c> 参照は拒否する。</summary>
+    [Fact]
+    public void Validate_SiblingStatesLiteral_Fails()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "D1",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("Left", "Right"),
+                ["Left"] = new StateDefinition
+                {
+                    Input = new StateInputDefinition
+                    {
+                        Values = new Dictionary<string, StateInputValueDefinition>
+                        {
+                            ["sibling"] = new() { Path = "$.states.Right.output" }
+                        }
+                    },
+                    On = new Dictionary<string, TransitionDefinition>
+                    {
+                        ["Completed"] = new TransitionDefinition { Next = "Join" }
+                    }
+                },
+                ["Right"] = Next("Join"),
+                ["Join"] = Join(["Left", "Right"], "End"),
+                ["End"] = End()
+            }
+        };
+
+        // Act
+        var result = DefinitionValidator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "ForkRegion.SiblingStateRef");
+    }
+
+    private static WorkflowDefinition CreateSimpleForkJoin() =>
+        new()
+        {
+            Name = "Simple",
+            States = new Dictionary<string, StateDefinition>
+            {
+                ["Start"] = Fork("A", "B"),
+                ["A"] = Next("Join"),
+                ["B"] = Next("Join"),
+                ["Join"] = Join(["A", "B"], "End"),
+                ["End"] = End()
+            }
+        };
+
+    private static StateDefinition Fork(params string[] branches) =>
+        new()
+        {
+            On = new Dictionary<string, TransitionDefinition>
+            {
+                ["Completed"] = new TransitionDefinition { Fork = branches }
+            }
+        };
+
+    private static StateDefinition Next(string next) =>
+        new()
+        {
+            On = new Dictionary<string, TransitionDefinition>
+            {
+                ["Completed"] = new TransitionDefinition { Next = next }
+            }
+        };
+
+    private static StateDefinition End() =>
+        new()
+        {
+            On = new Dictionary<string, TransitionDefinition>
+            {
+                ["Completed"] = new TransitionDefinition { End = true }
+            }
+        };
+
+    private static StateDefinition Join(string[] all, string next) =>
+        new()
+        {
+            Join = new JoinDefinition { All = all },
+            On = new Dictionary<string, TransitionDefinition>
+            {
+                ["Joined"] = new TransitionDefinition { Next = next }
+            }
+        };
+
+    private static StateDefinition Wait(string eventName, string next) =>
+        Wait((eventName, next));
+
+    private static StateDefinition Wait(params (string Event, string Next)[] events) =>
+        new()
+        {
+            Wait = new WaitDefinition
+            {
+                Events = events.ToDictionary(e => e.Event, e => e.Next, StringComparer.OrdinalIgnoreCase)
+            }
+        };
+}

--- a/core/engine/Statevia.Core.Engine.Tests/Definition/JoinSupplyTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Definition/JoinSupplyTests.cs
@@ -1,0 +1,104 @@
+using Statevia.Core.Engine.Definition.Validation;
+using Xunit;
+
+namespace Statevia.Core.Engine.Tests.Definition;
+
+/// <summary><see cref="JoinSupply.Reaches"/> の障壁・自己到達・空後続。</summary>
+public class JoinSupplyTests
+{
+    /// <summary>始点と終点が同じなら後続を辿らず true。</summary>
+    [Fact]
+    public void Reaches_WhenFromEqualsTo_ReturnsTrue()
+    {
+        // Arrange
+        var successors = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+        // Act
+        var reached = JoinSupply.Reaches(successors, "Join", "Join");
+
+        // Assert
+        Assert.True(reached);
+    }
+
+    /// <summary>空白の後続名は無視し、有効な経路があれば到達する。</summary>
+    [Fact]
+    public void Reaches_WhenNeighborIsWhitespace_SkipsAndFollowsValid()
+    {
+        // Arrange
+        var successors = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = ["", "  ", "Join"]
+        };
+
+        // Act
+        var reached = JoinSupply.Reaches(successors, "A", "Join");
+
+        // Assert
+        Assert.True(reached);
+    }
+
+    /// <summary>他 Join 障壁を通過しないため外側 Join へ誤供給しない。</summary>
+    [Fact]
+    public void Reaches_WhenBarrierIsOtherJoin_DoesNotTraverse()
+    {
+        // Arrange
+        var successors = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["InnerA"] = ["InnerJoin"],
+            ["InnerJoin"] = ["OuterJoin"]
+        };
+        var barriers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "InnerJoin", "OuterJoin" };
+
+        // Act
+        var reached = JoinSupply.Reaches(successors, "InnerA", "OuterJoin", barriers);
+
+        // Assert
+        Assert.False(reached);
+    }
+
+    /// <summary>障壁集合に終点自身が含まれていても終点到達は true。</summary>
+    [Fact]
+    public void Reaches_WhenTargetIsInBarrierSet_StillReturnsTrueOnHit()
+    {
+        // Arrange
+        var successors = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = ["Join"]
+        };
+        var barriers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Join" };
+
+        // Act
+        var reached = JoinSupply.Reaches(successors, "A", "Join", barriers);
+
+        // Assert
+        Assert.True(reached);
+    }
+
+    /// <summary>後続辞書に始点が無いときは到達しない。</summary>
+    [Fact]
+    public void Reaches_WhenFromHasNoSuccessors_ReturnsFalse()
+    {
+        // Arrange
+        var successors = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Other"] = ["Join"]
+        };
+
+        // Act
+        var reached = JoinSupply.Reaches(successors, "A", "Join");
+
+        // Assert
+        Assert.False(reached);
+    }
+
+    /// <summary>null の供給辞書は ArgumentNullException。</summary>
+    [Fact]
+    public void Reaches_WhenSuccessorsIsNull_Throws()
+    {
+        // Arrange
+        IReadOnlyDictionary<string, IReadOnlyList<string>> successors = null!;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => JoinSupply.Reaches(successors, "A", "B"));
+    }
+}

--- a/core/engine/Statevia.Core.Engine.Tests/Definition/Level2ValidationTests.cs
+++ b/core/engine/Statevia.Core.Engine.Tests/Definition/Level2ValidationTests.cs
@@ -228,4 +228,24 @@ public class Level2ValidationTests
         // Assert
         Assert.True(result.IsValid);
     }
+
+    /// <summary>状態が空のときは初期状態を決められず Reachability が失敗する。</summary>
+    [Fact]
+    public void Validate_WhenNoStates_FailsToDetermineInitialState()
+    {
+        // Arrange
+        var def = new WorkflowDefinition
+        {
+            Name = "Empty",
+            States = new Dictionary<string, StateDefinition>()
+        };
+
+        // Act
+        var result = Level2Validator.Validate(def);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, i => i.RuleId == "Reachability.UnreachableStates");
+        Assert.Contains("initial state", result.Errors[0], StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/CircularJoinRule.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/CircularJoinRule.cs
@@ -1,0 +1,45 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>Join 同士の循環待機を検出する。</summary>
+internal sealed class CircularJoinRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "Reachability.CircularJoin";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.Reachability;
+
+    /// <inheritdoc />
+    public int Weight => 20;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(issues);
+        if (context.InitialState == null)
+        {
+            return;
+        }
+
+        foreach (var (stateName, stateDef) in definition.States)
+        {
+            if (stateDef.Join != null
+                && Level2Validator.HasCircularJoin(
+                    definition,
+                    stateName,
+                    stateDef.Join.All,
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase)))
+            {
+                issues.Add(new ValidationIssue(
+                    RuleId,
+                    $"Circular join detected involving: {stateName}",
+                    stateName));
+            }
+        }
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/ControlEdge.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/ControlEdge.cs
@@ -1,0 +1,49 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>定義上の制御辺の種別。</summary>
+internal enum ControlEdgeKind
+{
+    /// <summary><c>on.Completed</c> 等の成功遷移（<c>next</c> / <c>fork</c> / <c>cases</c>）。</summary>
+    Completed,
+
+    /// <summary><c>on.Failed</c>（nodes の <c>error</c>）。供給には数えない。</summary>
+    Failed,
+
+    /// <summary>Wait <c>events</c>。</summary>
+    WaitEvent,
+
+    /// <summary>Wait <c>subscribe</c>。</summary>
+    Subscribe
+}
+
+/// <summary>状態間の制御辺 1 本。</summary>
+/// <param name="From">始点状態名。</param>
+/// <param name="To">終点状態名。</param>
+/// <param name="Kind">辺の種別。</param>
+internal readonly record struct ControlEdge(string From, string To, ControlEdgeKind Kind)
+{
+    /// <summary>Join 供給の経路に含めるか（D10-A: Failed は含めない）。</summary>
+    public bool CountsAsSupply => Kind is not ControlEdgeKind.Failed;
+}
+
+/// <summary>Fork と対応 Join、各枝 Body。</summary>
+/// <param name="ForkState">Fork 状態（Start）。</param>
+/// <param name="JoinState">対応 Join（End）。</param>
+/// <param name="Branches">枝先頭。</param>
+/// <param name="BranchBodies">枝先頭 → Body 集合（互いに素。Join は含めない）。</param>
+internal sealed record ForkJoinPair(
+    string ForkState,
+    string JoinState,
+    IReadOnlyList<string> Branches,
+    IReadOnlyDictionary<string, IReadOnlySet<string>> BranchBodies)
+{
+    /// <summary>全枝 Body の和（領域内ノード。Fork / Join 自身は含まない）。</summary>
+    public IReadOnlySet<string> RegionBody { get; } = new HashSet<string>(
+        BranchBodies.Values.SelectMany(static b => b),
+        StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>ノードが属する Fork-Join ペアと枝先頭。</summary>
+/// <param name="Pair">所属ペア。</param>
+/// <param name="BranchHead">枝先頭。</param>
+internal readonly record struct BodyLocation(ForkJoinPair Pair, string BranchHead);

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/DefinitionValidationContext.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/DefinitionValidationContext.cs
@@ -1,0 +1,38 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// 1 回の <see cref="DefinitionValidator.Validate"/> で共有するスナップショット。
+/// ルールはこれを読むだけとし、同じグラフ走査を繰り返さない。
+/// </summary>
+/// <remarks>
+/// <para>呼び出し元は <see cref="DefinitionValidator"/>。寿命は 1 回の Validate に閉じる。</para>
+/// <para>Fork 領域集合・Join 供給は ForkRegion フェーズのルールが必要になった時点で載せる。</para>
+/// </remarks>
+public sealed class DefinitionValidationContext
+{
+    /// <summary>検証対象の定義。</summary>
+    public WorkflowDefinition Definition { get; }
+
+    /// <summary>状態名集合（OrdinalIgnoreCase）。</summary>
+    public IReadOnlySet<string> StateNames { get; }
+
+    /// <summary>初期状態。Reachability ルールが設定する。</summary>
+    public string? InitialState { get; internal set; }
+
+    /// <summary>初期状態から到達可能な状態。Reachability ルールが設定する。</summary>
+    public IReadOnlySet<string>? ReachableStates { get; internal set; }
+
+    /// <summary>Fork 領域スナップショット。ForkRegion フェーズ開始時に構築する。</summary>
+    internal ForkRegionSnapshot? ForkRegion { get; set; }
+
+    /// <summary>
+    /// 定義からコンテキストを構築する。
+    /// </summary>
+    /// <param name="definition">検証対象。</param>
+    public DefinitionValidationContext(WorkflowDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        Definition = definition;
+        StateNames = new HashSet<string>(definition.States.Keys, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/DefinitionValidationException.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/DefinitionValidationException.cs
@@ -1,0 +1,57 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// 定義検証失敗。HTTP 422 の <c>code</c> は <see cref="Issues"/> の <see cref="ValidationIssue.RuleId"/> と一致させる。
+/// </summary>
+public sealed class DefinitionValidationException : ArgumentException
+{
+    /// <summary>検証失敗を構築する。</summary>
+    public DefinitionValidationException()
+        : this("Definition validation failed.")
+    {
+    }
+
+    /// <summary>検証失敗を構築する。</summary>
+    /// <param name="message">メッセージ。</param>
+    public DefinitionValidationException(string message)
+        : base(message)
+    {
+        Issues = [];
+    }
+
+    /// <summary>検証失敗を構築する。</summary>
+    /// <param name="message">メッセージ。</param>
+    /// <param name="innerException">内部例外。</param>
+    public DefinitionValidationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Issues = [];
+    }
+
+    /// <summary>検証失敗を構築する。</summary>
+    /// <param name="result">失敗した検証結果。</param>
+    public DefinitionValidationException(ValidationResult result)
+        : base(FormatMessage(result))
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        Issues = result.Issues;
+    }
+
+    /// <summary>ルール単位の指摘。</summary>
+    public IReadOnlyList<ValidationIssue> Issues { get; }
+
+    private static string FormatMessage(ValidationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var firstRuleId = result.Issues.Count > 0 ? result.Issues[0].RuleId : string.Empty;
+        var prefix = firstRuleId switch
+        {
+            var id when id.StartsWith("Structural.", StringComparison.Ordinal) =>
+                "Level 1 validation failed: ",
+            var id when id.StartsWith("Reachability.", StringComparison.Ordinal) =>
+                "Level 2 validation failed: ",
+            _ => "Definition validation failed: "
+        };
+        return prefix + string.Join("; ", result.Errors);
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/DefinitionValidator.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/DefinitionValidator.cs
@@ -1,27 +1,19 @@
 namespace Statevia.Core.Engine.Definition.Validation;
 
 /// <summary>
-/// Level1Validator と Level2Validator を集約し、ワークフロー定義を一括検証します。
-/// Level1（状態名・参照の整合性）→ Level2（到達可能性・循環 Join）の順で実行します。
+/// <see cref="IValidationRule"/> 列をフェーズ順に実行するオーケストレータ。
+/// Structural（旧 Level1）→ Reachability（旧 Level2）→ ForkRegion の順。先行フェーズ失敗時は後続をスキップする。
 /// </summary>
 public static class DefinitionValidator
 {
-    /// <summary>ワークフロー定義を検証し、エラー一覧を返します。Level1 通過後に Level2 を実行します。</summary>
+    /// <summary>
+    /// ワークフロー定義を検証し、エラー一覧を返します。
+    /// </summary>
+    /// <param name="definition">検証対象。</param>
+    /// <returns>指摘付きの検証結果。</returns>
     public static ValidationResult Validate(WorkflowDefinition definition)
     {
         ArgumentNullException.ThrowIfNull(definition);
-        var level1Result = Level1Validator.Validate(definition);
-        if (!level1Result.IsValid)
-        {
-            return level1Result;
-        }
-
-        var level2Result = Level2Validator.Validate(definition);
-        if (!level2Result.IsValid)
-        {
-            return level2Result;
-        }
-
-        return level1Result;
+        return ValidationPipeline.Run(definition, onlyPhase: null);
     }
 }

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/ForkRegionRules.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/ForkRegionRules.cs
@@ -1,0 +1,556 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>Fork 領域スナップショットをコンテキストへ載せる（指摘は出さない）。</summary>
+internal sealed class ForkRegionSnapshotRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.Snapshot";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 0;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(context);
+        context.ForkRegion = ForkRegionSnapshotBuilder.Build(definition);
+        _ = issues;
+    }
+}
+
+/// <summary>A1: 領域外から枝 Body への侵入。</summary>
+internal sealed class ForkRegionIngressRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.IngressFromOutside";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 10;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.Edges
+                .Where(e => !ForkRegionRuleSupport.IsLegalForkEntry(snap, e))
+                .Where(e => ForkRegionRuleSupport.LocateBody(snap, e.To) is not null
+                    && ForkRegionRuleSupport.LocateBody(snap, e.From) is null)
+                .Select(e => new ValidationIssue(
+                    RuleId,
+                    $"Fork region ingress from '{e.From}' into '{e.To}'.",
+                    e.To)));
+    }
+}
+
+/// <summary>A2 / D10-A: Join 経由なしの領域外脱出（Failed 辺を含む）。</summary>
+internal sealed class ForkRegionEgressRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.EgressWithoutJoin";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 20;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.Edges
+                .Where(e => !ForkRegionRuleSupport.IsLegalForkEntry(snap, e))
+                .Select(e => (Edge: e, From: ForkRegionRuleSupport.LocateBody(snap, e.From)))
+                .Where(x => x.From is { } from
+                    && !ForkRegionRuleSupport.IsLegalExit(snap, from.Pair, from.BranchHead, x.Edge.To))
+                .Select(x => new ValidationIssue(
+                    RuleId,
+                    $"Fork region egress from '{x.Edge.From}' to '{x.Edge.To}' without join '{x.From!.Value.Pair.JoinState}'.",
+                    x.Edge.From)));
+    }
+}
+
+/// <summary>A3: 他枝 Body 横断（同一 Fork 兄弟を含む）。</summary>
+internal sealed class ForkRegionCrossBranchRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.CrossBranch";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 30;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.Pairs.SelectMany(pair => pair.BranchBodies
+                .SelectMany(kv => kv.Value.Select(n => (pair.ForkState, Head: kv.Key, Node: n)))
+                .GroupBy(static x => x.Node, StringComparer.OrdinalIgnoreCase)
+                .Where(static g => g.Select(x => x.Head).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1)
+                .Select(g => new ValidationIssue(
+                    RuleId,
+                    $"Fork '{g.First().ForkState}' branch bodies share node '{g.Key}'.",
+                    g.Key))));
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.Edges
+                .Select(e => (
+                    Edge: e,
+                    From: ForkRegionRuleSupport.LocateBody(snap, e.From),
+                    To: ForkRegionRuleSupport.LocateBody(snap, e.To)))
+                .Where(x => x.From is { } from && x.To is { } to
+                    && string.Equals(from.Pair.ForkState, to.Pair.ForkState, StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(from.BranchHead, to.BranchHead, StringComparison.OrdinalIgnoreCase))
+                .Select(x => new ValidationIssue(
+                    RuleId,
+                    $"Cross-branch edge '{x.Edge.From}' → '{x.Edge.To}' in fork '{x.From!.Value.Pair.ForkState}'.",
+                    x.Edge.From)));
+    }
+}
+
+/// <summary>A4: 内側 Body と外側の別枝との横断。</summary>
+internal sealed class ForkRegionNestedCrossRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.NestedCrossBranch";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 40;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(issues, snap.Edges.SelectMany(e => IssuesFor(snap, e)));
+    }
+
+    /// <summary>1 辺について NestedCross 指摘を返す。</summary>
+    private IEnumerable<ValidationIssue> IssuesFor(ForkRegionSnapshot snap, ControlEdge edge)
+    {
+        if (ForkRegionRuleSupport.LocateBody(snap, edge.From) is not { } from
+            || ForkRegionRuleSupport.LocateBody(snap, edge.To) is not { } to)
+        {
+            return [];
+        }
+
+        if (string.Equals(from.Pair.ForkState, to.Pair.ForkState, StringComparison.OrdinalIgnoreCase))
+        {
+            return [];
+        }
+
+        return IssuesForDistinctPairs(snap, edge, from, to);
+    }
+
+    /// <summary>異なる Fork ペア間の横断指摘。</summary>
+    private IEnumerable<ValidationIssue> IssuesForDistinctPairs(
+        ForkRegionSnapshot snap,
+        ControlEdge edge,
+        BodyLocation from,
+        BodyLocation to)
+    {
+        var fromIsInner = ForkRegionSnapshotBuilder.SupplyReaches(
+            snap.Outgoing, from.Pair.JoinState, to.Pair.JoinState);
+        var toIsInner = ForkRegionSnapshotBuilder.SupplyReaches(
+            snap.Outgoing, to.Pair.JoinState, from.Pair.JoinState);
+        if (!fromIsInner && !toIsInner)
+        {
+            return
+            [
+                new ValidationIssue(
+                    RuleId,
+                    $"Nested or parallel region cross '{edge.From}' → '{edge.To}'.",
+                    edge.From)
+            ];
+        }
+
+        return InnerOuterIssues(snap, edge, from, to, fromIsInner, toIsInner);
+    }
+
+    /// <summary>入れ子の内外横断。</summary>
+    private IEnumerable<ValidationIssue> InnerOuterIssues(
+        ForkRegionSnapshot snap,
+        ControlEdge edge,
+        BodyLocation from,
+        BodyLocation to,
+        bool fromIsInner,
+        bool toIsInner)
+    {
+        if (fromIsInner && !string.Equals(edge.To, from.Pair.ForkState, StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new ValidationIssue(
+                RuleId,
+                $"Inner region '{from.Pair.ForkState}' crosses to outer node '{edge.To}'.",
+                edge.From);
+        }
+
+        if (toIsInner && !ForkRegionRuleSupport.IsLegalForkEntry(snap, edge)
+            && !string.Equals(edge.From, to.Pair.ForkState, StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new ValidationIssue(
+                RuleId,
+                $"Outer node '{edge.From}' enters inner region '{to.Pair.ForkState}' at '{edge.To}'.",
+                edge.From);
+        }
+    }
+}
+
+/// <summary>B1: Join-all が供給経路を持たない。</summary>
+internal sealed class ForkRegionJoinNotFedRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.JoinNotFed";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 50;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.UnpairedJoins.Select(joinState => new ValidationIssue(
+                RuleId,
+                $"Join '{joinState}' is not paired with a fork branch set.",
+                joinState)));
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.Pairs.SelectMany(pair => pair.Branches
+                .Where(head => !ForkRegionSnapshotBuilder.SupplyReaches(snap.Outgoing, head, pair.JoinState))
+                .Select(head => new ValidationIssue(
+                    RuleId,
+                    $"Branch '{head}' does not supply join '{pair.JoinState}'.",
+                    head))));
+    }
+}
+
+/// <summary>B2: 非入れ子の複数 Fork が同一 Join を供給する。</summary>
+internal sealed class ForkRegionAmbiguousJoinRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.AmbiguousJoin";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 60;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.AmbiguousJoins.Select(item => new ValidationIssue(
+                RuleId,
+                $"Join '{item.JoinState}' is supplied by multiple forks: {string.Join(", ", item.ForkStates)}.",
+                item.JoinState)));
+    }
+}
+
+/// <summary>C1: 枝先頭への Fork 以外の入口。</summary>
+internal sealed class ForkRegionBranchEntryRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.BranchHeadExtraEntry";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 70;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.Pairs.SelectMany(pair => pair.Branches.SelectMany(head =>
+                IncomingOf(snap, head)
+                    .Where(e => !ForkRegionRuleSupport.IsLegalForkEntry(snap, e))
+                    .Select(e => new ValidationIssue(
+                        RuleId,
+                        $"Branch head '{head}' has extra entry from '{e.From}'.",
+                        head)))));
+    }
+
+    private static IReadOnlyList<ControlEdge> IncomingOf(ForkRegionSnapshot snap, string head) =>
+        snap.Incoming.TryGetValue(head, out var incoming) ? incoming : [];
+}
+
+/// <summary>C3: 対応 Join が無い Fork。</summary>
+internal sealed class ForkRegionMissingJoinRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.MissingJoin";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 80;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.UnpairedForks.Select(forkState => new ValidationIssue(
+                RuleId,
+                $"Fork '{forkState}' has no matching join (branch set as join.all).",
+                forkState)));
+    }
+}
+
+/// <summary>禁止パターン D1: Join 前の他枝 <c>$.states</c> リテラル。</summary>
+internal sealed class ForkRegionSiblingStateRefRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.SiblingStateRef";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 90;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            definition.States
+                .Select(kv => (Name: kv.Key, Def: kv.Value, Loc: ForkRegionRuleSupport.LocateBody(snap, kv.Key)))
+                .Where(x => x.Loc is not null)
+                .SelectMany(x => ForkRegionRuleSupport.EnumerateStatesPathRefs(x.Def)
+                    .Select(referenced => (x.Name, Loc: x.Loc!.Value, Referenced: referenced))
+                    .Where(y => ForkRegionRuleSupport.LocateBody(snap, y.Referenced) is { } other
+                        && string.Equals(y.Loc.Pair.ForkState, other.Pair.ForkState, StringComparison.OrdinalIgnoreCase)
+                        && !string.Equals(y.Loc.BranchHead, other.BranchHead, StringComparison.OrdinalIgnoreCase))
+                    .Select(y => new ValidationIssue(
+                        RuleId,
+                        $"State '{y.Name}' references sibling '{y.Referenced}' before join.",
+                        y.Name))));
+    }
+}
+
+/// <summary>禁止パターン D2: 枝内 Wait の遷移先が領域外または他枝。</summary>
+internal sealed class ForkRegionWaitTargetRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "ForkRegion.WaitTargetOutside";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.ForkRegion;
+
+    /// <inheritdoc />
+    public int Weight => 100;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        if (context.ForkRegion is not { } snap)
+        {
+            return;
+        }
+
+        ForkRegionRuleSupport.AddAll(
+            issues,
+            snap.Edges
+                .Where(static e => e.Kind is ControlEdgeKind.WaitEvent or ControlEdgeKind.Subscribe)
+                .Select(e => (Edge: e, From: ForkRegionRuleSupport.LocateBody(snap, e.From)))
+                .Where(x => x.From is { } from
+                    && !ForkRegionRuleSupport.IsLegalExit(snap, from.Pair, from.BranchHead, x.Edge.To))
+                .Select(x => new ValidationIssue(
+                    RuleId,
+                    $"Wait target '{x.Edge.To}' from '{x.Edge.From}' leaves fork region of '{x.From!.Value.Pair.ForkState}'.",
+                    x.Edge.From)));
+    }
+}
+
+/// <summary>Fork 領域ルールの共有判定。</summary>
+internal static class ForkRegionRuleSupport
+{
+    /// <summary>Fork の branches 辺かどうか。</summary>
+    public static bool IsLegalForkEntry(ForkRegionSnapshot snap, ControlEdge edge) =>
+        snap.Pairs.Any(p =>
+            string.Equals(p.ForkState, edge.From, StringComparison.OrdinalIgnoreCase)
+            && p.Branches.Contains(edge.To, StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>ノードが属するペアと枝先頭。領域外なら null。</summary>
+    public static BodyLocation? LocateBody(ForkRegionSnapshot snap, string node)
+    {
+        var hit = snap.Pairs
+            .SelectMany(pair => pair.BranchBodies.Select(body => (pair, Head: body.Key, Body: body.Value)))
+            .FirstOrDefault(x => x.Body.Contains(node));
+        return hit.pair is null ? null : new BodyLocation(hit.pair, hit.Head);
+    }
+
+    /// <summary>指摘を蓄積する。</summary>
+    public static void AddAll(ICollection<ValidationIssue> issues, IEnumerable<ValidationIssue> found)
+    {
+        foreach (var issue in found)
+        {
+            issues.Add(issue);
+        }
+    }
+
+    /// <summary>同一 Body・当該 Join・入れ子 Fork 開始なら合法出口。</summary>
+    public static bool IsLegalExit(ForkRegionSnapshot snap, ForkJoinPair pair, string fromHead, string to)
+    {
+        if (string.Equals(to, pair.JoinState, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (pair.BranchBodies.TryGetValue(fromHead, out var body) && body.Contains(to))
+        {
+            return true;
+        }
+
+        return snap.Pairs.Any(p =>
+            string.Equals(p.ForkState, to, StringComparison.OrdinalIgnoreCase)
+            && ForkRegionSnapshotBuilder.SupplyReaches(snap.Outgoing, p.JoinState, pair.JoinState));
+    }
+
+    /// <summary><c>input</c> 上の <c>$.states…</c> リテラルが指す状態名。</summary>
+    public static IEnumerable<string> EnumerateStatesPathRefs(StateDefinition stateDef)
+    {
+        var fromPath = stateDef.Input?.Path is { } path
+            ? ExtractStatesNames(path)
+            : [];
+        var fromValues = stateDef.Input?.Values?.Values
+            .Select(static v => v.Path)
+            .OfType<string>()
+            .SelectMany(ExtractStatesNames) ?? [];
+        return fromPath.Concat(fromValues);
+    }
+
+    private static IEnumerable<string> ExtractStatesNames(string path)
+    {
+        const string prefix = "$.states";
+        if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            yield break;
+        }
+
+        var rest = path[prefix.Length..];
+        if (rest.StartsWith("['", StringComparison.Ordinal) || rest.StartsWith("[\"", StringComparison.Ordinal))
+        {
+            var quote = rest[1];
+            var end = rest.IndexOf(quote, 2);
+            if (end > 2)
+            {
+                yield return rest[2..end];
+            }
+
+            yield break;
+        }
+
+        if (rest.Length > 1 && rest[0] == '.')
+        {
+            var name = rest[1..].Split('.')[0];
+            if (name.Length > 0)
+            {
+                yield return name;
+            }
+        }
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/ForkRegionSnapshot.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/ForkRegionSnapshot.cs
@@ -1,0 +1,34 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// Fork 領域検証用の共有スナップショット。1 回の Validate で一度だけ構築する。
+/// </summary>
+internal sealed class ForkRegionSnapshot
+{
+    /// <summary>制御辺（Failed 含む）。</summary>
+    public required IReadOnlyList<ControlEdge> Edges { get; init; }
+
+    /// <summary>始点 → 出辺。</summary>
+    public required IReadOnlyDictionary<string, IReadOnlyList<ControlEdge>> Outgoing { get; init; }
+
+    /// <summary>終点 → 入辺。</summary>
+    public required IReadOnlyDictionary<string, IReadOnlyList<ControlEdge>> Incoming { get; init; }
+
+    /// <summary>Fork 状態 → 枝先頭。</summary>
+    public required IReadOnlyDictionary<string, IReadOnlyList<string>> Forks { get; init; }
+
+    /// <summary>Join 状態 → all。</summary>
+    public required IReadOnlyDictionary<string, IReadOnlyList<string>> Joins { get; init; }
+
+    /// <summary>対応が取れた Fork-Join ペア。</summary>
+    public required IReadOnlyList<ForkJoinPair> Pairs { get; init; }
+
+    /// <summary>対応 Join が無い Fork。</summary>
+    public required IReadOnlyList<string> UnpairedForks { get; init; }
+
+    /// <summary>対応 Fork が無い Join。</summary>
+    public required IReadOnlyList<string> UnpairedJoins { get; init; }
+
+    /// <summary>同一 Join を非入れ子の複数 Fork が供給する組。</summary>
+    public required IReadOnlyList<(string JoinState, IReadOnlyList<string> ForkStates)> AmbiguousJoins { get; init; }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/ForkRegionSnapshotBuilder.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/ForkRegionSnapshotBuilder.cs
@@ -1,0 +1,316 @@
+using Statevia.Core.Engine.FSM;
+
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// 制御辺と Fork-Join ペア・枝 Body を 1 回構築する。
+/// </summary>
+internal static class ForkRegionSnapshotBuilder
+{
+    private static readonly IReadOnlyDictionary<string, TransitionDefinition> EmptyOn =
+        new Dictionary<string, TransitionDefinition>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>定義からスナップショットを構築する。</summary>
+    /// <param name="definition">検証対象。</param>
+    /// <returns>Fork 領域スナップショット。</returns>
+    public static ForkRegionSnapshot Build(WorkflowDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        var edges = CollectEdges(definition);
+        var outgoing = edges
+            .GroupBy(static e => e.From, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static g => g.Key, static g => (IReadOnlyList<ControlEdge>)g.ToArray(), StringComparer.OrdinalIgnoreCase);
+        var incoming = edges
+            .GroupBy(static e => e.To, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static g => g.Key, static g => (IReadOnlyList<ControlEdge>)g.ToArray(), StringComparer.OrdinalIgnoreCase);
+
+        var forks = CollectForks(definition);
+        var joins = CollectJoins(definition);
+        var (pairs, unpairedForks, unpairedJoins, ambiguous) = PairForkJoins(forks, joins);
+
+        var pairsWithBodies = pairs
+            .Select(p => p with { BranchBodies = ComputeBranchBodies(p, pairs, outgoing) })
+            .ToArray();
+
+        return new ForkRegionSnapshot
+        {
+            Edges = edges,
+            Outgoing = outgoing,
+            Incoming = incoming,
+            Forks = forks,
+            Joins = joins,
+            Pairs = pairsWithBodies,
+            UnpairedForks = unpairedForks,
+            UnpairedJoins = unpairedJoins,
+            AmbiguousJoins = ambiguous
+        };
+    }
+
+    /// <summary>供給辺だけで <paramref name="from"/> から <paramref name="to"/> へ到達できるか。</summary>
+    public static bool SupplyReaches(
+        IReadOnlyDictionary<string, IReadOnlyList<ControlEdge>> outgoing,
+        string from,
+        string to)
+    {
+        return Reaches(outgoing, from, to, supplyOnly: true);
+    }
+
+    /// <summary><paramref name="from"/> から <paramref name="to"/> へ制御辺で到達できるか。</summary>
+    public static bool Reaches(
+        IReadOnlyDictionary<string, IReadOnlyList<ControlEdge>> outgoing,
+        string from,
+        string to,
+        bool supplyOnly)
+    {
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        if (comparer.Equals(from, to))
+        {
+            return true;
+        }
+
+        var visited = new HashSet<string>(comparer) { from };
+        var queue = new Queue<string>();
+        queue.Enqueue(from);
+        while (queue.Count > 0)
+        {
+            if (!outgoing.TryGetValue(queue.Dequeue(), out var list))
+            {
+                continue;
+            }
+
+            if (list.Any(edge => VisitReachable(edge, to, supplyOnly, comparer, visited, queue)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>1 本の制御辺を辿り、終点なら true。</summary>
+    private static bool VisitReachable(
+        ControlEdge edge,
+        string to,
+        bool supplyOnly,
+        StringComparer comparer,
+        HashSet<string> visited,
+        Queue<string> queue)
+    {
+        if (supplyOnly && !edge.CountsAsSupply)
+        {
+            return false;
+        }
+
+        if (!visited.Add(edge.To))
+        {
+            return false;
+        }
+
+        if (comparer.Equals(edge.To, to))
+        {
+            return true;
+        }
+
+        queue.Enqueue(edge.To);
+        return false;
+    }
+
+    private static List<ControlEdge> CollectEdges(WorkflowDefinition definition) =>
+        definition.States.SelectMany(static kv => EdgesFrom(kv.Key, kv.Value)).ToList();
+
+    private static IEnumerable<ControlEdge> EdgesFrom(string stateName, StateDefinition stateDef)
+    {
+        var onEdges = (stateDef.On ?? EmptyOn)
+            .SelectMany(kv =>
+            {
+                var kind = IsFailedFact(kv.Key) ? ControlEdgeKind.Failed : ControlEdgeKind.Completed;
+                return EnumerateTargets(kv.Value).Select(to => new ControlEdge(stateName, to, kind));
+            });
+        if (stateDef.Wait is not { } wait)
+        {
+            return onEdges;
+        }
+
+        var waitEdges = wait.Events.Values.Select(to => new ControlEdge(stateName, to, ControlEdgeKind.WaitEvent));
+        var subscribeEdges = wait.Subscribe.Select(sub => new ControlEdge(stateName, sub.Next, ControlEdgeKind.Subscribe));
+        return onEdges.Concat(waitEdges).Concat(subscribeEdges);
+    }
+
+    private static bool IsFailedFact(string fact) =>
+        string.Equals(fact, Fact.Failed, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(fact, Fact.Cancelled, StringComparison.OrdinalIgnoreCase);
+
+    private static IEnumerable<string> EnumerateTargets(TransitionDefinition? trans)
+    {
+        if (trans is null)
+        {
+            return [];
+        }
+
+        IEnumerable<string> next = string.IsNullOrWhiteSpace(trans.Next) ? [] : [trans.Next];
+        IEnumerable<string> forks = trans.Fork?.Where(static s => !string.IsNullOrWhiteSpace(s)) ?? [];
+        IEnumerable<string> cases = trans.Cases?.SelectMany(static c => EnumerateTargets(c.Transition)) ?? [];
+        return next.Concat(forks).Concat(cases).Concat(EnumerateTargets(trans.Default));
+    }
+
+    private static Dictionary<string, IReadOnlyList<string>> CollectForks(WorkflowDefinition definition) =>
+        definition.States
+            .Select(kv => (
+                kv.Key,
+                Branches: kv.Value.On?.Values
+                    .Select(static t => t.Fork)
+                    .FirstOrDefault(static f => f is { Count: > 0 })))
+            .Where(static x => x.Branches is { Count: > 0 })
+            .ToDictionary(static x => x.Key, static x => x.Branches!, StringComparer.OrdinalIgnoreCase);
+
+    private static Dictionary<string, IReadOnlyList<string>> CollectJoins(WorkflowDefinition definition) =>
+        definition.States
+            .Where(static kv => kv.Value.Join?.All is { Count: > 0 })
+            .ToDictionary(
+                static kv => kv.Key,
+                static kv => kv.Value.Join!.All,
+                StringComparer.OrdinalIgnoreCase);
+
+    private static (
+        List<ForkJoinPair> Pairs,
+        List<string> UnpairedForks,
+        List<string> UnpairedJoins,
+        List<(string JoinState, IReadOnlyList<string> ForkStates)> Ambiguous) PairForkJoins(
+        IReadOnlyDictionary<string, IReadOnlyList<string>> forks,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> joins)
+    {
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        var pairs = new List<ForkJoinPair>();
+        var unpairedForks = new List<string>();
+        var joinOwners = new Dictionary<string, List<string>>(comparer);
+
+        foreach (var (forkState, branches) in forks)
+        {
+            var branchSet = new HashSet<string>(branches, comparer);
+            var matches = joins
+                .Where(j => branchSet.SetEquals(j.Value))
+                .Select(static j => j.Key)
+                .ToList();
+            switch (matches.Count)
+            {
+                case 1:
+                    var joinState = matches[0];
+                    pairs.Add(new ForkJoinPair(
+                        forkState,
+                        joinState,
+                        branches,
+                        new Dictionary<string, IReadOnlySet<string>>(comparer)));
+                    if (!joinOwners.TryGetValue(joinState, out var owners))
+                    {
+                        owners = [];
+                        joinOwners[joinState] = owners;
+                    }
+
+                    owners.Add(forkState);
+                    break;
+                default:
+                    unpairedForks.Add(forkState);
+                    break;
+            }
+        }
+
+        var pairedJoins = new HashSet<string>(pairs.Select(static p => p.JoinState), comparer);
+        var unpairedJoins = joins.Keys.Where(j => !pairedJoins.Contains(j)).ToList();
+        var ambiguous = joinOwners
+            .Where(static kv => kv.Value.Count > 1)
+            .Select(kv => (kv.Key, (IReadOnlyList<string>)kv.Value))
+            .ToList();
+
+        return (pairs, unpairedForks, unpairedJoins, ambiguous);
+    }
+
+    private static Dictionary<string, IReadOnlySet<string>> ComputeBranchBodies(
+        ForkJoinPair pair,
+        IReadOnlyList<ForkJoinPair> allPairs,
+        IReadOnlyDictionary<string, IReadOnlyList<ControlEdge>> outgoing)
+    {
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        var nestedForks = new HashSet<string>(
+            allPairs
+                .Where(p => !comparer.Equals(p.ForkState, pair.ForkState)
+                    && SupplyReaches(outgoing, p.JoinState, pair.JoinState))
+                .Select(static p => p.ForkState),
+            comparer);
+        var siblingHeads = new HashSet<string>(pair.Branches, comparer);
+        return pair.Branches.ToDictionary(
+            head => head,
+            head => (IReadOnlySet<string>)WalkBody(head, pair.JoinState, siblingHeads, nestedForks, outgoing),
+            comparer);
+    }
+
+    private static HashSet<string> WalkBody(
+        string head,
+        string joinState,
+        HashSet<string> siblingHeads,
+        HashSet<string> nestedForks,
+        IReadOnlyDictionary<string, IReadOnlyList<ControlEdge>> outgoing)
+    {
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        var body = new HashSet<string>(comparer);
+        var visited = new HashSet<string>(comparer) { head };
+        var queue = new Queue<string>();
+        queue.Enqueue(head);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (IsOutsideWalk(current, head, joinState, siblingHeads, comparer))
+            {
+                continue;
+            }
+
+            body.Add(current);
+            if (nestedForks.Contains(current))
+            {
+                continue;
+            }
+
+            EnqueueBodyNeighbors(current, joinState, visited, queue, outgoing, comparer);
+        }
+
+        return body;
+    }
+
+    /// <summary>Join または兄弟枝先頭なら Body に含めない。</summary>
+    private static bool IsOutsideWalk(
+        string current,
+        string head,
+        string joinState,
+        HashSet<string> siblingHeads,
+        StringComparer comparer) =>
+        comparer.Equals(current, joinState)
+        || (siblingHeads.Contains(current) && !comparer.Equals(current, head));
+
+    /// <summary>Join へ到達できる未訪問後続だけを Body 走査へ載せる。</summary>
+    private static void EnqueueBodyNeighbors(
+        string current,
+        string joinState,
+        HashSet<string> visited,
+        Queue<string> queue,
+        IReadOnlyDictionary<string, IReadOnlyList<ControlEdge>> outgoing,
+        StringComparer comparer)
+    {
+        if (!outgoing.TryGetValue(current, out var list))
+        {
+            return;
+        }
+
+        foreach (var target in list.Select(static e => e.To))
+        {
+            if (comparer.Equals(target, joinState) || !visited.Add(target))
+            {
+                continue;
+            }
+
+            if (Reaches(outgoing, target, joinState, supplyOnly: false))
+            {
+                queue.Enqueue(target);
+            }
+        }
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/IValidationRule.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/IValidationRule.cs
@@ -1,0 +1,27 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// 定義検証の 1 単位。オーケストレータはフェーズ順・Weight 順に列を回すだけとする。
+/// </summary>
+public interface IValidationRule
+{
+    /// <summary>安定 <c>code</c>。Fork 領域ルールは <c>ForkRegion.*</c>。</summary>
+    string RuleId { get; }
+
+    /// <summary>所属フェーズ。</summary>
+    ValidationPhase Phase { get; }
+
+    /// <summary>フェーズ内順（昇順。同値は <see cref="RuleId"/>）。</summary>
+    int Weight { get; }
+
+    /// <summary>
+    /// 定義を検証し、検出した指摘を <paramref name="issues"/> へ追加する。
+    /// </summary>
+    /// <param name="definition">検証対象。</param>
+    /// <param name="context">1 回の Validate で共有するスナップショット。</param>
+    /// <param name="issues">指摘の蓄積先。</param>
+    void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues);
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/JoinSupply.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/JoinSupply.cs
@@ -1,0 +1,82 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// Join 供給経路の到達判定。呼び出し側は <c>error</c> / Failed 辺を後続に含めない。
+/// </summary>
+/// <remarks>
+/// <para>Loader の枝→Join 照合と Engine の Fork 領域検証が同じ 1 経路判定を共有する。</para>
+/// <para>供給辺は <c>next</c> / <c>wait.events</c> / <c>edges</c>。ネスト Fork は呼び出し側で内側 Join 出口へ正規化する。</para>
+/// </remarks>
+public static class JoinSupply
+{
+    /// <summary>供給後続だけを辿って <paramref name="from"/> から <paramref name="to"/> へ到達できるか。</summary>
+    /// <param name="supplySuccessors">状態名 → 供給後続（Failed / error を含めてはならない）。</param>
+    /// <param name="from">始点。</param>
+    /// <param name="to">終点（通常は Join）。</param>
+    /// <param name="doNotTraverse">通過してはならないノード（対象 <paramref name="to"/> 自身は除く。他 Join など）。</param>
+    /// <returns>1 経路でも届けば <see langword="true"/>。</returns>
+    /// <remarks>
+    /// 他 Join を通過すると内側枝が外側 Join を誤供給するため、Loader は Join 名集合を渡す。
+    /// </remarks>
+    public static bool Reaches(
+        IReadOnlyDictionary<string, IReadOnlyList<string>> supplySuccessors,
+        string from,
+        string to,
+        IReadOnlySet<string>? doNotTraverse = null)
+    {
+        ArgumentNullException.ThrowIfNull(supplySuccessors);
+        ArgumentException.ThrowIfNullOrWhiteSpace(from);
+        ArgumentException.ThrowIfNullOrWhiteSpace(to);
+
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        if (comparer.Equals(from, to))
+        {
+            return true;
+        }
+
+        var visited = new HashSet<string>(comparer) { from };
+        var queue = new Queue<string>();
+        queue.Enqueue(from);
+        while (queue.Count > 0)
+        {
+            if (!supplySuccessors.TryGetValue(queue.Dequeue(), out var list))
+            {
+                continue;
+            }
+
+            if (list.Any(next => VisitSupplyNeighbor(next, to, comparer, visited, doNotTraverse, queue)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>供給後続を訪問し、終点なら true。障壁ならキューに載せない。</summary>
+    private static bool VisitSupplyNeighbor(
+        string next,
+        string to,
+        StringComparer comparer,
+        HashSet<string> visited,
+        IReadOnlySet<string>? doNotTraverse,
+        Queue<string> queue)
+    {
+        if (string.IsNullOrWhiteSpace(next) || !visited.Add(next))
+        {
+            return false;
+        }
+
+        if (comparer.Equals(next, to))
+        {
+            return true;
+        }
+
+        if (doNotTraverse is null || !doNotTraverse.Contains(next))
+        {
+            queue.Enqueue(next);
+        }
+
+        return false;
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/Level1Validator.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/Level1Validator.cs
@@ -10,17 +10,20 @@ namespace Statevia.Core.Engine.Definition.Validation;
 /// </summary>
 public static class Level1Validator
 {
-    /// <summary>ワークフロー定義を検証し、エラー一覧を返します。</summary>
+    /// <summary>ワークフロー定義を検証し、エラー一覧を返します（Structural フェーズのみ）。</summary>
     public static ValidationResult Validate(WorkflowDefinition definition)
     {
         ArgumentNullException.ThrowIfNull(definition);
-        var errors = new List<string>();
-        if (definition.States.Count == 0)
-        {
-            errors.Add("At least one state is required.");
-            return new ValidationResult(errors);
-        }
+        return ValidationPipeline.Run(definition, ValidationPhase.Structural);
+    }
 
+    /// <summary>
+    /// 空でない定義に対する状態グラフ検査（名前・遷移・Wait・Join・input/output・終端）。
+    /// </summary>
+    /// <param name="definition">検証対象（状態 1 件以上）。</param>
+    /// <param name="errors">検出したエラーメッセージの蓄積先。</param>
+    internal static void CollectStateGraphErrors(WorkflowDefinition definition, List<string> errors)
+    {
         var stateNames = new HashSet<string>(definition.States.Keys, StringComparer.OrdinalIgnoreCase);
         var terminalTransitionCount = 0;
 
@@ -41,7 +44,6 @@ public static class Level1Validator
             errors.Add("At least one terminal transition (end: true) is required.");
         }
 
-        return new ValidationResult(errors);
     }
 
     /// <summary>状態名が空でないことを検証する。</summary>
@@ -601,19 +603,4 @@ public static class Level1Validator
         }
     }
 
-}
-
-/// <summary>検証結果。エラー一覧と有効フラグを保持します。</summary>
-public sealed class ValidationResult
-{
-    /// <summary>検出されたエラーメッセージの一覧。</summary>
-    public IReadOnlyList<string> Errors { get; }
-    /// <summary>エラーが 0 件の場合 true。</summary>
-    public bool IsValid => Errors.Count == 0;
-
-    /// <summary>
-    /// 検証で収集したエラーメッセージで結果を構築する。
-    /// </summary>
-    /// <param name="errors">エラーメッセージの一覧。</param>
-    public ValidationResult(IReadOnlyList<string> errors) => Errors = errors;
 }

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/Level2Validator.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/Level2Validator.cs
@@ -5,34 +5,22 @@ namespace Statevia.Core.Engine.Definition.Validation;
 /// </summary>
 public static class Level2Validator
 {
-    /// <summary>ワークフロー定義を検証し、エラー一覧を返します。</summary>
+    /// <summary>ワークフロー定義を検証し、エラー一覧を返します（Reachability フェーズのみ）。</summary>
     public static ValidationResult Validate(WorkflowDefinition definition)
     {
         ArgumentNullException.ThrowIfNull(definition);
-        var errors = new List<string>();
-        var stateNames = new HashSet<string>(definition.States.Keys, StringComparer.OrdinalIgnoreCase);
-        var initialState = FindInitialState(definition);
-        if (initialState == null) { errors.Add("Could not determine initial state."); return new ValidationResult(errors); }
-
-        var reachable = ComputeReachableStates(definition, initialState);
-        var unreachable = stateNames.Except(reachable, StringComparer.OrdinalIgnoreCase).ToList();
-        if (unreachable.Count > 0)
-        {
-            errors.Add($"Unreachable states: {string.Join(", ", unreachable)}");
-        }
-
-        foreach (var (stateName, stateDef) in definition.States)
-        {
-            if (stateDef.Join != null && HasCircularJoin(definition, stateName, stateDef.Join.All, new HashSet<string>(StringComparer.OrdinalIgnoreCase)))
-            {
-                errors.Add($"Circular join detected involving: {stateName}");
-            }
-        }
-        return new ValidationResult(errors);
+        return ValidationPipeline.Run(definition, ValidationPhase.Reachability);
     }
 
-    private static string? FindInitialState(WorkflowDefinition definition)
+    /// <summary>参照されていない状態を初期状態とする。状態が空なら null。</summary>
+    /// <param name="definition">検証対象。</param>
+    /// <returns>初期状態名。状態が無いとき null。</returns>
+    internal static string? FindInitialState(WorkflowDefinition definition)
     {
+        if (definition.States.Count == 0)
+        {
+            return null;
+        }
         var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var (_, stateDef) in definition.States)
         {
@@ -56,7 +44,11 @@ public static class Level2Validator
         return definition.States.Keys.FirstOrDefault(s => !referenced.Contains(s)) ?? definition.States.Keys.First();
     }
 
-    private static HashSet<string> ComputeReachableStates(WorkflowDefinition definition, string start)
+    /// <summary>初期状態から到達可能な状態名を計算する。</summary>
+    /// <param name="definition">検証対象。</param>
+    /// <param name="start">開始状態名。</param>
+    /// <returns>到達可能な状態名。</returns>
+    internal static HashSet<string> ComputeReachableStates(WorkflowDefinition definition, string start)
     {
         var reachable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var queue = new Queue<string>();
@@ -220,7 +212,13 @@ public static class Level2Validator
         }
     }
 
-    private static bool HasCircularJoin(WorkflowDefinition definition, string joinState, IReadOnlyList<string> allOf, HashSet<string> visited)
+    /// <summary>Join の all 依存を辿り循環があれば true。</summary>
+    /// <param name="definition">検証対象。</param>
+    /// <param name="joinState">起点の Join 状態名。</param>
+    /// <param name="allOf">当該 Join の all。</param>
+    /// <param name="visited">走査中の Join 名。</param>
+    /// <returns>循環があれば true。</returns>
+    internal static bool HasCircularJoin(WorkflowDefinition definition, string joinState, IReadOnlyList<string> allOf, HashSet<string> visited)
     {
         if (!visited.Add(joinState))
         {

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/RequiredStatesRule.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/RequiredStatesRule.cs
@@ -1,0 +1,29 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>状態が 1 件以上あることを検証する。</summary>
+internal sealed class RequiredStatesRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "Structural.AtLeastOneState";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.Structural;
+
+    /// <inheritdoc />
+    public int Weight => 10;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(issues);
+        if (definition.States.Count == 0)
+        {
+            issues.Add(new ValidationIssue(RuleId, "At least one state is required."));
+        }
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/StateGraphRule.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/StateGraphRule.cs
@@ -1,0 +1,38 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// 状態名・遷移形状・Wait・Join 参照・input/output・終端遷移など、旧 Level1 の状態グラフ検査。
+/// </summary>
+internal sealed class StateGraphRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "Structural.StateGraph";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.Structural;
+
+    /// <inheritdoc />
+    public int Weight => 20;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(issues);
+        if (context.StateNames.Count == 0)
+        {
+            return;
+        }
+
+        var errors = new List<string>();
+        Level1Validator.CollectStateGraphErrors(definition, errors);
+        foreach (var message in errors)
+        {
+            issues.Add(new ValidationIssue(RuleId, message));
+        }
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/UnreachableStatesRule.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/UnreachableStatesRule.cs
@@ -1,0 +1,43 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>初期状態から到達できない状態を検出する。</summary>
+internal sealed class UnreachableStatesRule : IValidationRule
+{
+    /// <inheritdoc />
+    public string RuleId => "Reachability.UnreachableStates";
+
+    /// <inheritdoc />
+    public ValidationPhase Phase => ValidationPhase.Reachability;
+
+    /// <inheritdoc />
+    public int Weight => 10;
+
+    /// <inheritdoc />
+    public void Validate(
+        WorkflowDefinition definition,
+        DefinitionValidationContext context,
+        ICollection<ValidationIssue> issues)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(issues);
+
+        var initialState = Level2Validator.FindInitialState(definition);
+        context.InitialState = initialState;
+        if (initialState == null)
+        {
+            issues.Add(new ValidationIssue(RuleId, "Could not determine initial state."));
+            return;
+        }
+
+        var reachable = Level2Validator.ComputeReachableStates(definition, initialState);
+        context.ReachableStates = reachable;
+        var unreachable = context.StateNames.Except(reachable, StringComparer.OrdinalIgnoreCase).ToList();
+        if (unreachable.Count > 0)
+        {
+            issues.Add(new ValidationIssue(
+                RuleId,
+                $"Unreachable states: {string.Join(", ", unreachable)}"));
+        }
+    }
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/ValidationIssue.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/ValidationIssue.cs
@@ -1,0 +1,9 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// 定義検証の 1 件。安定 <c>code</c>（<see cref="RuleId"/>）とメッセージを持つ。
+/// </summary>
+/// <param name="RuleId">ルール識別子。HTTP / CLI の <c>code</c> と一致させる。</param>
+/// <param name="Message">人向けメッセージ（既存 <see cref="ValidationResult.Errors"/> と互換）。</param>
+/// <param name="StateName">対象状態名。ワークフロー全体の指摘では null。</param>
+public sealed record ValidationIssue(string RuleId, string Message, string? StateName = null);

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/ValidationPhase.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/ValidationPhase.cs
@@ -1,0 +1,16 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// 定義検証ルールの実行フェーズ。後続フェーズは先行フェーズが成功したときだけ走る。
+/// </summary>
+public enum ValidationPhase
+{
+    /// <summary>状態名・参照・遷移形状など（旧 Level1）。</summary>
+    Structural = 0,
+
+    /// <summary>到達不能・循環 Join（旧 Level2）。</summary>
+    Reachability = 1,
+
+    /// <summary>Fork 領域・Join 供給・枝の独立 Definition。</summary>
+    ForkRegion = 2
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/ValidationPipeline.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/ValidationPipeline.cs
@@ -1,0 +1,70 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>
+/// <see cref="IValidationRule"/> 列をフェーズ順・Weight 順に実行する。
+/// Structural / Reachability 失敗時は後続フェーズをスキップする。ForkRegion はフェーズ内全件収集。
+/// </summary>
+internal static class ValidationPipeline
+{
+    internal static readonly IReadOnlyList<IValidationRule> Rules = CreateRules();
+
+    /// <summary>
+    /// 指定フェーズだけ、または全フェーズを実行する。
+    /// </summary>
+    /// <param name="definition">検証対象。</param>
+    /// <param name="onlyPhase">指定時はそのフェーズのみ（Level1/Level2 互換）。null なら全フェーズ。</param>
+    /// <returns>検証結果。</returns>
+    public static ValidationResult Run(WorkflowDefinition definition, ValidationPhase? onlyPhase)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        var context = new DefinitionValidationContext(definition);
+        var issues = new List<ValidationIssue>();
+        var phases = onlyPhase is { } single
+            ? [single]
+            : new[] { ValidationPhase.Structural, ValidationPhase.Reachability, ValidationPhase.ForkRegion };
+
+        foreach (var phase in phases)
+        {
+            var phaseIssues = new List<ValidationIssue>();
+            foreach (var rule in RulesFor(phase))
+            {
+                rule.Validate(definition, context, phaseIssues);
+            }
+
+            issues.AddRange(phaseIssues);
+            if (onlyPhase is null
+                && phase != ValidationPhase.ForkRegion
+                && phaseIssues.Count > 0)
+            {
+                break;
+            }
+        }
+
+        return new ValidationResult(issues);
+    }
+
+    private static IEnumerable<IValidationRule> RulesFor(ValidationPhase phase) =>
+        Rules
+            .Where(r => r.Phase == phase)
+            .OrderBy(static r => r.Weight)
+            .ThenBy(static r => r.RuleId, StringComparer.Ordinal);
+
+    private static IReadOnlyList<IValidationRule> CreateRules() =>
+    [
+        new RequiredStatesRule(),
+        new StateGraphRule(),
+        new UnreachableStatesRule(),
+        new CircularJoinRule(),
+        new ForkRegionSnapshotRule(),
+        new ForkRegionIngressRule(),
+        new ForkRegionEgressRule(),
+        new ForkRegionCrossBranchRule(),
+        new ForkRegionNestedCrossRule(),
+        new ForkRegionJoinNotFedRule(),
+        new ForkRegionAmbiguousJoinRule(),
+        new ForkRegionBranchEntryRule(),
+        new ForkRegionMissingJoinRule(),
+        new ForkRegionSiblingStateRefRule(),
+        new ForkRegionWaitTargetRule()
+    ];
+}

--- a/core/engine/Statevia.Core.Engine/Definition/Validation/ValidationResult.cs
+++ b/core/engine/Statevia.Core.Engine/Definition/Validation/ValidationResult.cs
@@ -1,0 +1,34 @@
+namespace Statevia.Core.Engine.Definition.Validation;
+
+/// <summary>検証結果。エラー一覧と有効フラグを保持します。</summary>
+public sealed class ValidationResult
+{
+    /// <summary>検出されたエラーメッセージの一覧（<see cref="Issues"/> の Message）。</summary>
+    public IReadOnlyList<string> Errors { get; }
+
+    /// <summary>安定 <c>code</c> 付きの指摘。旧経路で文字列だけ渡した場合は <see cref="ValidationIssue.RuleId"/> が空。</summary>
+    public IReadOnlyList<ValidationIssue> Issues { get; }
+
+    /// <summary>エラーが 0 件の場合 true。</summary>
+    public bool IsValid => Errors.Count == 0;
+
+    /// <summary>
+    /// 検証で収集したエラーメッセージで結果を構築する。
+    /// </summary>
+    /// <param name="errors">エラーメッセージの一覧。</param>
+    public ValidationResult(IReadOnlyList<string> errors)
+        : this(errors.Select(static m => new ValidationIssue(string.Empty, m)).ToArray())
+    {
+    }
+
+    /// <summary>
+    /// 指摘一覧から結果を構築する。
+    /// </summary>
+    /// <param name="issues">指摘。</param>
+    public ValidationResult(IReadOnlyList<ValidationIssue> issues)
+    {
+        ArgumentNullException.ThrowIfNull(issues);
+        Issues = issues;
+        Errors = issues.Select(static i => i.Message).ToArray();
+    }
+}

--- a/docs/specifications/definition.md
+++ b/docs/specifications/definition.md
@@ -3,14 +3,16 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Specification |
-| Version | 1.5.1 |
-| 更新日 | 2026-08-09 |
+| Version | 1.5.2 |
+| 更新日 | 2026-08-14 |
 | 関連 | [concepts/definition.md](../concepts/definition.md), [execution/wait-cancel.md](execution/wait-cancel.md), [execution/fork-join.md](execution/fork-join.md) |
 
 ---
 
 ## Normative 要約
 
+- **MUST**: Fork の各枝は **Fork（Start）–任意ノード–Join（End）の単一 Definition** である。兄弟枝 Body は互いに素。領域外への出入は拒否する。
+- **MUST**: Join 供給は `next` / `wait.events` / `edges` の **1 経路**で足りる。`error` / `on.Failed` は供給に数えない。
 - **MUST**: publish 時に参照する `action` ID は Catalog に存在すること。未登録はエラー。
 - **MUST**: `wait` または `join` を持つ状態に `action` を併記してはならない。
 - **MUST**: Wait の正本は `wait.events`（イベント名 → 遷移先）。`events` は非空で、遷移先が定義内に存在すること。
@@ -562,7 +564,8 @@ Service API の **`GET /v1/definitions/schema/nodes`** が返すスキーマに�
 - **wait**: 正本は **`events`**（イベント名 → 次ノード名）。単一イベントの旧形式 `event` + `next` も受理し、Loader が `events` へ正規化する。`timeout`（ISO 8601 duration）は現行変換では未使用。
 - **fork**: `branches` に並列ブランチのノード名の配列。
 - **join**: すべてのブランチの完了を待ち、`next` へ進む。
-  - Join と Fork の対応: 各枝先頭が当該 Join を**供給**する一意の Fork を選ぶ。供給は (1) 枝の `next` が直接 Join、または (2) 枝先頭が内側 Fork で、その内側 Join の `next` 連鎖が当該 Join に到達すること（ネスト）。`Join.all` は外側 Fork の枝先頭集合になる。例: [`docs/samples/ui-nested-fork.yaml`](../samples/ui-nested-fork.yaml)。Fork 再到達（循環）の例: [`docs/samples/ui-cyclic-fork.yaml`](../samples/ui-cyclic-fork.yaml)。
+  - Join と Fork の対応: 各枝先頭が当該 Join を**供給**する一意の Fork を選ぶ。供給は **1 経路**で足り、次を含む。(1) 枝の `next` が直接 Join。(2) `wait.events` または `edges` を辿って Join に着く。(3) 枝先頭が内側 Fork で、その内側 Join の出口連鎖が当該 Join に到達する（ネスト）。`error` は供給に数えない。`Join.all` は外側 Fork の枝先頭集合になる。例: [`docs/samples/ui-nested-fork.yaml`](../samples/ui-nested-fork.yaml)。Fork 再到達（循環）の例: [`docs/samples/ui-cyclic-fork.yaml`](../samples/ui-cyclic-fork.yaml)。
+  - 枝 Body は互いに素。Join 前の兄弟 `$.states…` 参照、領域外への出入（`wait.events` の一部が領域外を含む場合を含む）は拒否する。`error` は枝内または当該 Join へ戻す（領域外へ出してはならない）。
 
 ### 2.3 例（Nodes 形式・抜粋）
 
@@ -735,20 +738,28 @@ Nodes 形式は、実行前に **states 形式の CompiledWorkflowDefinition に
 
 ## 4. 検証レベル（States 形式）
 
-エンジンが States 形式に対して行う検証の目安。
+エンジンが States 形式に対して行う検証。`DefinitionValidator` はフェーズ順に実行し、各ルールが安定 `code`（`RuleId`）を持つ。HTTP 422 の details はルール単位の `code` を載せる。
 
-**LEVEL 1**
+**Structural（旧 LEVEL 1）**
 
 - 構文・参照整合性
 - 自己遷移の禁止
+- 失敗時は Reachability / ForkRegion を実行しない
 
-**LEVEL 2**
+**Reachability（旧 LEVEL 2）**
 
 - 開始状態からの到達可能性
 - 循環 Join の禁止
-- 明示的依存関係の強制
+- 失敗時は ForkRegion を実行しない
 
-Nodes 形式の検証は、変換後の states に対して同様のレベルを適用するか、変換前の nodes 用ルールを別途定義する。
+**ForkRegion**
+
+- 枝＝単一 Definition（侵入・脱出・兄弟横断・ネスト横断）
+- Join 供給（`next` / `wait.events` / `edges` の 1 経路。`error` は供給に数えない）
+- 禁止パターン（他枝 `$.states`、領域外 `wait.events`）
+- フェーズ内は **Weight 昇順**のうえ **全件収集**
+
+Nodes 形式は変換後の states に対して同じ検証を適用する。Loader の Join 照合も同じ供給定義（`JoinSupply`）を使う。
 
 ---
 

--- a/docs/specifications/definition.md
+++ b/docs/specifications/definition.md
@@ -564,7 +564,7 @@ Service API の **`GET /v1/definitions/schema/nodes`** が返すスキーマに�
 - **wait**: 正本は **`events`**（イベント名 → 次ノード名）。単一イベントの旧形式 `event` + `next` も受理し、Loader が `events` へ正規化する。`timeout`（ISO 8601 duration）は現行変換では未使用。
 - **fork**: `branches` に並列ブランチのノード名の配列。
 - **join**: すべてのブランチの完了を待ち、`next` へ進む。
-  - Join と Fork の対応: 各枝先頭が当該 Join を**供給**する一意の Fork を選ぶ。供給は **1 経路**で足り、次を含む。(1) 枝の `next` が直接 Join。(2) `wait.events` または `edges` を辿って Join に着く。(3) 枝先頭が内側 Fork で、その内側 Join の出口連鎖が当該 Join に到達する（ネスト）。`error` は供給に数えない。`Join.all` は外側 Fork の枝先頭集合になる。例: [`docs/samples/ui-nested-fork.yaml`](../samples/ui-nested-fork.yaml)。Fork 再到達（循環）の例: [`docs/samples/ui-cyclic-fork.yaml`](../samples/ui-cyclic-fork.yaml)。
+  - Join と Fork の対応: 各枝先頭が当該 Join を**供給**する一意の Fork を選ぶ。供給は **1 経路**で足り、次を含む。(1) 枝の `next` が直接 Join。(2) `wait.events` または `edges` を辿って Join に着く。(3) 枝先頭または枝内の内側 Fork で、その内側 Join の出口が当該 Join に到達する（ネスト。出口が他 Join のときは、その Join とペアの Fork が一段外側への供給を担う。3 段以上も各段が直近のペアだけを見る）。`error` は供給に数えない。`Join.all` は外側 Fork の枝先頭集合になる。例: [`docs/samples/ui-nested-fork.yaml`](../samples/ui-nested-fork.yaml)。Fork 再到達（循環）の例: [`docs/samples/ui-cyclic-fork.yaml`](../samples/ui-cyclic-fork.yaml)。
   - 枝 Body は互いに素。Join 前の兄弟 `$.states…` 参照、領域外への出入（`wait.events` の一部が領域外を含む場合を含む）は拒否する。`error` は枝内または当該 Join へ戻す（領域外へ出してはならない）。
 
 ### 2.3 例（Nodes 形式・抜粋）

--- a/docs/specifications/execution/fork-join.md
+++ b/docs/specifications/execution/fork-join.md
@@ -102,7 +102,7 @@ Join は複数の状態からの事実を待ってから次に進みます。
 - Resume（Again → Fork）後に Suspend Unload した場合、in-process 投影が欠けても SuspendHandler が書いた DB 断面を使い 500 にしない。
 - 同一実行の checkpoint Persist/Unload は直列化する。加えて、永続済みに `pendingWaits` があるのに空の Fork 待ち断面で上書きしようとした Persist は拒否する（遅延 Fork Unload が decide Wait を消す競合の防止）。
 - Fork 展開通知は非同期のため、`ExpandFork` 完了後の Persist が Join→decide より遅れることがある。その時点で Engine に `activeStates` / `pendingWaits` がある、または当該 Fork 以降の Join が既に `Joined` なら **Unload しない**（Wait Suspend 側の Persist に委ね、初回 Wait 断面の消失を防ぐ）。
-- 定義グラフ（Studio）の Join 辺は `joinTable` 依存のうち **Fork 状態を除外**する。ネストでは OuterJoin の Join.all が InnerFork を含むが、描画経路は InnerJoin→OuterJoin（transitions）とし、InnerFork→OuterJoin の幽霊辺を作らない。
+- 定義グラフ（Studio）の Join 辺は `joinTable` 依存のうち、当該 Join へ**直接**着くものだけを描く。Fork 状態、および枝内の内側 Fork へ進む action（`mid → inner.fork` など）は除外する。ネストの描画経路は InnerJoin→OuterJoin（transitions）とし、枝先頭→OuterJoin の幽霊辺を作らない。
 
 ### Context マージと兄弟参照
 

--- a/docs/specifications/execution/fork-join.md
+++ b/docs/specifications/execution/fork-join.md
@@ -3,14 +3,15 @@
 | 項目 | 値 |
 | --- | --- |
 | 種別 | Specification |
-| Version | 1.3 |
-| 更新日 | 2026-08-10 |
+| Version | 1.3.1 |
+| 更新日 | 2026-08-14 |
 | 関連 | [fsm.md](fsm.md), [../definition.md](../definition.md), [wait-cancel.md](wait-cancel.md), [execution-graph.md](execution-graph.md), [../../concepts/durability.md](../../concepts/durability.md), [../../reference/database-schema.md](../../reference/database-schema.md) |
 
 ---
 
 ## Normative 要約
 
+- **MUST**: 定義時、各 Fork 枝は **Fork（Start）–任意ノード–Join（End）の単一 Definition** である。兄弟 Body は互いに素。Join 供給は `next` / `wait.events` / `edges` の 1 経路（`error` は供給に数えない）。詳細は [definition.md](../definition.md) §2.2 / §4。
 - **MUST**: Fork / Join は**制御ノード**であり、通常の状態（State）ではない。
 - **MUST**: Join は依存する全分岐から所定の事実が揃うまで次へ進んではならない。
 - **MUST**: **Hosted Runtime** では Fork 到達時に各分岐を**物理子 execution** として展開する（論理 Fork 互換フラグは設けない）。
@@ -120,6 +121,7 @@ Join は複数の状態からの事実を待ってから次に進みます。
 - Fork と Join は状態ではありません。
 - Join は依存状態が事実を生成するたびに評価されます。
 - 必須状態のいずれかが失敗またはキャンセルされた場合、Join は失敗します。
+- **定義時の領域**: 枝は単一 Definition。Join 後の Again で同じ Fork に戻る循環は合法。枝内から Join 以外へ出る遷移、領域外からの侵入、兄弟 Body の共有は拒否する。`error` は枝内または当該 Join へ戻し、領域外へ出してはならない。
 - Fork は実行順序を保証しません。
 - 親 Cancel は未終端の物理子へ Cancel をカスケードする（[wait-cancel.md](wait-cancel.md)）。
 - 分岐上の Wait へのイベント配送は**子 execution** を正とする（親 ID への誤配送を解決または拒否する）。

--- a/service/api/Statevia.Service.Api.Tests/Application/Definition/NodesWorkflowDefinitionLoaderTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Definition/NodesWorkflowDefinitionLoaderTests.cs
@@ -1,5 +1,6 @@
 using Statevia.Service.Api.Application.Definition;
 using Statevia.Core.Engine.Definition;
+using Statevia.Core.Engine.Definition.Validation;
 using Statevia.Core.Engine.FSM;
 
 namespace Statevia.Service.Api.Tests.Application.Definition;
@@ -94,6 +95,216 @@ public sealed class NodesWorkflowDefinitionLoaderTests
         Assert.Contains("outerFast", outer.All, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("innerFork", outer.All, StringComparer.OrdinalIgnoreCase);
         Assert.DoesNotContain("innerA", outer.All, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// 3 段ネストでも各 Join が直近の Fork とだけペアになり、外側 Join が解決できる。
+    /// </summary>
+    [Fact]
+    public void Load_TripleNestedForkJoin_PairsEachJoinWithImmediateFork()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: TripleNested
+            nodes:
+              - name: start
+                type: start
+                next: outer.fork
+              - name: outer.fork
+                type: fork
+                branches: [outer.fast, mid.fork]
+              - name: outer.fast
+                type: action
+                action: noop
+                next: outer.join
+              - name: mid.fork
+                type: fork
+                branches: [mid.fast, inner.fork]
+              - name: mid.fast
+                type: action
+                action: noop
+                next: mid.join
+              - name: inner.fork
+                type: fork
+                branches: [inner.a, inner.b]
+              - name: inner.a
+                type: action
+                action: noop
+                next: inner.join
+              - name: inner.b
+                type: action
+                action: noop
+                next: inner.join
+              - name: inner.join
+                type: join
+                mode: all
+                next: mid.join
+              - name: mid.join
+                type: join
+                mode: all
+                next: outer.join
+              - name: outer.join
+                type: join
+                mode: all
+                next: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var definition = _loader.Load(yaml);
+
+        // Assert
+        var inner = definition.States["inner.join"].Join;
+        Assert.NotNull(inner);
+        Assert.Equal(2, inner.All.Count);
+        Assert.Contains("inner.a", inner.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("inner.b", inner.All, StringComparer.OrdinalIgnoreCase);
+
+        var mid = definition.States["mid.join"].Join;
+        Assert.NotNull(mid);
+        Assert.Equal(2, mid.All.Count);
+        Assert.Contains("mid.fast", mid.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("inner.fork", mid.All, StringComparer.OrdinalIgnoreCase);
+
+        var outer = definition.States["outer.join"].Join;
+        Assert.NotNull(outer);
+        Assert.Equal(2, outer.All.Count);
+        Assert.Contains("outer.fast", outer.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("mid.fork", outer.All, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("inner.fork", outer.All, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>内側 Join の出口が非 Join を経由して外側 Join に着く定義も合法。</summary>
+    [Fact]
+    public void Load_NestedJoinExitViaAction_StillFeedsOuterJoin()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: NestedExitViaAction
+            nodes:
+              - name: start
+                type: start
+                next: outerFork
+              - name: outerFork
+                type: fork
+                branches: [outerFast, innerFork]
+              - name: outerFast
+                type: action
+                action: noop
+                next: outerJoin
+              - name: innerFork
+                type: fork
+                branches: [innerA, innerB]
+              - name: innerA
+                type: action
+                action: noop
+                next: innerJoin
+              - name: innerB
+                type: action
+                action: noop
+                next: innerJoin
+              - name: innerJoin
+                type: join
+                mode: all
+                next: afterInner
+              - name: afterInner
+                type: action
+                action: noop
+                next: outerJoin
+              - name: outerJoin
+                type: join
+                mode: all
+                next: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var definition = _loader.Load(yaml);
+
+        // Assert
+        var outer = definition.States["outerJoin"].Join;
+        Assert.NotNull(outer);
+        Assert.Contains("outerFast", outer.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("innerFork", outer.All, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// 枝先頭が action で、その先に内側 Fork がある定義でも外側 Join が解決できる。
+    /// </summary>
+    [Fact]
+    public void Load_InnerForkAfterMidAction_PairsOuterJoinWithOuterBranchHeads()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: D3InnerForkFromMidBranch
+            nodes:
+              - name: start
+                type: start
+                next: outer.fork
+              - name: outer.fork
+                type: fork
+                branches:
+                  - outer.fast
+                  - mid
+              - name: outer.fast
+                type: action
+                action: noop
+                next: outer.join
+              - name: mid
+                type: action
+                action: noop
+                next: inner.fork
+              - name: inner.fork
+                type: fork
+                branches:
+                  - inner.a
+                  - inner.b
+              - name: inner.a
+                type: action
+                action: noop
+                next: inner.join
+              - name: inner.b
+                type: action
+                action: noop
+                next: inner.join
+              - name: inner.join
+                type: join
+                mode: all
+                next: outer.join
+              - name: outer.join
+                type: join
+                mode: all
+                next: end
+              - name: end
+                type: end
+            """;
+
+        // Act
+        var definition = _loader.Load(yaml);
+
+        // Assert
+        var inner = definition.States["inner.join"].Join;
+        Assert.NotNull(inner);
+        Assert.Contains("inner.a", inner.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("inner.b", inner.All, StringComparer.OrdinalIgnoreCase);
+
+        var outer = definition.States["outer.join"].Join;
+        Assert.NotNull(outer);
+        Assert.Equal(2, outer.All.Count);
+        Assert.Contains("outer.fast", outer.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("mid", outer.All, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("inner.fork", outer.All, StringComparer.OrdinalIgnoreCase);
+
+        var validation = DefinitionValidator.Validate(definition);
+        Assert.True(validation.IsValid, string.Join("; ", validation.Errors));
     }
 
     /// <summary>action.error だけの経路は Join 供給に数えず、Fork とペアにならない。</summary>

--- a/service/api/Statevia.Service.Api.Tests/Application/Definition/NodesWorkflowDefinitionLoaderTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Application/Definition/NodesWorkflowDefinitionLoaderTests.cs
@@ -96,6 +96,44 @@ public sealed class NodesWorkflowDefinitionLoaderTests
         Assert.DoesNotContain("innerA", outer.All, StringComparer.OrdinalIgnoreCase);
     }
 
+    /// <summary>action.error だけの経路は Join 供給に数えず、Fork とペアにならない。</summary>
+    [Fact]
+    public void Load_ActionErrorOnlyToJoin_DoesNotTreatErrorAsJoinSupply()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: ErrorNotSupply
+            nodes:
+              - name: start
+                type: start
+                next: fork1
+              - name: fork1
+                type: fork
+                branches: [left, work]
+              - name: left
+                type: action
+                action: noop
+                next: join1
+              - name: work
+                type: action
+                action: noop
+                next: endNode
+                error: join1
+              - name: join1
+                type: join
+                mode: all
+                next: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => _loader.Load(yaml));
+        Assert.Contains("no matching fork", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>fork / join（mode: all）から Join.All が構築される。</summary>
     [Fact]
     public void Load_ForkJoin_BuildsJoinAll()
@@ -138,6 +176,95 @@ public sealed class NodesWorkflowDefinitionLoaderTests
         Assert.Contains("b1", join.All, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("b2", join.All, StringComparer.OrdinalIgnoreCase);
         Assert.True(definition.States["join1"].On!.ContainsKey(Fact.Joined));
+    }
+
+    /// <summary>枝先頭 Wait の events 経由で Join に着く定義は Load できる（E1）。</summary>
+    [Fact]
+    public void Load_WaitEventsFeedJoin_BuildsJoinAll()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: E1
+            nodes:
+              - name: start
+                type: start
+                next: fork1
+              - name: fork1
+                type: fork
+                branches: [left, wait2]
+              - name: left
+                type: action
+                action: noop
+                next: join1
+              - name: wait2
+                type: wait
+                events:
+                  Resume: right
+              - name: right
+                type: action
+                action: noop
+                next: join1
+              - name: join1
+                type: join
+                mode: all
+                next: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var definition = _loader.Load(yaml);
+
+        // Assert
+        var join = definition.States["join1"].Join;
+        Assert.NotNull(join);
+        Assert.Contains("left", join.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("wait2", join.All, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>枝先頭の edges 経由で Join に着く定義は Load できる。</summary>
+    [Fact]
+    public void Load_EdgesFeedJoin_BuildsJoinAll()
+    {
+        // Arrange
+        var yaml = """
+            version: 1
+            workflow:
+              name: EdgesSupply
+            nodes:
+              - name: start
+                type: start
+                next: fork1
+              - name: fork1
+                type: fork
+                branches: [left, chooser]
+              - name: left
+                type: action
+                action: noop
+                next: join1
+              - name: chooser
+                type: action
+                action: noop
+                edges:
+                  - to: join1
+              - name: join1
+                type: join
+                mode: all
+                next: endNode
+              - name: endNode
+                type: end
+            """;
+
+        // Act
+        var definition = _loader.Load(yaml);
+
+        // Assert
+        var join = definition.States["join1"].Join;
+        Assert.NotNull(join);
+        Assert.Contains("left", join.All, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("chooser", join.All, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>action.error は on.Failed 遷移として正規化される。</summary>

--- a/service/api/Statevia.Service.Api.Tests/Hosting/DefinitionCompilerServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Hosting/DefinitionCompilerServiceTests.cs
@@ -13,6 +13,7 @@ using Statevia.Service.Api.Application.Definition;
 using Statevia.Service.Api.Hosting;
 using Statevia.Core.Engine.Abstractions;
 using Statevia.Core.Engine.Definition;
+using Statevia.Core.Engine.Definition.Validation;
 using Statevia.Core.Engine.Engine;
 using Statevia.Core.Engine.Execution;
 using Statevia.Core.Engine.Infrastructure;
@@ -98,7 +99,7 @@ public sealed class DefinitionCompilerServiceTests
             """;
 
         // Act & Assert
-        var ex = Assert.Throws<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
+        var ex = Assert.ThrowsAny<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
 
         Assert.Contains("Unknown action 'my.vendor.missing'", ex.Message, StringComparison.Ordinal);
         Assert.Contains("state 'A'", ex.Message, StringComparison.Ordinal);
@@ -126,7 +127,7 @@ public sealed class DefinitionCompilerServiceTests
             """;
 
         // Act & Assert
-        var ex = Assert.Throws<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
+        var ex = Assert.ThrowsAny<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
 
         Assert.Contains("Level 1 validation failed", ex.Message, StringComparison.Ordinal);
     }
@@ -154,7 +155,7 @@ public sealed class DefinitionCompilerServiceTests
             """;
 
         // Act & Assert
-        var ex = Assert.Throws<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
+        var ex = Assert.ThrowsAny<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
 
         Assert.Contains("duplicate alias 'mail'", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -185,7 +186,7 @@ public sealed class DefinitionCompilerServiceTests
             """;
 
         // Act & Assert
-        var ex = Assert.Throws<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
+        var ex = Assert.ThrowsAny<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
 
         Assert.Contains("Level 1 validation failed", ex.Message, StringComparison.Ordinal);
     }
@@ -295,7 +296,7 @@ public sealed class DefinitionCompilerServiceTests
             """;
 
         // Act / Assert
-        var ex = Assert.Throws<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
+        var ex = Assert.ThrowsAny<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
         Assert.Contains("delay5s", ex.Message, StringComparison.Ordinal);
     }
 
@@ -545,9 +546,96 @@ public sealed class DefinitionCompilerServiceTests
             """;
 
         // Act & Assert
-        var ex = Assert.Throws<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
+        var ex = Assert.ThrowsAny<ArgumentException>(() => svc.ValidateAndCompile("W", yaml));
 
         Assert.Contains("Level 2 validation failed", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Wait events 経由で Join を供給する定義はコンパイルできる（E1）。</summary>
+    [Fact]
+    public void ValidateAndCompile_WaitEventsFeedJoin_Succeeds()
+    {
+        // Arrange
+        var svc = CreateSut();
+        var yaml = """
+            workflow:
+              name: E1
+            states:
+              Start:
+                on:
+                  Completed:
+                    fork: [Left, Wait2]
+              Left:
+                on:
+                  Completed:
+                    next: Join
+              Wait2:
+                wait:
+                  events:
+                    Resume: Right
+              Right:
+                on:
+                  Completed:
+                    next: Join
+              Join:
+                join:
+                  all: [Left, Wait2]
+                on:
+                  Joined:
+                    next: End
+              End:
+                on:
+                  Completed:
+                    end: true
+            """;
+
+        // Act
+        var (compiled, _) = svc.ValidateAndCompile("E1", yaml);
+
+        // Assert
+        Assert.Equal("Start", compiled.InitialState);
+        Assert.Contains("Join", compiled.JoinTable.Keys, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>領域外へ出る Fork 枝は ForkRegion code 付きで失敗する。</summary>
+    [Fact]
+    public void ValidateAndCompile_EgressWithoutJoin_ThrowsForkRegionCode()
+    {
+        // Arrange
+        var svc = CreateSut();
+        var yaml = """
+            workflow:
+              name: A2
+            states:
+              Start:
+                on:
+                  Completed:
+                    fork: [Left, Right]
+              Left:
+                on:
+                  Completed:
+                    next: End
+              Right:
+                on:
+                  Completed:
+                    next: Join
+              Join:
+                join:
+                  all: [Left, Right]
+                on:
+                  Joined:
+                    next: End
+              End:
+                on:
+                  Completed:
+                    end: true
+            """;
+
+        // Act
+        var ex = Assert.Throws<DefinitionValidationException>(() => svc.ValidateAndCompile("A2", yaml));
+
+        // Assert
+        Assert.Contains(ex.Issues, i => i.RuleId == "ForkRegion.EgressWithoutJoin");
     }
 
     /// <summary>

--- a/service/api/Statevia.Service.Api.Tests/Services/DefinitionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/DefinitionServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Statevia.Service.Api.Application.Actions;
 using Statevia.Service.Api.Application.Actions.Validation;
 using Statevia.Core.Engine.Abstractions;
+using Statevia.Core.Engine.Definition.Validation;
 using Statevia.Service.Api.Abstractions.Services;
 
 using Statevia.Service.Api.Contracts;
@@ -460,6 +461,33 @@ public sealed class DefinitionServiceTests
         Assert.IsType<ArgumentException>(ex.InnerException);
     }
 
+    /// <summary>Engine 検証失敗時は details にルール単位 code を載せる。</summary>
+    [Fact]
+    public async Task CreateAsync_WhenCompilerThrowsDefinitionValidationException_IncludesRuleCode()
+    {
+        // Arrange
+        using var inDb = new InMemoryTestDatabase();
+        var definitionsRepo = TestRepositoryFactory.CreateDefinitionRepository();
+        var display = new StubDisplayIdService();
+        var compiler = new ThrowingCompiler(new DefinitionValidationException(
+            new ValidationResult(
+            [
+                new ValidationIssue("ForkRegion.EgressWithoutJoin", "egress", "Left")
+            ])));
+        var idGen = new FixedIdGenerator(Guid.NewGuid());
+        var sut = CreateDefinitionService(inDb, display, compiler, definitionsRepo, idGen);
+        var request = new CreateDefinitionRequest { Name = "def", Yaml = "workflow:\n  name: A2" };
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ApiValidationException>(() => sut.CreateAsync(request, CancellationToken.None));
+
+        // Assert
+        Assert.Equal(DefinitionValidationMessages.ValidationFailed, ex.Message);
+        var detailsJson = System.Text.Json.JsonSerializer.Serialize(ex.Details);
+        Assert.Contains("ForkRegion.EgressWithoutJoin", detailsJson, StringComparison.Ordinal);
+        Assert.Contains("Left", detailsJson, StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// 既存定義を更新し、yaml と compiled_json が反映される。
     /// </summary>
@@ -551,6 +579,47 @@ public sealed class DefinitionServiceTests
         // Assert
         Assert.Equal(DefinitionValidationMessages.ValidationFailed, ex.Message);
         Assert.IsType<ArgumentException>(ex.InnerException);
+    }
+
+    /// <summary>更新時の Engine 検証失敗は details にルール単位 code を載せる。</summary>
+    [Fact]
+    public async Task UpdateAsync_WhenCompilerThrowsDefinitionValidationException_IncludesRuleCode()
+    {
+        // Arrange
+        using var inDb = new InMemoryTestDatabase();
+        var projectId = await SeedDefaultTenantAndProjectAsync(inDb.Options);
+        var definitionsRepo = TestRepositoryFactory.CreateDefinitionRepository();
+        var guid = Guid.NewGuid();
+        await using (var ctx = new CoreDbContext(inDb.Options))
+        {
+            DefinitionTestData.AddDefinitionWithVersion(ctx, TestTenantIds.DefaultTenantId,
+                guid,
+                "old",
+                projectId,
+                sourceYaml: "workflow:\n  name: old",
+                createdAt: DateTime.UtcNow);
+            await ctx.SaveChangesAsync();
+        }
+
+        var display = new StubDisplayIdService();
+        display.ResolveMap["definition|DEF-1"] = guid;
+        var compiler = new ThrowingCompiler(new DefinitionValidationException(
+            new ValidationResult(
+            [
+                new ValidationIssue("ForkRegion.JoinNotFed", "not fed", "Join")
+            ])));
+        var sut = CreateDefinitionService(inDb, display, compiler, definitionsRepo, new FixedIdGenerator(Guid.NewGuid()));
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ApiValidationException>(() =>
+            sut.UpdateAsync("DEF-1", new UpdateDefinitionRequest { Name = "n", Yaml = "bad" }, CancellationToken.None));
+
+        // Assert
+        Assert.Equal(DefinitionValidationMessages.ValidationFailed, ex.Message);
+        var detailsJson = System.Text.Json.JsonSerializer.Serialize(ex.Details);
+        Assert.Contains("ForkRegion.JoinNotFed", detailsJson, StringComparison.Ordinal);
+        Assert.Contains("Join", detailsJson, StringComparison.Ordinal);
+        Assert.IsType<DefinitionValidationException>(ex.InnerException);
     }
 
     /// <summary>action input schema 検証失敗時に state / actionId / jsonPath を details に含める。</summary>

--- a/service/api/Statevia.Service.Api.Tests/Services/GraphDefinitionServiceTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/GraphDefinitionServiceTests.cs
@@ -228,6 +228,67 @@ public sealed class GraphDefinitionServiceTests
     }
 
     /// <summary>
+    /// 枝先頭 action の先に内側 Fork があるとき、mid→outer.join の幽霊辺を描かない。
+    /// </summary>
+    [Fact]
+    public async Task GetByGraphIdAsync_InnerForkAfterMidAction_DoesNotDrawJoinEdgeFromMidToOuterJoin()
+    {
+        // Arrange
+        using var db = new InMemoryTestDatabase();
+        var uuid = Guid.NewGuid();
+        var graphId = uuid.ToString("N")[..10];
+        const string compiledJson = """
+            {
+              "name": "D3InnerForkFromMidBranch",
+              "initialState": "start",
+              "transitions": {
+                "start": { "Completed": { "next": "outer.fork", "fork": null, "end": false } },
+                "outer.fork": { "Completed": { "next": null, "fork": ["outer.fast", "mid"], "end": false } },
+                "outer.fast": { "Completed": { "next": "outer.join", "fork": null, "end": false } },
+                "mid": { "Completed": { "next": "inner.fork", "fork": null, "end": false } },
+                "inner.fork": { "Completed": { "next": null, "fork": ["inner.a", "inner.b"], "end": false } },
+                "inner.a": { "Completed": { "next": "inner.join", "fork": null, "end": false } },
+                "inner.b": { "Completed": { "next": "inner.join", "fork": null, "end": false } },
+                "inner.join": { "Joined": { "next": "outer.join", "fork": null, "end": false } },
+                "outer.join": { "Joined": { "next": "end", "fork": null, "end": false } },
+                "end": { "Completed": { "next": null, "fork": null, "end": true } }
+              },
+              "forkTable": {
+                "outer.fork": ["outer.fast", "mid"],
+                "inner.fork": ["inner.a", "inner.b"]
+              },
+              "joinTable": {
+                "inner.join": ["inner.a", "inner.b"],
+                "outer.join": ["outer.fast", "mid"]
+              }
+            }
+            """;
+
+        var projectId = await SeedDefaultTenantAndProjectAsync(db.Options);
+
+        await using (var ctx = new CoreDbContext(db.Options))
+        {
+            var now = DateTime.UtcNow;
+            DefinitionTestData.AddDefinitionWithVersion(
+                ctx, TestTenantIds.DefaultTenantId, uuid, "d3-mid", projectId, compiledJson: compiledJson, createdAt: now);
+            await ctx.SaveChangesAsync();
+        }
+
+        var sut = CreateSut(db, new StubDisplayIdService(uuid));
+
+        // Act
+        var res = await sut.GetByGraphIdAsync(graphId, CancellationToken.None);
+
+        // Assert
+        Assert.Contains(res.Edges, e => e.From == "outer.fast" && e.To == "outer.join");
+        Assert.Contains(res.Edges, e => e.From == "inner.join" && e.To == "outer.join");
+        Assert.Contains(res.Edges, e => e.From == "mid" && e.To == "inner.fork");
+        Assert.DoesNotContain(res.Edges, e => e.From == "mid" && e.To == "outer.join");
+        Assert.DoesNotContain(res.Edges, e => e.From == "inner.fork" && e.To == "outer.join");
+        Assert.DoesNotContain(res.Edges, e => e.From == "inner.a" && e.To == "outer.join");
+    }
+
+    /// <summary>
     /// 終端遷移がない状態を通常ノードとして組み立てる。
     /// </summary>
     [Fact]

--- a/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkGraphComposerTests.cs
+++ b/service/api/Statevia.Service.Api.Tests/Services/PhysicalForkGraphComposerTests.cs
@@ -178,6 +178,80 @@ public sealed class PhysicalForkGraphComposerTests
     }
 
     /// <summary>
+    /// 枝先頭が action でその先に内側 Fork があるとき、親 Fork は mid だけへ張り inner.a を幽霊枝にしない。
+    /// </summary>
+    [Fact]
+    public void Compose_WhenInnerForkAfterMidAction_DoesNotAttachInnerLeavesToOuterForkOrJoin()
+    {
+        // Arrange
+        const string parentJson = """
+            {
+              "nodes": [
+                {"nodeId":"outer-fork","nodeName":"outer.fork","nodeType":"Fork"},
+                {"nodeId":"outer-join","nodeName":"outer.join","nodeType":"Join"}
+              ],
+              "edges": []
+            }
+            """;
+        const string midChildJson = """
+            {
+              "nodes": [
+                {"nodeId":"mid-1","nodeName":"mid","nodeType":"Task"},
+                {"nodeId":"inner-fork","nodeName":"inner.fork","nodeType":"Fork"},
+                {"nodeId":"inner-a","nodeName":"inner.a","nodeType":"Task"},
+                {"nodeId":"inner-b","nodeName":"inner.b","nodeType":"Task"},
+                {"nodeId":"inner-join","nodeName":"inner.join","nodeType":"Join"}
+              ],
+              "edges": [
+                {"from":"mid-1","to":"inner-fork","type":0},
+                {"from":"inner-fork","to":"inner-a","type":1},
+                {"from":"inner-fork","to":"inner-b","type":1},
+                {"from":"inner-a","to":"inner-join","type":2},
+                {"from":"inner-b","to":"inner-join","type":2}
+              ]
+            }
+            """;
+        const string fastChildJson = """
+            {"nodes":[{"nodeId":"outer-fast","nodeName":"outer.fast","nodeType":"Task"}],"edges":[]}
+            """;
+
+        // Act
+        var composed = PhysicalForkGraphComposer.Compose(
+            parentJson,
+            [
+                new PhysicalForkGraphComposer.BranchGraph(
+                    "outer-fork", "outer-join", "outer.fast", fastChildJson),
+                new PhysicalForkGraphComposer.BranchGraph(
+                    "outer-fork", "outer-join", "mid", midChildJson)
+            ]);
+
+        // Assert
+        var edges = JsonNode.Parse(composed)!["edges"]!.AsArray().OfType<JsonObject>().ToList();
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "outer-fork"
+                && e["to"]!.GetValue<string>() == "mid-1"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Fork);
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "outer-fork"
+                && e["to"]!.GetValue<string>() == "inner-a");
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "mid-1"
+                && e["to"]!.GetValue<string>() == "outer-join");
+        Assert.Contains(
+            edges,
+            e => e["from"]!.GetValue<string>() == "inner-join"
+                && e["to"]!.GetValue<string>() == "outer-join"
+                && e["type"]!.GetValue<int>() == (int)EdgeType.Next);
+        Assert.DoesNotContain(
+            edges,
+            e => e["from"]!.GetValue<string>() == "inner-a"
+                && e["to"]!.GetValue<string>() == "outer-join");
+    }
+
+    /// <summary>
     /// 内側合成が Fork+Join のみ（子辺なし）でも、InnerFork→OuterJoin の幽霊辺を付けない。
     /// </summary>
     [Fact]

--- a/service/api/Statevia.Service.Api/Application/Definition/NodesWorkflowDefinitionLoader.cs
+++ b/service/api/Statevia.Service.Api/Application/Definition/NodesWorkflowDefinitionLoader.cs
@@ -508,6 +508,29 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
         }
 
         /// <summary>
+        /// Join 供給に使う後続。Fork 枝と <c>error</c> は含めない。
+        /// </summary>
+        public IEnumerable<string> SupplyNeighborNames()
+        {
+            if (Kind is NodeKind.Fork or NodeKind.End)
+            {
+                yield break;
+            }
+
+            foreach (var neighbor in OutNeighborNames())
+            {
+                if (Kind == NodeKind.Action
+                    && !string.IsNullOrWhiteSpace(Error)
+                    && string.Equals(neighbor, Error, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                yield return neighbor;
+            }
+        }
+
+        /// <summary>
         /// MVP で未対応のノード属性を拒否する。
         /// </summary>
         public void ValidateForbiddenMvp()
@@ -781,8 +804,9 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
         /// <remarks>
         /// <para>
         /// 各枝先頭が当該 Join を「供給」する一意の Fork を選ぶ。
-        /// 供給とは (1) <c>next</c> が直接 Join、または (2) 枝先頭が内側 Fork で、
-        /// その内側 Join の出口（<c>next</c> 連鎖）が当該 Join に到達すること。
+        /// 供給は (1) <c>next</c> / <c>wait.events</c> / <c>edges</c> の 1 経路、または
+        /// (2) 枝先頭が内側 Fork で、その内側 Join の出口連鎖が当該 Join に到達すること。
+        /// <c>error</c> は供給に数えない。
         /// </para>
         /// </remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -792,6 +816,11 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
         private IReadOnlyList<string> ResolveJoinAll(IReadOnlyDictionary<string, ParsedNode> byName)
         {
             var joinName = Name;
+            var supplySuccessors = BuildSupplySuccessors(byName);
+            var joinBarriers = byName.Values
+                .Where(static n => n.Kind == NodeKind.Join)
+                .Select(static n => n.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             var candidates = new List<(string ForkName, IReadOnlyList<string> Branches)>();
 
             foreach (var n in byName.Values)
@@ -801,7 +830,7 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
                     continue;
                 }
 
-                if (ForkFeedsJoin(n, joinName, byName, []))
+                if (ForkFeedsJoin(n, joinName, byName, supplySuccessors, joinBarriers, []))
                 {
                     candidates.Add((n.Name, n.Branches));
                 }
@@ -811,7 +840,7 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
             {
                 throw new ArgumentException(
                     $"Join '{joinName}' has no matching fork whose branches feed this join " +
-                    "(direct next, or nested fork whose inner join exits to this join).");
+                    "(next, wait.events, or edges; or nested fork whose inner join exits to this join).");
             }
 
             if (candidates.Count > 1)
@@ -829,6 +858,8 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
             ParsedNode fork,
             string joinName,
             IReadOnlyDictionary<string, ParsedNode> byName,
+            Dictionary<string, IReadOnlyList<string>> supplySuccessors,
+            IReadOnlySet<string> joinBarriers,
             HashSet<string> visitingForks)
         {
             if (fork.Branches is null || fork.Branches.Count < 2)
@@ -839,7 +870,7 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
                 if (!byName.TryGetValue(branchName, out var branchHead) || branchHead.Kind == NodeKind.Join)
                     return false;
 
-                if (!BranchFeedsJoin(branchHead, joinName, byName, visitingForks))
+                if (!BranchFeedsJoin(branchHead, joinName, byName, supplySuccessors, joinBarriers, visitingForks))
                     return false;
             }
 
@@ -847,15 +878,18 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
         }
 
         /// <summary>
-        /// 枝先頭が Join を供給するか（直接 <c>next</c>、またはネスト Fork → 内側 Join → 出口連鎖）。
+        /// 枝先頭が Join を供給するか（<c>next</c> / <c>wait.events</c> / <c>edges</c>、
+        /// またはネスト Fork → 内側 Join → 出口連鎖）。
         /// </summary>
         private static bool BranchFeedsJoin(
             ParsedNode branchHead,
             string joinName,
             IReadOnlyDictionary<string, ParsedNode> byName,
+            Dictionary<string, IReadOnlyList<string>> supplySuccessors,
+            IReadOnlySet<string> joinBarriers,
             HashSet<string> visitingForks)
         {
-            if (string.Equals(branchHead.Next, joinName, StringComparison.OrdinalIgnoreCase))
+            if (JoinSupply.Reaches(supplySuccessors, branchHead.Name, joinName, joinBarriers))
                 return true;
 
             if (branchHead.Kind != NodeKind.Fork || branchHead.Branches is null)
@@ -864,18 +898,23 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
             if (!visitingForks.Add(branchHead.Name))
                 return false;
 
-            var pairedInnerJoin = TryFindUniqueJoinPairedWithFork(branchHead, byName, visitingForks);
+            var pairedInnerJoin = TryFindUniqueJoinPairedWithFork(
+                branchHead, byName, supplySuccessors, joinBarriers, visitingForks);
             if (pairedInnerJoin is null)
                 return false;
 
-            // 内側 Join 完了後の next 連鎖が外側 Join に到達すればネスト供給とみなす。
-            return PathReachesNode(pairedInnerJoin.Next, joinName, byName, maxSteps: byName.Count + 1);
+            if (string.IsNullOrWhiteSpace(pairedInnerJoin.Next))
+                return JoinSupply.Reaches(supplySuccessors, pairedInnerJoin.Name, joinName, joinBarriers);
+
+            return JoinSupply.Reaches(supplySuccessors, pairedInnerJoin.Next, joinName, joinBarriers);
         }
 
         /// <summary>指定 Fork と一意にペアになる Join（全枝が当該 Join を供給）を探す。</summary>
         private static ParsedNode? TryFindUniqueJoinPairedWithFork(
             ParsedNode fork,
             IReadOnlyDictionary<string, ParsedNode> byName,
+            Dictionary<string, IReadOnlyList<string>> supplySuccessors,
+            IReadOnlySet<string> joinBarriers,
             HashSet<string> visitingForks)
         {
             ParsedNode? found = null;
@@ -884,7 +923,7 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
                 if (candidate.Kind != NodeKind.Join)
                     continue;
 
-                if (!ForkFeedsJoin(fork, candidate.Name, byName, visitingForks))
+                if (!ForkFeedsJoin(fork, candidate.Name, byName, supplySuccessors, joinBarriers, visitingForks))
                     continue;
 
                 if (found is not null)
@@ -896,30 +935,22 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
             return found;
         }
 
-        /// <summary><paramref name="fromNodeName"/> から <c>next</c> だけを辿り <paramref name="targetName"/> に達するか。</summary>
-        private static bool PathReachesNode(
-            string? fromNodeName,
-            string targetName,
-            IReadOnlyDictionary<string, ParsedNode> byName,
-            int maxSteps)
+        /// <summary>
+        /// Join 供給用の後続マップ。<c>error</c> と Fork 枝は含めない（ネストは内側 Join 出口で辿る）。
+        /// </summary>
+        private static Dictionary<string, IReadOnlyList<string>> BuildSupplySuccessors(
+            IReadOnlyDictionary<string, ParsedNode> byName)
         {
-            var current = fromNodeName;
-            for (var step = 0; step < maxSteps && !string.IsNullOrWhiteSpace(current); step++)
+            var map = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (name, node) in byName)
             {
-                if (string.Equals(current, targetName, StringComparison.OrdinalIgnoreCase))
-                    return true;
-
-                if (!byName.TryGetValue(current, out var node))
-                    return false;
-
-                // Fork に入ったらネスト解決側に任せ、直線追跡は打ち切る。
-                if (node.Kind is NodeKind.Fork or NodeKind.End)
-                    return false;
-
-                current = node.Next;
+                map[name] = node.SupplyNeighborNames()
+                    .Where(static n => !string.IsNullOrWhiteSpace(n))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
             }
 
-            return false;
+            return map;
         }
 
         /// <summary>

--- a/service/api/Statevia.Service.Api/Application/Definition/NodesWorkflowDefinitionLoader.cs
+++ b/service/api/Statevia.Service.Api/Application/Definition/NodesWorkflowDefinitionLoader.cs
@@ -966,13 +966,14 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
             if (!supplySuccessors.TryGetValue(currentName, out var nexts))
                 return;
 
-            foreach (var next in nexts.Where(n =>
-                         !string.IsNullOrWhiteSpace(n)
-                         && !string.Equals(n, joinName, StringComparison.OrdinalIgnoreCase)
-                         && !joinBarriers.Contains(n)))
+            foreach (var next in nexts
+                         .Where(n =>
+                             !string.IsNullOrWhiteSpace(n)
+                             && !string.Equals(n, joinName, StringComparison.OrdinalIgnoreCase)
+                             && !joinBarriers.Contains(n))
+                         .Where(visited.Add))
             {
-                if (visited.Add(next))
-                    queue.Enqueue(next);
+                queue.Enqueue(next);
             }
         }
 

--- a/service/api/Statevia.Service.Api/Application/Definition/NodesWorkflowDefinitionLoader.cs
+++ b/service/api/Statevia.Service.Api/Application/Definition/NodesWorkflowDefinitionLoader.cs
@@ -805,7 +805,8 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
         /// <para>
         /// 各枝先頭が当該 Join を「供給」する一意の Fork を選ぶ。
         /// 供給は (1) <c>next</c> / <c>wait.events</c> / <c>edges</c> の 1 経路、または
-        /// (2) 枝先頭が内側 Fork で、その内側 Join の出口連鎖が当該 Join に到達すること。
+        /// (2) 枝先頭または枝内の内側 Fork で、その内側 Join の出口（他 Join を跨がない）が当該 Join に到達すること。
+        /// 3 段以上のネストでは、一段外側の Join への供給は「その段のペア Join の出口」だけが担う。
         /// <c>error</c> は供給に数えない。
         /// </para>
         /// </remarks>
@@ -879,7 +880,7 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
 
         /// <summary>
         /// 枝先頭が Join を供給するか（<c>next</c> / <c>wait.events</c> / <c>edges</c>、
-        /// またはネスト Fork → 内側 Join → 出口連鎖）。
+        /// または枝先頭・枝内のネスト Fork → 内側 Join の出口）。
         /// </summary>
         private static bool BranchFeedsJoin(
             ParsedNode branchHead,
@@ -892,21 +893,116 @@ internal sealed class NodesWorkflowDefinitionLoader : WorkflowDefinitionLoaderBa
             if (JoinSupply.Reaches(supplySuccessors, branchHead.Name, joinName, joinBarriers))
                 return true;
 
-            if (branchHead.Kind != NodeKind.Fork || branchHead.Branches is null)
+            return ForkOnSupplyPathExitsTo(
+                branchHead, joinName, byName, supplySuccessors, joinBarriers, visitingForks);
+        }
+
+        /// <summary>
+        /// 供給経路上（Join 障壁まで）の内側 Fork が、ペア Join の出口で <paramref name="joinName"/> を供給するか。
+        /// </summary>
+        /// <remarks>
+        /// 枝先頭が Fork のネストに加え、action 等の後に内側 Fork がある形
+        ///（<c>mid → inner.fork → inner.join → outer.join</c>）も外側 Join の供給とみなす。
+        /// Fork の枝は線形供給に含めない（内側 Join 出口で正規化する）。
+        /// </remarks>
+        private static bool ForkOnSupplyPathExitsTo(
+            ParsedNode start,
+            string joinName,
+            IReadOnlyDictionary<string, ParsedNode> byName,
+            Dictionary<string, IReadOnlyList<string>> supplySuccessors,
+            IReadOnlySet<string> joinBarriers,
+            HashSet<string> visitingForks)
+        {
+            var comparer = StringComparer.OrdinalIgnoreCase;
+            var visited = new HashSet<string>(comparer) { start.Name };
+            var queue = new Queue<string>();
+            queue.Enqueue(start.Name);
+
+            while (queue.Count > 0)
+            {
+                var currentName = queue.Dequeue();
+                if (!byName.TryGetValue(currentName, out var current))
+                    continue;
+
+                if (TryNestedForkExit(current, joinName, byName, supplySuccessors, joinBarriers, visitingForks))
+                    return true;
+
+                EnqueueSupplyNeighbors(currentName, joinName, supplySuccessors, joinBarriers, visited, queue);
+            }
+
+            return false;
+        }
+
+        /// <summary>現在ノードが Fork なら、ペア Join の出口が対象 Join に着くか。</summary>
+        private static bool TryNestedForkExit(
+            ParsedNode current,
+            string joinName,
+            IReadOnlyDictionary<string, ParsedNode> byName,
+            Dictionary<string, IReadOnlyList<string>> supplySuccessors,
+            IReadOnlySet<string> joinBarriers,
+            HashSet<string> visitingForks)
+        {
+            if (current.Kind != NodeKind.Fork || current.Branches is null)
                 return false;
 
-            if (!visitingForks.Add(branchHead.Name))
+            if (!visitingForks.Add(current.Name))
                 return false;
 
             var pairedInnerJoin = TryFindUniqueJoinPairedWithFork(
-                branchHead, byName, supplySuccessors, joinBarriers, visitingForks);
-            if (pairedInnerJoin is null)
+                current, byName, supplySuccessors, joinBarriers, visitingForks);
+            return pairedInnerJoin is not null
+                && InnerJoinExitsTo(pairedInnerJoin, joinName, supplySuccessors, joinBarriers);
+        }
+
+        /// <summary>Join 障壁と対象 Join を除いた供給後続を走査キューへ載せる。</summary>
+        private static void EnqueueSupplyNeighbors(
+            string currentName,
+            string joinName,
+            Dictionary<string, IReadOnlyList<string>> supplySuccessors,
+            IReadOnlySet<string> joinBarriers,
+            HashSet<string> visited,
+            Queue<string> queue)
+        {
+            if (!supplySuccessors.TryGetValue(currentName, out var nexts))
+                return;
+
+            foreach (var next in nexts.Where(n =>
+                         !string.IsNullOrWhiteSpace(n)
+                         && !string.Equals(n, joinName, StringComparison.OrdinalIgnoreCase)
+                         && !joinBarriers.Contains(n)))
+            {
+                if (visited.Add(next))
+                    queue.Enqueue(next);
+            }
+        }
+
+        /// <summary>
+        /// 内側 Join の出口が <paramref name="joinName"/> に着くか。
+        /// </summary>
+        /// <remarks>
+        /// 出口が他 Join のときは、その Join とペアの Fork が外側への供給を担う。
+        /// ここから他 Join の <c>next</c> を辿ると、3 段ネストで中間 Fork が外側 Join にも
+        /// 供給していると誤判定し、ペアが一意でなくなって <c>outer.join</c> が解決できない。
+        /// 非 Join ノード（通知 action など）経由の到達は従来どおり許す。
+        /// </remarks>
+        /// <param name="innerJoin">ネスト Fork とペアの内側 Join。</param>
+        /// <param name="joinName">供給先として判定する Join 名。</param>
+        /// <param name="supplySuccessors">Join 供給用の後続マップ。</param>
+        /// <param name="joinBarriers">他 Join 名の集合（横断禁止）。</param>
+        /// <returns>出口が <paramref name="joinName"/> に着くとき true。</returns>
+        private static bool InnerJoinExitsTo(
+            ParsedNode innerJoin,
+            string joinName,
+            Dictionary<string, IReadOnlyList<string>> supplySuccessors,
+            IReadOnlySet<string> joinBarriers)
+        {
+            if (!supplySuccessors.TryGetValue(innerJoin.Name, out var exits) || exits.Count == 0)
                 return false;
 
-            if (string.IsNullOrWhiteSpace(pairedInnerJoin.Next))
-                return JoinSupply.Reaches(supplySuccessors, pairedInnerJoin.Name, joinName, joinBarriers);
-
-            return JoinSupply.Reaches(supplySuccessors, pairedInnerJoin.Next, joinName, joinBarriers);
+            return exits.Any(exit =>
+                string.Equals(exit, joinName, StringComparison.OrdinalIgnoreCase)
+                || (!joinBarriers.Contains(exit)
+                    && JoinSupply.Reaches(supplySuccessors, exit, joinName, joinBarriers)));
         }
 
         /// <summary>指定 Fork と一意にペアになる Join（全枝が当該 Join を供給）を探す。</summary>

--- a/service/api/Statevia.Service.Api/Hosting/DefinitionCompilerService.cs
+++ b/service/api/Statevia.Service.Api/Hosting/DefinitionCompilerService.cs
@@ -63,16 +63,10 @@ internal sealed class DefinitionCompilerService : IDefinitionCompilerService
         var def = _definitionLoadStrategy.Load(yaml);
         var compileBindings = ModuleActionCompileBinder.Bind(def, _actionCatalog);
         def = ResolveActionNames(def);
-        var l1 = Level1Validator.Validate(def);
-        if (!l1.IsValid)
+        var validation = DefinitionValidator.Validate(def);
+        if (!validation.IsValid)
         {
-            throw new ArgumentException("Level 1 validation failed: " + string.Join("; ", l1.Errors));
-        }
-
-        var l2 = Level2Validator.Validate(def);
-        if (!l2.IsValid)
-        {
-            throw new ArgumentException("Level 2 validation failed: " + string.Join("; ", l2.Errors));
+            throw new DefinitionValidationException(validation);
         }
 
         ValidateRegisteredActions(compileBindings.StateActionBindings, tenantId);

--- a/service/api/Statevia.Service.Api/Services/GraphDefinitionService.cs
+++ b/service/api/Statevia.Service.Api/Services/GraphDefinitionService.cs
@@ -136,9 +136,9 @@ internal sealed class GraphDefinitionService : IGraphDefinitionService
         AddEdgesFromConditionalTransitions(edges, dto.ConditionalTransitions);
         AddEdgesFromWaitEventRouteTable(edges, dto.WaitEventRouteTable);
         AddEdgesFromStateTable(edges, dto.ForkTable);
-        // Join.all の依存にネスト枝先頭の Fork が含まれるが、描画では内側 Join→外側の遷移辺を使う。
-        // Fork→Join を JoinTable から描くと幽霊枝になるため、Fork 依存は除外する。
-        AddEdgesFromJoinTable(edges, dto.JoinTable, dto.ForkTable);
+        // Join.all の依存がネスト枝先頭（Fork または内側へ進む action）のとき、
+        // JoinTable から描くと幽霊枝になる。直接当該 Join へ着く依存だけ辺にする。
+        AddEdgesFromJoinTable(edges, dto);
         return edges;
     }
 
@@ -345,26 +345,70 @@ internal sealed class GraphDefinitionService : IGraphDefinitionService
     /// join テーブル（joinState ← dependencies）から描画用エッジを追加する。
     /// </summary>
     /// <remarks>
-    /// 依存が <paramref name="forkTable"/> 上の Fork 状態のときは辺を作らない。
-    /// ネストでは OuterJoin の Join.all が InnerFork を依存に持つが、見た目の経路は
-    /// InnerJoin → OuterJoin（transitions）であり、InnerFork → OuterJoin は幽霊枝になる。
+    /// 依存が Fork 状態、または当該 Join へ直接着かない（枝内の内側 Fork へ進む action など）ときは辺を作らない。
+    /// ネストの見た目の経路は内側 Join→外側 Join（transitions）であり、枝先頭→OuterJoin は幽霊枝になる。
     /// </remarks>
-    private static void AddEdgesFromJoinTable(
-        List<GraphEdgeDefinition> edges,
-        Dictionary<string, List<string>?>? joinTable,
-        Dictionary<string, List<string>?>? forkTable)
+    private static void AddEdgesFromJoinTable(List<GraphEdgeDefinition> edges, CompiledDefinitionDto dto)
     {
-        if (joinTable is null) return;
+        var joinTable = dto.JoinTable;
+        if (joinTable is null)
+            return;
+
+        var forkTable = dto.ForkTable;
         joinTable
             .Where(pair => pair.Value is not null)
             .SelectMany(pair => pair.Value!
-                .Where(from =>
-                    !string.IsNullOrWhiteSpace(from)
-                    && (forkTable is null || !forkTable.ContainsKey(from)))
+                .Where(from => ShouldDrawJoinTableEdge(from, pair.Key, dto, forkTable))
                 .Select(from => new GraphEdgeDefinition { From = from, To = pair.Key }))
             .ToList()
             .ForEach(edges.Add);
     }
+
+    /// <summary>
+    /// Join.all 依存から Join への描画辺を付けるか。
+    /// Fork 依存と、Join へ直接着かない枝先頭（ネスト途中の action）は付けない。
+    /// </summary>
+    private static bool ShouldDrawJoinTableEdge(
+        string from,
+        string joinState,
+        CompiledDefinitionDto dto,
+        Dictionary<string, List<string>?>? forkTable) =>
+        !string.IsNullOrWhiteSpace(from)
+        && (forkTable is null || !forkTable.ContainsKey(from))
+        && DirectlyTargetsJoin(from, joinState, dto);
+
+    /// <summary>遷移・Wait・条件辺のいずれかが <paramref name="joinState"/> を直接指すか。</summary>
+    private static bool DirectlyTargetsJoin(string from, string joinState, CompiledDefinitionDto dto) =>
+        TransitionMapTargetsJoin(dto.Transitions?.GetValueOrDefault(from), joinState)
+        || WaitRoutesTargetJoin(dto.WaitEventRouteTable?.GetValueOrDefault(from), joinState)
+        || ConditionalMapTargetsJoin(dto.ConditionalTransitions?.GetValueOrDefault(from), joinState);
+
+    private static bool TransitionMapTargetsJoin(
+        Dictionary<string, TransitionTargetDto>? map,
+        string joinState) =>
+        map is not null
+        && map.Values.Any(target => TargetNextIsJoin(target, joinState));
+
+    private static bool WaitRoutesTargetJoin(
+        Dictionary<string, WaitEventRouteDto>? routes,
+        string joinState) =>
+        routes is not null
+        && routes.Values.Any(route =>
+            !string.IsNullOrWhiteSpace(route?.Next)
+            && string.Equals(route.Next, joinState, StringComparison.OrdinalIgnoreCase));
+
+    private static bool ConditionalMapTargetsJoin(
+        Dictionary<string, CompiledFactTransitionDto>? map,
+        string joinState) =>
+        map is not null
+        && map.Values.Any(transition =>
+            TargetNextIsJoin(transition?.LinearTarget, joinState)
+            || TargetNextIsJoin(transition?.DefaultTarget, joinState)
+            || (transition?.Cases?.Any(c => TargetNextIsJoin(c?.Target, joinState)) ?? false));
+
+    private static bool TargetNextIsJoin(TransitionTargetDto? target, string joinState) =>
+        !string.IsNullOrWhiteSpace(target?.Next)
+        && string.Equals(target.Next, joinState, StringComparison.OrdinalIgnoreCase);
 
     private sealed class CompiledDefinitionDto
     {

--- a/ui/studio/features/definition-editor/i18n/en.ts
+++ b/ui/studio/features/definition-editor/i18n/en.ts
@@ -80,6 +80,12 @@ export const definitionEditorUiTextEn: DefinitionEditorFeatureUiText = {
         `Node '${nodeName}': only one edge can have default=true.`,
       selfReferenceEdge: (nodeName: string) => `Node '${nodeName}': self-referencing edge is not allowed.`,
       missingTargetNode: (nodeName: string, targetName: string) => `Node '${nodeName}': target '${targetName}' does not exist.`,
+      forkRegionIngressFromOutside: (fromName: string, toName: string) =>
+        `Node '${fromName}': cannot enter branch '${toName}' from outside the fork region.`,
+      forkRegionEgressWithoutJoin: (fromName: string, toName: string, joinName: string) =>
+        `Node '${fromName}': cannot leave to '${toName}' without join '${joinName}'.`,
+      forkRegionWaitTargetOutside: (nodeName: string, toName: string) =>
+        `Node '${nodeName}': wait target '${toName}' is outside the fork region.`,
       selfReferenceRejected: "Self-referencing edges are not allowed.",
       whenOpPlaceholder: "Select operator",
       whenPathPlaceholder: "$.states.Fetch.output.amount",

--- a/ui/studio/features/definition-editor/i18n/ja.ts
+++ b/ui/studio/features/definition-editor/i18n/ja.ts
@@ -77,6 +77,12 @@ export const definitionEditorUiTextJa: DefinitionEditorFeatureUiText = {
         `Node '${nodeName}': default=true の edge は 1 つまでです。`,
       selfReferenceEdge: (nodeName: string) => `Node '${nodeName}': 自己参照エッジは許可されません。`,
       missingTargetNode: (nodeName: string, targetName: string) => `Node '${nodeName}': 参照先 '${targetName}' が存在しません。`,
+      forkRegionIngressFromOutside: (fromName: string, toName: string) =>
+        `Node '${fromName}': Fork 領域外から枝内の '${toName}' へ入れません。`,
+      forkRegionEgressWithoutJoin: (fromName: string, toName: string, joinName: string) =>
+        `Node '${fromName}': Join '${joinName}' を経由せず '${toName}' へ出られません。`,
+      forkRegionWaitTargetOutside: (nodeName: string, toName: string) =>
+        `Node '${nodeName}': wait の遷移先 '${toName}' は Fork 領域外です。`,
       selfReferenceRejected: "自己参照エッジは作成できません。",
       whenOpPlaceholder: "演算子を選択",
       whenPathPlaceholder: "$.states.Fetch.output.amount",

--- a/ui/studio/features/definition-editor/i18n/types.ts
+++ b/ui/studio/features/definition-editor/i18n/types.ts
@@ -67,6 +67,9 @@ export type DefinitionEditorFeatureUiText = {
       edgeDefaultMultiple: (nodeName: string) => string;
       selfReferenceEdge: (nodeName: string) => string;
       missingTargetNode: (nodeName: string, targetName: string) => string;
+      forkRegionIngressFromOutside: (fromName: string, toName: string) => string;
+      forkRegionEgressWithoutJoin: (fromName: string, toName: string, joinName: string) => string;
+      forkRegionWaitTargetOutside: (nodeName: string, toName: string) => string;
       selfReferenceRejected: string;
       whenOpPlaceholder: string;
       whenPathPlaceholder: string;

--- a/ui/studio/features/definition-editor/lib/validateForkRegionLight.ts
+++ b/ui/studio/features/definition-editor/lib/validateForkRegionLight.ts
@@ -1,0 +1,240 @@
+import type { DefinitionGraphNode } from "./types";
+
+/** Studio の安い Fork 領域指摘メッセージ。 */
+export type ForkRegionLightMessageOptions = {
+  forkRegionIngressFromOutside: (fromName: string, toName: string) => string;
+  forkRegionEgressWithoutJoin: (fromName: string, toName: string, joinName: string) => string;
+  forkRegionWaitTargetOutside: (nodeName: string, toName: string) => string;
+};
+
+type NameMap = Map<string, DefinitionGraphNode>;
+
+type ForkJoinLightPair = {
+  forkName: string;
+  joinName: string;
+  body: Set<string>;
+};
+
+/**
+ * Studio 向けの安い Fork 領域チェック（A1 / A2 / 禁止パターン D2）。
+ *
+ * @param byName - 正規化名 → ノード。
+ * @param messages - 指摘の蓄積先。
+ * @param options - i18n メッセージ。
+ * @remarks Engine のスナップショット正本は共有しない。対応 Join が一意に決まる Fork だけ見る。
+ */
+export function validateForkRegionLight(
+  byName: NameMap,
+  messages: string[],
+  options: ForkRegionLightMessageOptions
+): void {
+  const pairs = collectLightPairs(byName);
+  pairs.forEach((pair) => {
+    addIngressIssues(pair, byName, messages, options);
+    addEgressAndWaitIssues(pair, byName, messages, options);
+  });
+}
+
+function collectLightPairs(byName: NameMap): ForkJoinLightPair[] {
+  return [...byName.values()]
+    .filter((node) => node.type === "fork")
+    .map((fork) => tryPairFork(fork, byName))
+    .filter((pair): pair is ForkJoinLightPair => pair !== null);
+}
+
+function tryPairFork(fork: DefinitionGraphNode, byName: NameMap): ForkJoinLightPair | null {
+  const heads = (fork.branches ?? [])
+    .map((branch) => normalizeName(branch))
+    .filter((head) => head.length > 0 && byName.has(head));
+  if (heads.length < 2) {
+    return null;
+  }
+
+  const joinSets = heads.map((head) => collectReachableJoins(head, byName));
+  const joinName = pickPairedJoin(joinSets);
+  if (!joinName) {
+    return null;
+  }
+  const forkName = normalizeName(fork.name);
+  return {
+    forkName,
+    joinName,
+    body: collectRegionBody(heads, joinName, byName)
+  };
+}
+
+function collectReachableJoins(start: string, byName: NameMap): Set<string> {
+  const joins = new Set<string>();
+  const visited = new Set<string>([start]);
+  const queue = [start];
+  const stepLimit = byName.size + 8;
+  let steps = 0;
+  while (queue.length > 0 && steps < stepLimit) {
+    steps += 1;
+    const current = queue.shift();
+    if (current === undefined) {
+      break;
+    }
+    const node = byName.get(current);
+    if (!node) {
+      continue;
+    }
+    if (node.type === "join") {
+      joins.add(current);
+    }
+    enqueueNew(queue, visited, outgoingTargets(node, { includeError: false }));
+  }
+  return joins;
+}
+
+function collectRegionBody(heads: string[], joinName: string, byName: NameMap): Set<string> {
+  const body = new Set<string>();
+  const visited = new Set<string>(heads);
+  const queue = [...heads];
+  const stepLimit = byName.size + 8;
+  let steps = 0;
+  while (queue.length > 0 && steps < stepLimit) {
+    steps += 1;
+    const current = queue.shift();
+    if (current === undefined || current === joinName) {
+      continue;
+    }
+    const node = byName.get(current);
+    if (!node || node.type === "end") {
+      continue;
+    }
+    body.add(current);
+    enqueueNew(queue, visited, outgoingTargets(node, { includeError: true }));
+  }
+  return body;
+}
+
+function addIngressIssues(
+  pair: ForkJoinLightPair,
+  byName: NameMap,
+  messages: string[],
+  options: ForkRegionLightMessageOptions
+): void {
+  [...byName.entries()]
+    .filter(([source]) => source !== pair.forkName && !pair.body.has(source))
+    .forEach(([source, node]) => {
+      outgoingTargets(node, { includeError: true })
+        .filter((target) => pair.body.has(target))
+        .forEach((target) => {
+          messages.push(options.forkRegionIngressFromOutside(displayName(node, source), displayTarget(byName, target)));
+        });
+    });
+}
+
+function addEgressAndWaitIssues(
+  pair: ForkJoinLightPair,
+  byName: NameMap,
+  messages: string[],
+  options: ForkRegionLightMessageOptions
+): void {
+  [...pair.body]
+    .map((name) => byName.get(name))
+    .filter((node): node is DefinitionGraphNode => node !== undefined)
+    .forEach((node) => {
+      const sourceName = displayName(node, normalizeName(node.name));
+      outgoingTargets(node, { includeError: true })
+        .filter((target) => target !== pair.joinName && !pair.body.has(target))
+        .forEach((target) => {
+          messages.push(
+            options.forkRegionEgressWithoutJoin(sourceName, displayTarget(byName, target), displayTarget(byName, pair.joinName))
+          );
+        });
+      if (node.type !== "wait") {
+        return;
+      }
+      waitTargets(node)
+        .filter((target) => target !== pair.joinName && !pair.body.has(target))
+        .forEach((target) => {
+          messages.push(options.forkRegionWaitTargetOutside(sourceName, displayTarget(byName, target)));
+        });
+    });
+}
+
+function outgoingTargets(node: DefinitionGraphNode, flags: { includeError: boolean }): string[] {
+  const next = optionalName(node.next);
+  const error = flags.includeError && node.type === "action" ? optionalName(node.error) : undefined;
+  const edgeTargets = (node.edges ?? []).map((edge) => optionalName(edge.to)).filter((to): to is string => Boolean(to));
+  const branchTargets =
+    node.type === "fork"
+      ? (node.branches ?? []).map((branch) => optionalName(branch)).filter((to): to is string => Boolean(to))
+      : [];
+  const wait = waitTargets(node);
+  return uniqueNames([next, error, ...edgeTargets, ...branchTargets, ...wait].filter((to): to is string => Boolean(to)));
+}
+
+function waitTargets(node: DefinitionGraphNode): string[] {
+  if (node.type !== "wait") {
+    return [];
+  }
+  if (node.events) {
+    return uniqueNames(
+      Object.values(node.events)
+        .map((target) => optionalName(target))
+        .filter((to): to is string => Boolean(to))
+    );
+  }
+  const legacyNext = optionalName(node.next);
+  return legacyNext ? [legacyNext] : [];
+}
+
+function pickPairedJoin(joinSets: Set<string>[]): string | undefined {
+  const intersection = intersectAll(joinSets);
+  if (intersection.size === 1) {
+    return [...intersection][0];
+  }
+  const union = unionAll(joinSets);
+  if (union.size === 1) {
+    return [...union][0];
+  }
+  return undefined;
+}
+
+function enqueueNew(queue: string[], visited: Set<string>, targets: string[]): void {
+  targets
+    .filter((target) => visited.add(target))
+    .forEach((target) => {
+      queue.push(target);
+    });
+}
+
+function intersectAll(sets: Set<string>[]): Set<string> {
+  if (sets.length === 0) {
+    return new Set();
+  }
+  return sets.reduce(
+    (acc, current) => new Set([...acc].filter((name) => current.has(name))),
+    new Set(sets[0])
+  );
+}
+
+function unionAll(sets: Set<string>[]): Set<string> {
+  return new Set(sets.flatMap((current) => [...current]));
+}
+
+function uniqueNames(names: string[]): string[] {
+  return [...new Set(names)];
+}
+
+function optionalName(value: string | undefined): string | undefined {
+  const normalized = normalizeName(value ?? "");
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function displayName(node: DefinitionGraphNode, fallback: string): string {
+  const trimmed = node.name?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : fallback;
+}
+
+function displayTarget(byName: NameMap, normalized: string): string {
+  const node = byName.get(normalized);
+  return node ? displayName(node, normalized) : normalized;
+}

--- a/ui/studio/features/definition-editor/lib/validateGraphDocument.ts
+++ b/ui/studio/features/definition-editor/lib/validateGraphDocument.ts
@@ -4,6 +4,7 @@ import type {
   DefinitionGraphNode,
   ValidateGraphDocumentResult
 } from "./types";
+import { validateForkRegionLight } from "./validateForkRegionLight";
 
 /** グラフ検証メッセージのオプション。 */
 export type ValidateGraphDocumentMessageOptions = {
@@ -33,6 +34,9 @@ export type ValidateGraphDocumentMessageOptions = {
   edgeDefaultMultiple: (nodeName: string) => string;
   selfReferenceEdge: (nodeName: string) => string;
   missingTargetNode: (nodeName: string, targetName: string) => string;
+  forkRegionIngressFromOutside: (fromName: string, toName: string) => string;
+  forkRegionEgressWithoutJoin: (fromName: string, toName: string, joinName: string) => string;
+  forkRegionWaitTargetOutside: (nodeName: string, toName: string) => string;
 };
 
 function collectConfiguredEdgeTargets(node: DefinitionGraphNode): string[] {
@@ -380,7 +384,9 @@ function validateNode(
 
 /**
  * Graph編集用ドキュメントのクライアント側整合性を検証する。
- * 保存前に弾ける構造不整合（自己参照、重複名、必須項目不足）を返す。
+ * 保存前に弾ける構造不整合（自己参照、重複名、必須項目不足）と、
+ * Fork 領域の安いチェック（領域外侵入・Join なし脱出・Wait 領域外）を返す。
+ * Engine 検証の正本は共有しない。
  */
 export function validateGraphDocument(
   document: DefinitionGraphDocument,
@@ -399,6 +405,7 @@ export function validateGraphDocument(
   for (const node of document.nodes) {
     validateNode(node, byName, messages, options);
   }
+  validateForkRegionLight(byName, messages, options);
 
   return {
     isValid: messages.length === 0,

--- a/ui/studio/features/definition-editor/ui/DefinitionEditorPageClient.tsx
+++ b/ui/studio/features/definition-editor/ui/DefinitionEditorPageClient.tsx
@@ -166,7 +166,10 @@ export function DefinitionEditorPageClient({ definitionId }: Readonly<Definition
       edgeWhenValueBetweenInvalid: uiText.definitionEditor.graph.edgeWhenValueBetweenInvalid,
       edgeDefaultMultiple: uiText.definitionEditor.graph.edgeDefaultMultiple,
       selfReferenceEdge: uiText.definitionEditor.graph.selfReferenceEdge,
-      missingTargetNode: uiText.definitionEditor.graph.missingTargetNode
+      missingTargetNode: uiText.definitionEditor.graph.missingTargetNode,
+      forkRegionIngressFromOutside: uiText.definitionEditor.graph.forkRegionIngressFromOutside,
+      forkRegionEgressWithoutJoin: uiText.definitionEditor.graph.forkRegionEgressWithoutJoin,
+      forkRegionWaitTargetOutside: uiText.definitionEditor.graph.forkRegionWaitTargetOutside
     }),
     [uiText.definitionEditor.graph]
   );

--- a/ui/studio/tests/lib/definition-editor/validateGraphDocument.test.ts
+++ b/ui/studio/tests/lib/definition-editor/validateGraphDocument.test.ts
@@ -31,7 +31,10 @@ function opts(): ValidateGraphDocumentMessageOptions {
     edgeWhenValueBetweenInvalid: m("whenBetween"),
     edgeDefaultMultiple: m("defaultMulti"),
     selfReferenceEdge: m("selfRef"),
-    missingTargetNode: m2("missing")
+    missingTargetNode: m2("missing"),
+    forkRegionIngressFromOutside: m2("ingress"),
+    forkRegionEgressWithoutJoin: (fromName, toName, joinName) => `egress:${fromName}:${toName}:${joinName}`,
+    forkRegionWaitTargetOutside: m2("waitOutside")
   };
 }
 
@@ -295,5 +298,183 @@ describe("validateGraphDocument / wait.events", () => {
     const r = validateGraphDocument(doc, opts());
     expect(r.isValid).toBe(false);
     expect(r.messages).toContain("missing:w1:unknown");
+  });
+});
+
+describe("validateGraphDocument / fork region light", () => {
+  it("標準 Fork-Join は有効", () => {
+    // Arrange
+    const doc: DefinitionGraphDocument = {
+      version: 1,
+      workflow: { name: "simple" },
+      nodes: [
+        { name: "s", type: "start", next: "fork1" },
+        { name: "fork1", type: "fork", branches: ["left", "right"] },
+        { name: "left", type: "action", action: "noop", next: "join1" },
+        { name: "right", type: "action", action: "noop", next: "join1" },
+        { name: "join1", type: "join", next: "e" },
+        { name: "e", type: "end" }
+      ]
+    };
+
+    // Act
+    const r = validateGraphDocument(doc, opts());
+
+    // Assert
+    expect(r.isValid).toBe(true);
+  });
+
+  it("枝から Join を経由せず end へ出ると egress", () => {
+    // Arrange
+    const doc: DefinitionGraphDocument = {
+      version: 1,
+      workflow: { name: "A2" },
+      nodes: [
+        { name: "s", type: "start", next: "fork1" },
+        { name: "fork1", type: "fork", branches: ["left", "right"] },
+        { name: "left", type: "action", action: "noop", next: "e" },
+        { name: "right", type: "action", action: "noop", next: "join1" },
+        { name: "join1", type: "join", next: "e" },
+        { name: "e", type: "end" }
+      ]
+    };
+
+    // Act
+    const r = validateGraphDocument(doc, opts());
+
+    // Assert
+    expect(r.isValid).toBe(false);
+    expect(r.messages).toContain("egress:left:e:join1");
+  });
+
+  it("Join 後から枝先頭へ戻ると ingress", () => {
+    // Arrange
+    const doc: DefinitionGraphDocument = {
+      version: 1,
+      workflow: { name: "A1" },
+      nodes: [
+        { name: "s", type: "start", next: "fork1" },
+        { name: "fork1", type: "fork", branches: ["left", "right"] },
+        { name: "left", type: "action", action: "noop", next: "join1" },
+        { name: "right", type: "action", action: "noop", next: "join1" },
+        { name: "join1", type: "join", next: "decide" },
+        {
+          name: "decide",
+          type: "wait",
+          events: { Finish: "e", Rogue: "left" }
+        },
+        { name: "e", type: "end" }
+      ]
+    };
+
+    // Act
+    const r = validateGraphDocument(doc, opts());
+
+    // Assert
+    expect(r.isValid).toBe(false);
+    expect(r.messages).toContain("ingress:decide:left");
+  });
+
+  it("枝内 Wait の一方が領域外なら waitOutside", () => {
+    // Arrange
+    const doc: DefinitionGraphDocument = {
+      version: 1,
+      workflow: { name: "D2" },
+      nodes: [
+        { name: "s", type: "start", next: "fork1" },
+        { name: "fork1", type: "fork", branches: ["left", "wait2"] },
+        { name: "left", type: "action", action: "noop", next: "join1" },
+        {
+          name: "wait2",
+          type: "wait",
+          events: { Resume: "join1", Timeout: "e" }
+        },
+        { name: "join1", type: "join", next: "e" },
+        { name: "e", type: "end" }
+      ]
+    };
+
+    // Act
+    const r = validateGraphDocument(doc, opts());
+
+    // Assert
+    expect(r.isValid).toBe(false);
+    expect(r.messages).toContain("waitOutside:wait2:e");
+    expect(r.messages).toContain("egress:wait2:e:join1");
+  });
+
+  it("Join 後に同一 Fork へ戻る循環は有効", () => {
+    // Arrange
+    const doc: DefinitionGraphDocument = {
+      version: 1,
+      workflow: { name: "cyclic" },
+      nodes: [
+        { name: "s", type: "start", next: "fork1" },
+        { name: "fork1", type: "fork", branches: ["a", "b"] },
+        { name: "a", type: "action", action: "noop", next: "join1" },
+        { name: "b", type: "action", action: "noop", next: "join1" },
+        { name: "join1", type: "join", next: "decide" },
+        {
+          name: "decide",
+          type: "wait",
+          events: { Again: "fork1", Finish: "e" }
+        },
+        { name: "e", type: "end" }
+      ]
+    };
+
+    // Act
+    const r = validateGraphDocument(doc, opts());
+
+    // Assert
+    expect(r.isValid).toBe(true);
+  });
+
+  it("ネスト Fork-Join は有効", () => {
+    // Arrange
+    const doc: DefinitionGraphDocument = {
+      version: 1,
+      workflow: { name: "nested" },
+      nodes: [
+        { name: "s", type: "start", next: "outerFork" },
+        { name: "outerFork", type: "fork", branches: ["outerFast", "innerFork"] },
+        { name: "outerFast", type: "action", action: "noop", next: "outerJoin" },
+        { name: "innerFork", type: "fork", branches: ["innerA", "innerB"] },
+        { name: "innerA", type: "action", action: "noop", next: "innerJoin" },
+        { name: "innerB", type: "action", action: "noop", next: "innerJoin" },
+        { name: "innerJoin", type: "join", next: "outerJoin" },
+        { name: "outerJoin", type: "join", next: "e" },
+        { name: "e", type: "end" }
+      ]
+    };
+
+    // Act
+    const r = validateGraphDocument(doc, opts());
+
+    // Assert
+    expect(r.isValid).toBe(true);
+  });
+
+  it("枝先頭 Wait が events で Join を供給する定義は有効", () => {
+    // Arrange
+    const doc: DefinitionGraphDocument = {
+      version: 1,
+      workflow: { name: "E1" },
+      nodes: [
+        { name: "s", type: "start", next: "fork1" },
+        { name: "fork1", type: "fork", branches: ["left", "wait2"] },
+        { name: "left", type: "action", action: "noop", next: "join1" },
+        { name: "wait2", type: "wait", events: { Resume: "right" } },
+        { name: "right", type: "action", action: "noop", next: "join1" },
+        { name: "join1", type: "join", next: "e" },
+        { name: "e", type: "end" }
+      ]
+    };
+
+    // Act
+    const r = validateGraphDocument(doc, opts());
+
+    // Assert
+    expect(r.isValid).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Engine で Fork 領域を「Fork（Start）–任意ノード–Join（End）の単一 Definition」として検証する。領域横断・Join 供給不足・兄弟 Body 共有などをルール単位 `code` で拒否し、ネスト Fork-Join と Join 後の再入場は合法のまま通す。
- API は検証失敗を 422 details に写し、ネストは直近 Fork-Join ペアで `join.all` を解決する。定義グラフは Join へ直接着く依存だけ描き、枝途中の内側 Fork による幽霊枝を除く。
- Studio は侵入・脱出・Wait 領域外など安い部分集合だけを保存前に知らせる（正本は Engine）。

## Test plan
- [x] `cd core/engine && dotnet test statevia-engine.sln` で ForkRegion / JoinSupply / DefinitionValidator が通ること
- [x] `cd service/api && dotnet test statevia-api.sln` で Loader のネスト Join 解決・Compiler 422・GraphDefinition の直接辺が通ること
- [x] `cd ui/studio && npm run test:run` で `validateForkRegionLight` / `validateGraphDocument` が通ること
- [x] ネスト Fork（枝先頭が action の内側 Fork 含む）が保存・実行でき、実行グラフに幽霊枝が出ないこと
- [x] SonarQube `StateviaServiceApi` / `StateviaCoreEngine` / `StateviaUIStudio` の Quality Gate（`new_violations = 0` / `new_coverage ≥ 80%`）が維持されること
